### PR TITLE
Add automatic platform selection for gpt4all-lora-quantized

### DIFF
--- a/chat/gpt4all-lora-quantized
+++ b/chat/gpt4all-lora-quantized
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+chmod +x gpt4all-lora-quantized-linux-x86
+
+# Determine the current platform
+platform=$(uname)
+
+# Choose the appropriate executable
+if [ "$platform" == "Linux" ]; then
+    executable="./gpt4all-lora-quantized-linux-x86"
+elif [ "$platform" == "Darwin" ]; then
+    if [[ $(uname -m) == 'arm64' ]]; then
+        executable="./gpt4all-lora-quantized-OSX-m1"
+    else
+        executable="./gpt4all-lora-quantized-OSX-intel"
+    fi
+else
+    echo "Unsupported platform: $platform"
+    exit 1
+fi
+
+# Execute the chosen executable with any arguments passed to this script
+"$executable" "$@"

--- a/chat/gpt4all-lora-quantized
+++ b/chat/gpt4all-lora-quantized
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 chmod +x gpt4all-lora-quantized-linux-x86
+chmod +x gpt4all-lora-quantized-OSX-m1
+chmod +x gpt4all-lora-quantized-OSX-intel
 
 # Determine the current platform
 platform=$(uname)

--- a/chat/gpt4all-lora-quantized.cmd
+++ b/chat/gpt4all-lora-quantized.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+".\gpt4all-lora-quantized-win64.exe" %1 %2 %3 %4 %5 %6 %7 %8 %9
+PAUSE && EXIT /B 0


### PR DESCRIPTION
This is tested on both Windows 10 and Debian 10.

**Untested on OSX and MAC. But should work.** 
Need reports as I have no such hardware to test.  

**What it does:** It will allow to simplify the **Try yourself** section in the README.md
The OS will be selected by a generic command `./gpt4all-lora-quantized` instead of manual selection by:
```
M1 Mac/OSX: cd chat;./gpt4all-lora-quantized-OSX-m1
Linux: cd chat;./gpt4all-lora-quantized-linux-x86
Windows (PowerShell): cd chat;./gpt4all-lora-quantized-win64.exe
Intel Mac/OSX: cd chat;./gpt4all-lora-quantized-OSX-intel
```
### Old
![image](https://user-images.githubusercontent.com/21064622/231138970-51faf88d-bea8-4285-a02e-fec16d6d78ac.png)

### New
1. Download the `gpt4all-lora-quantized.bin` file from [Direct Link](https://the-eye.eu/public/AI/models/nomic-ai/gpt4all/gpt4all-lora-quantized.bin) or [[Torrent-Magnet]](https://tinyurl.com/gpt4all-lora-quantized).
2. Clone this repository, navigate to `chat`, and place the downloaded file there.
3. Run the appropriate command for your OS: 
   * Windows 
      * (Batch) `cd chat && .\gpt4all-lora-quantized`
      * (PowerShell) `cd chat; ./gpt4all-lora-quantized`
   * Linux/Mac/OSX `cd chat; chmod +x ./gpt4all-lora-quantized; ./gpt4all-lora-quantized`

## All old arguments are supported and tested.
 `./gpt4all-lora-quantized --help`
 `./gpt4all-lora-quantized --model .\gpt4all-lora-quantized.bin`
...


