### PR TITLE
fix crash when no wandb configured

### DIFF
--- a/train.py
+++ b/train.py
@@ -203,5 +203,6 @@ if __name__ == "__main__":
         )
     else:
         accelerator = Accelerator()
+        accelerator.init_trackers("no_project")
 
     train(accelerator, config=config)


### PR DESCRIPTION
If `init_trackers` isn't called, the training process will throw an error:

```
Traceback (most recent call last):
  File "/home/xxx/gpt4all/train.py", line 213, in <module>
    train(accelerator, config=config)
  File "/home/xxx/gpt4all/train.py", line 189, in train
    accelerator.end_training()
  File "/home/xxx/gpt4all/venv/lib/python3.9/site-packages/accelerate/accelerator.py", line 548, in _inner
    return PartialState().on_main_process(function)(*args, **kwargs)
  File "/home/xxx/gpt4all/venv/lib/python3.9/site-packages/accelerate/accelerator.py", line 2118, in end_training
    for tracker in self.trackers:
AttributeError: 'Accelerator' object has no attribute 'trackers'
```