### PR TITLE
CI/CD that only runs on main and deploys python docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,33 @@ orbs:
   python: circleci/python@1.2
 
 jobs:
+  build-py-docs:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          # TODO: eventually this will be cleaned up so we aren't building
+          # new dependencies each time unnecessarily.
+          # This will be introduced once we setup branch and path filtering
+          command: |
+            sudo apt-get update
+            sudo apt-get -y install python3 python3-pip
+            sudo pip3 install awscli --upgrade
+            sudo pip3 install mkdocs mkdocs-material mkautodoc mkdocstrings
+      - run:
+          name: Make Documentation
+          command: |
+            cd gpt4all-bindings/python/
+            mkdocs build
+      - run:
+          name: Deploy Documentation
+          command: |
+            aws s3 cp ./site s3://docs.gpt4all.io/ --recursive | cat
+
+            
+
   build-py-linux:
     docker:
       - image: circleci/python:3.8
@@ -132,13 +159,20 @@ jobs:
 
 workflows:
   version: 2
-  build-py-deploy:
+  deploy-docs:
     jobs:
-      - build-py-linux
-      - build-py-macos
-      - build-py-windows
-      - store-and-upload-wheels:
-          requires:
-            - build-py-windows
-            - build-py-linux
-            - build-py-macos
+      - build-py-docs:
+          filters:
+            branches:
+              only:
+                - main
+  #build-py-deploy:
+  #  jobs:
+      #- build-py-linux
+      #- build-py-macos
+      #- build-py-windows
+      #- store-and-upload-wheels:
+      #    requires:
+      #      - build-py-windows
+      #      - build-py-linux
+      #      - build-py-macos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ workflows:
             branches:
               only:
                 - main
+                - rguo123/docs-cicd
   #build-py-deploy:
   #  jobs:
       #- build-py-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ workflows:
             branches:
               only:
                 - main
+                - rguo123/docs-cicd
   #build-py-deploy:
   #  jobs:
       #- build-py-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ workflows:
             branches:
               only:
                 - main
-                - rguo123/docs-cicd
   #build-py-deploy:
   #  jobs:
       #- build-py-linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             sudo apt-get update
             sudo apt-get -y install python3 python3-pip
             sudo pip3 install awscli --upgrade
-            sudo pip3 install mkdocs mkdocs-material mkautodoc mkdocstrings
+            sudo pip3 install mkdocs mkdocs-material mkautodoc 'mkdocstrings[python]'
       - run:
           name: Make Documentation
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
       - run:
           name: Deploy Documentation
           command: |
+            cd gpt4all-bindings/python/
             aws s3 cp ./site s3://docs.gpt4all.io/ --recursive | cat
 
             

--- a/gpt4all-bindings/python/README.md
+++ b/gpt4all-bindings/python/README.md
@@ -2,6 +2,9 @@
 
 This package contains a set of Python bindings around the `llmodel` C-API.
 
+## Documentation
+docs.gpt4all.io
+
 ## Installation
 
 ```


### PR DESCRIPTION
- Updated CircleCI with branch filtering
- CircleCI job to deploy Python documentation
- Updated Python binding readme with link to docs