### PR TITLE
Annotate file size for model checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run on M1 Mac (not sped up!)
 
 Here's how to get started with the CPU quantized GPT4All model checkpoint:
 
-1. Download the `gpt4all-lora-quantized.bin` file from [Direct Link](https://the-eye.eu/public/AI/models/nomic-ai/gpt4all/gpt4all-lora-quantized.bin) or [[Torrent-Magnet]](https://tinyurl.com/gpt4all-lora-quantized).
+1. Download the `gpt4all-lora-quantized.bin` file (4GB) from [Direct Link](https://the-eye.eu/public/AI/models/nomic-ai/gpt4all/gpt4all-lora-quantized.bin) or [[Torrent-Magnet]](https://tinyurl.com/gpt4all-lora-quantized).
 2. Clone this repository, navigate to `chat`, and place the downloaded file there.
 3. Run the appropriate command for your OS:
    - M1 Mac/OSX: `cd chat;./gpt4all-lora-quantized-OSX-m1`


### PR DESCRIPTION
Just a quick note to let folks downloading the checkpoint know how big it is.