### PR TITLE
Label Tag Warning and Fix 2 to PR Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Label Tagging**
+Add related label tags to your bug report. Please check all existing label tags before creating a new one.
+Issues without labels may be dismissed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+**Label Tagging**
+Add related label tags to your feature request. Please check all existing label tags before creating a new one.
+Issues without labels may be dismissed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 - [ ] I have performed a self-review of my code.
 - [ ] If it is a core feature, I have added thorough tests.
 - [ ] I have added thorough documentation for my code.
-- [ ] I have tagged PR with relevant project identifiers.
+- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
 - [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.
 
 ## Demo


### PR DESCRIPTION
TIL a single PR template must be in .github folder.
Added label tagging warning in all templates.