### PR TITLE
Bugfix on llmodel_model_create function

### DIFF
--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -59,8 +59,8 @@ llmodel_model llmodel_model_create(const char *model_path) {
     fread(&magic, sizeof(magic), 1, f);
 
     if (magic == 0x67676d6c) { model = llmodel_gptj_create();  }
-    if (magic == 0x67676a74) { model = llmodel_llama_create(); }
-    if (magic == 0x67676d6d) { model = llmodel_mpt_create();   }
+    else if (magic == 0x67676a74) { model = llmodel_llama_create(); }
+    else if (magic == 0x67676d6d) { model = llmodel_mpt_create();   }
     else  {fprintf(stderr, "Invalid model file\n");}
     fclose(f);
     return model;


### PR DESCRIPTION
Fixes the bug where `llmodel_model_create` prints "Invalid model file" in cases when the model is loaded correctly. 
Credits and thanks to @serendipity for the fix!

## Describe your changes
Replace `if` with `else if` to see that correct condition is triggered.

```c++
llmodel_model llmodel_model_create(const char *model_path) {

    uint32_t magic;
    llmodel_model model;
    FILE *f = fopen(model_path, "rb");
    fread(&magic, sizeof(magic), 1, f);

    if (magic == 0x67676d6c) { model = llmodel_gptj_create();  }
    else if (magic == 0x67676a74) { model = llmodel_llama_create(); }
    else if (magic == 0x67676d6d) { model = llmodel_mpt_create();   }
    else  {fprintf(stderr, "Invalid model file\n");}
    fclose(f);
    return model;
}
```