### PR TITLE
Change git clone url to https://github.com/nomic-ai/gpt4all.git to avoid `Permission denied`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can reproduce our trained model by doing the following:
 
 Clone the repo
 
-`git clone --recurse-submodules git@github.com:nomic-ai/gpt4all.git`
+`git clone --recurse-submodules https://github.com/nomic-ai/gpt4all.git`
 
 `git submodule configure && git submodule update`
 


### PR DESCRIPTION
`git clone git@github.com:nomic-ai/gpt4all.git` yield `Permission denied`

```sh
git clone --recurse-submodules git@github.com:nomic-ai/gpt4all.git

Cloning into 'gpt4all'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```