### PR TITLE
train.py enhanced checkpoint resuming

### DIFF
--- a/checkpoint_mgr.py
+++ b/checkpoint_mgr.py
@@ -1,0 +1,211 @@
+from os.path import basename, abspath, join, isdir
+from typing import List, Optional, Tuple, TypedDict
+import sys
+from glob import glob
+
+from accelerate import Accelerator
+from accelerate.data_loader import DataLoader
+
+
+class CheckpointManagerException(Exception):
+    pass
+
+
+class Checkpoint(TypedDict):
+    """Lightweight type that represents a saved checkpoint"""
+
+    epoch: int
+    step: int
+    path: str
+
+
+class CheckpointManager:
+    """Encapsulates training loop checkpointing logic"""
+
+    def __init__(
+        self,
+        base_dir: str,
+        accelerator: Accelerator,
+        epochs: int,
+        max_steps_between_checkpoints=2000,
+        prefix="ckpt",
+        max_runs=sys.maxsize,
+        max_epochs=sys.maxsize,
+        max_steps=sys.maxsize,
+    ) -> None:
+        self.base_dir = base_dir
+        self.accelerator = accelerator
+        self.epochs = epochs
+        self.max_steps_between_checkpoints = max_steps_between_checkpoints
+        self.prefix = prefix
+        self.max_runs = max_runs
+        self.max_epochs = max_epochs
+        self.max_steps = max_steps
+
+        # Calculated when start() is invoked
+        self._epoch_end: Optional[int] = None
+
+    @staticmethod
+    def parse_path(checkpoint_path: str) -> Checkpoint:
+        checkpoint_base_name = basename(checkpoint_path)
+        parts = checkpoint_base_name.split("_")
+
+        if len(parts) != 3:
+            raise CheckpointManagerException(
+                f"The following checkpoint path name cannot be parsed: '{checkpoint_base_name}', "
+                "checkpoint names must be in the following format: PREFIX_EPOCH_STEP."
+            )
+
+        try:
+            derived_epoch = int(parts[1])
+        except ValueError as ex:
+            raise CheckpointManagerException(
+                f"Unable to parse the epoch portion of '{checkpoint_base_name}' to an integer"
+            ) from ex
+
+        try:
+            derived_step = int(parts[2])
+        except ValueError as ex:
+            raise CheckpointManagerException(
+                f"Unable to parse the step portion of '{checkpoint_base_name}' to an integer"
+            ) from ex
+
+        return {
+            "epoch": derived_epoch,
+            "step": derived_step,
+            "path": abspath(checkpoint_path),
+        }
+
+    def gen_path(self, epoch: int, step: int) -> str:
+        cur_epoch_str = str(epoch).zfill(len(str(self.max_epochs)))
+        cur_step_str = str(step).zfill(len(str(self.max_steps)))
+
+        return join(
+            self.base_dir,
+            f"{self.prefix}_{cur_epoch_str}_{cur_step_str}",
+        )
+
+    def ls(self) -> List[Checkpoint]:
+        unsorted = []
+        for checkpoint_path in glob(join(self.base_dir, f"{self.prefix}*")):
+            if isdir(checkpoint_path):
+                unsorted.append(CheckpointManager.parse_path(checkpoint_path))
+
+        return sorted(unsorted, key=lambda x: x["path"])
+
+    def latest(self) -> Optional[Checkpoint]:
+        checkpoints = self.ls()
+        return checkpoints[-1] if len(checkpoints) > 0 else None
+
+    def _save_checkpoint(self, epoch: int, step: int) -> None:
+        new_checkpoint_path = self.gen_path(epoch=epoch, step=step)
+        self.accelerator.save_state(new_checkpoint_path)
+
+    def start(
+        self, train_dataloader: DataLoader, force_checkpoint_path: Optional[str] = None
+    ) -> Tuple[int, int, int]:
+        if self._epoch_end is not None:
+            raise CheckpointManagerException(
+                f"CheckpointManager session already started: self._epoch_end={self._epoch_end}"
+            )
+
+        last_checkpoint: Optional[Checkpoint] = None
+
+        if force_checkpoint_path:
+            self.accelerator.print(
+                "[CheckpointManager] Loading checkpoint specified in config file"
+            )
+            last_checkpoint = CheckpointManager.parse_path(
+                checkpoint_path=force_checkpoint_path
+            )
+
+        else:
+            # Else, if the auto-resume setting is enabled in the configuration then look for the most
+            # recent checkpoint in the configured output directory
+            self.accelerator.print(
+                "[CheckpointManager] Determining auto-resume checkpoint"
+            )
+            last_checkpoint = self.latest()
+
+        # If it was determined that a checkpoint needs to be loaded from the previous block, configure
+        # Accelerate accordingly
+        if last_checkpoint:
+            self.accelerator.print(
+                f"[CheckpointManager] Resuming from {last_checkpoint['path']}"
+            )
+            self.accelerator.load_state(last_checkpoint["path"])
+
+            if (last_checkpoint["step"] + 1) % len(train_dataloader) == 0:
+                # Start a the beginning of the next epoch
+                step_offset = 0
+                epoch_start = last_checkpoint["epoch"] + 1
+
+                # This logic will determine whether we are resuming from an in-process training session
+                # or starting a new one.
+                if (last_checkpoint["epoch"] + 1) % self.epochs == 0:
+                    self.accelerator.print(
+                        "[CheckpointManager] Previous session completed, starting new session"
+                    )
+
+                    # Starting a new session
+                    epoch_end = epoch_start + self.epochs
+                else:
+                    # TODO: Make sure we test this...
+                    self.accelerator.print(
+                        "[CheckpointManager] Previous session did not complete, resuming"
+                    )
+
+                    # Resuming an existing session
+                    epoch_end = self.epochs - epoch_start
+
+            else:
+                # Otherwise, we haven't reached the end of the current epoch, make the appropriate
+                # adjustments to resume where we left off
+                step_offset = last_checkpoint["step"]
+                epoch_start = last_checkpoint["epoch"]
+                epoch_end = (self.epochs * (epoch_start // self.epochs)) + (
+                    self.epochs - 1
+                )
+
+        else:
+            # When we are not resuming from a checkpoint, set the step and epoch offsets to 0
+            self.accelerator.print(
+                "[CheckpointManager] No checkpoints found, this is an initial run"
+            )
+            epoch_start = 0
+            epoch_end = self.epochs
+            step_offset = 0
+
+        # Fast-forward the dataloader if a step offset was detected. The +1 to the step_offset will simplify the training loop
+        if step_offset > 0:
+            self.accelerator.skip_first_batches(train_dataloader, step_offset)
+            step_offset = step_offset + 1
+
+        # Set the ending epochs in the object state. This will be used to determine if the final
+        # checkpoint needs to be saved at the end of the training session
+        self._epoch_end = epoch_end
+
+        # Output a helpful message summarizing the output of the checkpoint resuming logic
+        checkpoint_name = (
+            basename(last_checkpoint["path"]) if last_checkpoint else "N/A"
+        )
+        self.accelerator.print(
+            f"[CheckpointManager] checkpoint={checkpoint_name}, epoch_start={epoch_start}, epoch_end={epoch_end}, step_offset={step_offset}"
+        )
+
+        return (epoch_start, epoch_end, step_offset)
+
+    def step_complete(self, epoch: int, step: int):
+        # Save checkpoint when our current step has hit max_steps_between_checkpoints
+        if step > 0 and step % self.max_steps_between_checkpoints == 0:
+            self._save_checkpoint(epoch=epoch, step=step)
+
+    def epoch_complete(self, epoch: int, step: int):
+        # Always save checkpoint on the final epoch. Note that the self.epochs passed into the constructor
+        # is a count of epochs starting at 1 that the training process is configured to run however we
+        # need to do a +1 when comparing with an index
+        if (epoch + 1) == self._epoch_end:
+            self._save_checkpoint(epoch=epoch, step=step)
+
+    def end(self):
+        self._epoch_end = None

--- a/checkpoint_mgr.py
+++ b/checkpoint_mgr.py
@@ -2,6 +2,7 @@ from os.path import basename, abspath, join, isdir
 from typing import List, Optional, Tuple, TypedDict
 import sys
 from glob import glob
+import logging
 
 from accelerate import Accelerator
 from accelerate.data_loader import DataLoader
@@ -20,7 +21,51 @@ class Checkpoint(TypedDict):
 
 
 class CheckpointManager:
-    """Encapsulates training loop checkpointing logic"""
+    """A training loop checkpoint manager for HuggingFace Accelerate.
+
+    Example training loop:
+
+    ```
+    checkpoint_manager = CheckpointManager(
+        base_dir=base_dir,
+        accelerator=accelerator,
+        epochs=epochs_per_run,
+        max_steps_between_checkpoints=max_steps_between_checkpoints,
+    )
+
+    epoch_start, epoch_end, step_offset = checkpoint_manager.start(
+        train_dataloader=train_dataloader
+    )
+
+    for epoch in range(epoch_start, epoch_end):
+
+        # Step offsets returned by CheckpointManager only apply to the
+        # first epoch so we need to adjust accordingly
+        derived_step = step_offset if epoch == epoch_start else 0
+
+        with tqdm(
+            initial=derived_step,
+            total=len(train_dataloader),
+            desc=f"Epoch {epoch} of {epoch_end-1}",
+        ) as pbar:
+            for step in range(derived_step, len(train_dataloader)):
+                #
+                # Training logic goes here...
+                #
+
+                # Run step complete hook and update progress bar
+                checkpoint_manager.step_complete(epoch=epoch, step=step)
+                pbar.update(1)
+
+        # Run epoch complete hook
+        checkpoint_manager.epoch_complete(epoch=epoch, step=step)
+
+    # Run session end hook
+    checkpoint_manager.end()
+    ```
+
+
+    """
 
     def __init__(
         self,
@@ -32,6 +77,7 @@ class CheckpointManager:
         max_runs=sys.maxsize,
         max_epochs=sys.maxsize,
         max_steps=sys.maxsize,
+        log: logging.Logger = logging.getLogger(__name__),
     ) -> None:
         self.base_dir = base_dir
         self.accelerator = accelerator
@@ -45,8 +91,38 @@ class CheckpointManager:
         # Calculated when start() is invoked
         self._epoch_end: Optional[int] = None
 
+        # Add a default logging handler if the root logger hasn't been configured and there are
+        # no specific handlers attached to the Logger instance
+        self.log = log
+        if not logging.root.handlers and not self.log.handlers:
+            console_handler = logging.StreamHandler()
+            console_handler.propagate = False
+            console_formatter = logging.Formatter(
+                "%(asctime)s %(levelname)s: %(message)s"
+            )
+            console_handler.setFormatter(console_formatter)
+            self.log.addHandler(console_handler)
+            self.log.setLevel(logging.INFO)
+
     @staticmethod
     def parse_path(checkpoint_path: str) -> Checkpoint:
+        """Parses checkpoint path into corresponding typed dictionary
+
+        Parameters
+        ----------
+        checkpoint_path : str
+            Path to checkpoint directory
+
+        Returns
+        -------
+        Checkpoint
+            Parsed checkpoint dictionary
+
+        Raises
+        ------
+        CheckpointManagerException
+            Raised when parsing fails
+        """
         checkpoint_base_name = basename(checkpoint_path)
         parts = checkpoint_base_name.split("_")
 
@@ -77,6 +153,20 @@ class CheckpointManager:
         }
 
     def gen_path(self, epoch: int, step: int) -> str:
+        """Generates a checkpoint directory path. This method will not actually create the directory.
+
+        Parameters
+        ----------
+        epoch : int
+            Epoch number to encode in the path
+        step : int
+            Step number to encode in the path
+
+        Returns
+        -------
+        str
+            Path to the generated checkpoint directory
+        """
         cur_epoch_str = str(epoch).zfill(len(str(self.max_epochs)))
         cur_step_str = str(step).zfill(len(str(self.max_steps)))
 
@@ -86,6 +176,14 @@ class CheckpointManager:
         )
 
     def ls(self) -> List[Checkpoint]:
+        """List all checkpoints under the checkpoint base directory
+
+        Returns
+        -------
+        List[Checkpoint]
+            List of checkpoint objects found under the configured checkpoint
+            base. Will be an empty list of no checkpoints were found.
+        """
         unsorted = []
         for checkpoint_path in glob(join(self.base_dir, f"{self.prefix}*")):
             if isdir(checkpoint_path):
@@ -94,89 +192,98 @@ class CheckpointManager:
         return sorted(unsorted, key=lambda x: x["path"])
 
     def latest(self) -> Optional[Checkpoint]:
+        """Utility method to get the latest checkpoint directory
+
+        Returns
+        -------
+        Optional[Checkpoint]
+            If a checkpoint directory exists return a Checkpoint instance, else return None
+        """
         checkpoints = self.ls()
         return checkpoints[-1] if len(checkpoints) > 0 else None
 
     def _save_checkpoint(self, epoch: int, step: int) -> None:
+        """Saves a checkpoint
+
+        Parameters
+        ----------
+        epoch : int
+            Epoch number
+        step : int
+            Step number
+        """
         new_checkpoint_path = self.gen_path(epoch=epoch, step=step)
         self.accelerator.save_state(new_checkpoint_path)
 
     def start(
         self, train_dataloader: DataLoader, force_checkpoint_path: Optional[str] = None
     ) -> Tuple[int, int, int]:
+        """After a CheckpointManager instance has bene created call start() before the training
+        loop. This method analyzes the configured checkpoint base directory, restores the last
+        checkpoint, then determines the correct step_offset, epoch_start, and epoch_end.
+
+        Parameters
+        ----------
+        train_dataloader : DataLoader
+            Dataloader instance, used to determine the step offset
+        force_checkpoint_path : Optional[str], optional
+            When set, this method will resume from the specified checkpoint vs the latest, by default None
+
+        Returns
+        -------
+        Tuple[int, int, int]
+            Tuple containing (epoch_start, epoch_end, step_offset)
+
+        Raises
+        ------
+        CheckpointManagerException
+            Raised if start() is called twice
+        """
         if self._epoch_end is not None:
             raise CheckpointManagerException(
                 f"CheckpointManager session already started: self._epoch_end={self._epoch_end}"
             )
 
-        last_checkpoint: Optional[Checkpoint] = None
-
-        if force_checkpoint_path:
-            self.accelerator.print(
-                "[CheckpointManager] Loading checkpoint specified in config file"
-            )
-            last_checkpoint = CheckpointManager.parse_path(
-                checkpoint_path=force_checkpoint_path
-            )
-
-        else:
-            # Else, if the auto-resume setting is enabled in the configuration then look for the most
-            # recent checkpoint in the configured output directory
-            self.accelerator.print(
-                "[CheckpointManager] Determining auto-resume checkpoint"
-            )
-            last_checkpoint = self.latest()
+        self.log.info("Looking for last checkpoint")
+        last_checkpoint: Optional[Checkpoint] = self.latest()
 
         # If it was determined that a checkpoint needs to be loaded from the previous block, configure
         # Accelerate accordingly
         if last_checkpoint:
-            self.accelerator.print(
-                f"[CheckpointManager] Resuming from {last_checkpoint['path']}"
-            )
-            self.accelerator.load_state(last_checkpoint["path"])
+            if force_checkpoint_path:
+                # If we force resume from a specified checkpoint, load it here. Note that we don't want to replace
+                # last_checkpoint since we want the step/epoch numbering to be consistent.
+                resume_checkpoint = CheckpointManager.parse_path(
+                    checkpoint_path=force_checkpoint_path
+                )
+            else:
+                resume_checkpoint = last_checkpoint
 
-            if (last_checkpoint["step"] + 1) % len(train_dataloader) == 0:
-                # Start a the beginning of the next epoch
+            self.log.info("Resuming from checkpoint: %s", resume_checkpoint["path"])
+            self.accelerator.load_state(resume_checkpoint["path"])
+
+            if (last_checkpoint["step"] + 1) >= len(train_dataloader):
+                # Start a the beginning of the next epoch if the saved checkpoint is either
                 step_offset = 0
                 epoch_start = last_checkpoint["epoch"] + 1
-
-                # This logic will determine whether we are resuming from an in-process training session
-                # or starting a new one.
-                if (last_checkpoint["epoch"] + 1) % self.epochs == 0:
-                    self.accelerator.print(
-                        "[CheckpointManager] Previous session completed, starting new session"
-                    )
-
-                    # Starting a new session
-                    epoch_end = epoch_start + self.epochs
-                else:
-                    # TODO: Make sure we test this...
-                    self.accelerator.print(
-                        "[CheckpointManager] Previous session did not complete, resuming"
-                    )
-
-                    # Resuming an existing session
-                    epoch_end = self.epochs - epoch_start
+                epoch_end = epoch_start + self.epochs
 
             else:
                 # Otherwise, we haven't reached the end of the current epoch, make the appropriate
                 # adjustments to resume where we left off
                 step_offset = last_checkpoint["step"]
                 epoch_start = last_checkpoint["epoch"]
-                epoch_end = (self.epochs * (epoch_start // self.epochs)) + (
-                    self.epochs - 1
-                )
+                epoch_end = (self.epochs * (epoch_start // self.epochs)) + self.epochs
 
         else:
             # When we are not resuming from a checkpoint, set the step and epoch offsets to 0
-            self.accelerator.print(
-                "[CheckpointManager] No checkpoints found, this is an initial run"
-            )
+            self.log.info("No checkpoints found, this is an initial run")
             epoch_start = 0
             epoch_end = self.epochs
             step_offset = 0
 
-        # Fast-forward the dataloader if a step offset was detected. The +1 to the step_offset will simplify the training loop
+        # Fast-forward the dataloader if a step offset was detected. The +1 to the step_offset will
+        # simplify the training loop
         if step_offset > 0:
             self.accelerator.skip_first_batches(train_dataloader, step_offset)
             step_offset = step_offset + 1
@@ -189,18 +296,42 @@ class CheckpointManager:
         checkpoint_name = (
             basename(last_checkpoint["path"]) if last_checkpoint else "N/A"
         )
-        self.accelerator.print(
-            f"[CheckpointManager] checkpoint={checkpoint_name}, epoch_start={epoch_start}, epoch_end={epoch_end}, step_offset={step_offset}"
+        self.log.info(
+            "Started: checkpoint=%s, epoch_start=%i, epoch_end=%i, step_offset=%i",
+            checkpoint_name,
+            epoch_start,
+            epoch_end,
+            step_offset,
         )
 
         return (epoch_start, epoch_end, step_offset)
 
     def step_complete(self, epoch: int, step: int):
+        """Hook to call when a step is completed. Encapsulates checkpoint save logic.
+
+        Parameters
+        ----------
+        epoch : int
+            Current epoch
+        step : int
+            Current Step
+        """
         # Save checkpoint when our current step has hit max_steps_between_checkpoints
         if step > 0 and step % self.max_steps_between_checkpoints == 0:
             self._save_checkpoint(epoch=epoch, step=step)
 
     def epoch_complete(self, epoch: int, step: int):
+        """Hook to call when an epoch is complete. A checkpoint will always be saved at the end
+        of a the last epoch.
+
+        Parameters
+        ----------
+        epoch : int
+            Current epoch
+        step : int
+            Current step
+        """
+
         # Always save checkpoint on the final epoch. Note that the self.epochs passed into the constructor
         # is a count of epochs starting at 1 that the training process is configured to run however we
         # need to do a +1 when comparing with an index
@@ -208,4 +339,6 @@ class CheckpointManager:
             self._save_checkpoint(epoch=epoch, step=step)
 
     def end(self):
+        """Hook to call a the end of a training cycle."""
+
         self._epoch_end = None

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,4 @@
+
+
+class GPT4AllTrainingException(Exception):
+    """Raised when an error occurs during training"""

--- a/train.py
+++ b/train.py
@@ -18,8 +18,8 @@ from peft import get_peft_model, LoraConfig, TaskType
 from torchmetrics import MeanMetric
 from tqdm import tqdm
 import wandb
-from data import load_data
 
+from gpt4all.data import load_data
 from gpt4all.exceptions import GPT4AllTrainingException
 
 torch.backends.cuda.matmul.allow_tf32 = True
@@ -106,6 +106,7 @@ def train(accelerator, config):
 
     accelerator.print(config)
     accelerator.print(f"Using {accelerator.num_processes} GPUs")
+    accelerator.print(f"Loading tokenizer: {config['tokenizer_name']}")
 
     tokenizer = AutoTokenizer.from_pretrained(
         config["tokenizer_name"], model_max_length=config["max_length"]
@@ -117,6 +118,7 @@ def train(accelerator, config):
     with accelerator.main_process_first():
         train_dataloader, val_dataloader = load_data(config, tokenizer)
 
+    accelerator.print(f"Loading pretrained model: {config['model_name']}")
     checkpoint = config["gradient_checkpointing"]
     model = AutoModelForCausalLM.from_pretrained(
         config["model_name"],

--- a/train.py
+++ b/train.py
@@ -1,5 +1,10 @@
 import os
-from transformers import AutoModelForCausalLM, AutoTokenizer, get_scheduler, LlamaForCausalLM
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    get_scheduler,
+    LlamaForCausalLM,
+)
 import torch
 from torch.optim import AdamW
 from argparse import ArgumentParser
@@ -13,6 +18,7 @@ from tqdm import tqdm
 import wandb
 
 torch.backends.cuda.matmul.allow_tf32 = True
+
 
 def format_metrics(metrics, split, prefix=""):
     log = f"[{split}]" + prefix
@@ -37,32 +43,38 @@ def evaluate(model, val_dataloader):
 
 
 def train(accelerator, config):
-    set_seed(config['seed'])
+    set_seed(config["seed"])
 
     accelerator.print(config)
     accelerator.print(f"Using {accelerator.num_processes} GPUs")
 
-    tokenizer = AutoTokenizer.from_pretrained(config['tokenizer_name'], model_max_length=config['max_length'])
+    tokenizer = AutoTokenizer.from_pretrained(
+        config["tokenizer_name"], model_max_length=config["max_length"]
+    )
     # if no pad token, set it to eos
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-        
     with accelerator.main_process_first():
-        train_dataloader, val_dataloader = load_data(config, tokenizer) 
-
+        train_dataloader, val_dataloader = load_data(config, tokenizer)
 
     checkpoint = config["gradient_checkpointing"]
-    model = AutoModelForCausalLM.from_pretrained(config["model_name"], 
-                                                    use_cache=False if checkpoint else True,
-                                                    trust_remote_code=True) 
+    model = AutoModelForCausalLM.from_pretrained(
+        config["model_name"],
+        use_cache=False if checkpoint else True,
+        trust_remote_code=True,
+    )
     if checkpoint:
         model.gradient_checkpointing_enable()
 
     if config["lora"]:
         peft_config = LoraConfig(
             # should R be configurable?
-            task_type=TaskType.CAUSAL_LM, inference_mode=False, r=8, lora_alpha=32, lora_dropout=0.1
+            task_type=TaskType.CAUSAL_LM,
+            inference_mode=False,
+            r=8,
+            lora_alpha=32,
+            lora_dropout=0.1,
         )
         model = get_peft_model(model, peft_config)
         model.print_trainable_parameters()
@@ -76,17 +88,23 @@ def train(accelerator, config):
 
     # karpathy doesn't decay embeddding, maybe we should exclude
     # https://github.com/karpathy/minGPT/commit/bbbdac74fa9b2e55574d70056163ffbae42310c1#diff-2075fa9c224b395be5bda85544dd36572b59c76c54562819eadadbf268602834R157s
-    optimizer = optimizer_cls(model.parameters(), lr=config["lr"], weight_decay=config["weight_decay"])
+    optimizer = optimizer_cls(
+        model.parameters(), lr=config["lr"], weight_decay=config["weight_decay"]
+    )
 
     if accelerator.state.deepspeed_plugin is not None:
-        gradient_accumulation_steps = accelerator.state.deepspeed_plugin.deepspeed_config[
-            "gradient_accumulation_steps"
-        ]
+        gradient_accumulation_steps = (
+            accelerator.state.deepspeed_plugin.deepspeed_config[
+                "gradient_accumulation_steps"
+            ]
+        )
 
     # decay to min_lr instead of 0
     lr_ratio = config["min_lr"] / config["lr"]
     accelerator.print(f"Len of train_dataloader: {len(train_dataloader)}")
-    total_num_steps = (len(train_dataloader) / gradient_accumulation_steps) * config["num_epochs"]
+    total_num_steps = (len(train_dataloader) / gradient_accumulation_steps) * config[
+        "num_epochs"
+    ]
     # instead of decaying to zero, decay to ratio of min_lr / lr
     total_num_steps += int(total_num_steps * lr_ratio) + config["warmup_steps"]
     accelerator.print(f"Total training steps: {total_num_steps}")
@@ -104,11 +122,13 @@ def train(accelerator, config):
         )
     else:
         scheduler = DummyScheduler(
-            optimizer, total_num_steps=config["warmup_steps"], warmup_num_steps=config["warmup_steps"]
+            optimizer,
+            total_num_steps=config["warmup_steps"],
+            warmup_num_steps=config["warmup_steps"],
         )
 
     model, optimizer, train_dataloader, val_dataloader, scheduler = accelerator.prepare(
-            model, optimizer, train_dataloader, val_dataloader, scheduler
+        model, optimizer, train_dataloader, val_dataloader, scheduler
     )
 
     # setup for saving training states in case preemption
@@ -123,6 +143,11 @@ def train(accelerator, config):
         accelerator.skip_first_batches(train_dataloader, resume_step)
         accelerator.print(f"Resuming from step {resume_step}")
 
+        # When resuming we need to +1 to avoid trying to re-save a checkpoint
+        # before any work has been done
+        next_step = resume_step + 1
+    else:
+        next_step = 0
 
     # log gradients
     if accelerator.is_main_process and config["wandb"]:
@@ -130,54 +155,72 @@ def train(accelerator, config):
 
     for epoch in range(config["num_epochs"]):
         train_loss = MeanMetric(nan_strategy="error").to(model.device)
-        for step, batch in enumerate(tqdm(train_dataloader)):
-            model.train()
-            outputs = model(**batch)
-            loss = outputs.loss
 
-            # gather loss before backprop in case of gradient accumulation
-            loss_values = accelerator.gather_for_metrics({"loss": loss.detach().float()})
-            train_loss.update(loss_values["loss"])
+        with tqdm(
+            initial=next_step, total=len(train_dataloader), desc=f"Epoch {epoch}"
+        ) as pbar:
+            for iteration, batch in enumerate(train_dataloader):
+                step = iteration + next_step
 
-            loss = loss / gradient_accumulation_steps
-            accelerator.backward(loss)
-            # get gradient norm of all params
+                model.train()
+                outputs = model(**batch)
+                loss = outputs.loss
 
-            # log LR in case something weird happens 
-            if step > 0 and step % (config["eval_every"] // 10) == 0:
-                if config["wandb"]:
+                # gather loss before backprop in case of gradient accumulation
+                loss_values = accelerator.gather_for_metrics(
+                    {"loss": loss.detach().float()}
+                )
+                train_loss.update(loss_values["loss"])
+
+                loss = loss / gradient_accumulation_steps
+                accelerator.backward(loss)
+                # get gradient norm of all params
+
+                # log LR in case something weird happens
+                if step > 0 and step % (config["eval_every"] // 10) == 0:
+                    if config["wandb"]:
+                        curr_step = step + epoch * len(train_dataloader)
+                        accelerator.log(
+                            {"lr": scheduler.get_last_lr()[0]}, step=curr_step
+                        )
+
+                if (step + 1) % gradient_accumulation_steps == 0 or step == len(
+                    train_dataloader
+                ) - 1:
+                    optimizer.step()
+                    scheduler.step()
+                    optimizer.zero_grad()
+
+                if step > 0 and step % config["save_every"] == 0:
                     curr_step = step + epoch * len(train_dataloader)
-                    accelerator.log({"lr": scheduler.get_last_lr()[0]}, step=curr_step)
+                    accelerator.save_state(f"{config['output_dir']}/step_{curr_step}")
 
-            if (step + 1) % gradient_accumulation_steps == 0 or step == len(train_dataloader) - 1:
-                optimizer.step()
-                scheduler.step()
-                optimizer.zero_grad()
+                if step > 0 and (
+                    step % config["eval_every"] == 0
+                    or step == len(train_dataloader) - 1
+                ):
+                    val_loss = evaluate(model, val_dataloader)
 
+                    log_train = {"train_loss": train_loss.compute()}
+                    log_val = {"val_loss": val_loss.compute()}
 
-            if step > 0 and step % config["save_every"] == 0:
-                curr_step = step + epoch * len(train_dataloader)
-                accelerator.save_state(f"{config['output_dir']}/step_{curr_step}")
+                    if config["wandb"]:
+                        curr_step = step + epoch * len(train_dataloader)
+                        accelerator.log({**log_train, **log_val}, step=curr_step)
 
-            if step > 0 and (step % config["eval_every"] == 0 or step == len(train_dataloader) - 1):
-                val_loss = evaluate(model, val_dataloader)
+                    accelerator.print(f"Current LR: {scheduler.get_last_lr()[0]}")
+                    accelerator.print(
+                        format_metrics(log_train, "train", f" step {step} ")
+                    )
+                    accelerator.print(format_metrics(log_val, "val", f" step {step} "))
 
-                log_train = {
-                        "train_loss": train_loss.compute()
-                    }
-                log_val = {
-                    "val_loss": val_loss.compute()
-                }
+                    train_loss.reset()
 
-                if config["wandb"]:
-                    curr_step = step + epoch * len(train_dataloader)
-                    accelerator.log({**log_train, **log_val}, step=curr_step)
-
-                accelerator.print(f"Current LR: {scheduler.get_last_lr()[0]}")
-                accelerator.print(format_metrics(log_train, "train", f" step {step} "))
-                accelerator.print(format_metrics(log_val, "val", f" step {step} "))
-
-                train_loss.reset()
+                # Update the progress bar with training loss
+                pbar.update(1)
+                pbar.set_postfix(
+                    {"train_loss": f"{loss_values['loss'].mean().item():.4f}"}
+                )
 
         accelerator.print(f"Epoch {epoch} finished")
         accelerator.print(f"Pushing to HF hub")
@@ -185,7 +228,9 @@ def train(accelerator, config):
         unwrapped_model = accelerator.unwrap_model(model)
         try:
             if accelerator.is_main_process:
-                unwrapped_model.push_to_hub(config["save_name"] + f"-epoch_{epoch}", private=True)
+                unwrapped_model.push_to_hub(
+                    config["save_name"] + f"-epoch_{epoch}", private=True
+                )
 
         except Exception as e:
             accelerator.print(e)
@@ -197,7 +242,7 @@ def train(accelerator, config):
             save_function=accelerator.save,
             state_dict=accelerator.get_state_dict(model),
         )
-            
+
     accelerator.wait_for_everyone()
     unwrapped_model = accelerator.unwrap_model(model)
     unwrapped_model.save_pretrained(
@@ -209,7 +254,6 @@ def train(accelerator, config):
 
     accelerator.end_training()
 
-    
 
 if __name__ == "__main__":
     # parse arguments by reading in a config


### PR DESCRIPTION
* Adds automatic checkpoint resuming logic to ``train.py``
* Updated train progress bar to include epoch and train_loss
* Added an ``__init__.py`` to make it easier to invoke gpt4all code from other Python wrappers; there is a larger discussion that should be had regarding whether python files should be moved into a subfolder and make the project a proper Python package.
* Configuration files should be backwards compatible

To start a new training session use the following configuration:

```yaml
checkpoint: ~
```

As before, to force a specific checkpoint:

```yaml
checkpoint: "foo/gpt4all-7b-hf-lora/step_135000"
train_args:
  resume_from_checkpoint: "step_135000"
```