### PR TITLE
Fix #614, where relative paths to includes makes go builds fail

### DIFF
--- a/gpt4all-bindings/golang/gpt4all.go
+++ b/gpt4all-bindings/golang/gpt4all.go
@@ -1,7 +1,7 @@
 package gpt4all
 
-// #cgo CFLAGS: -I../../gpt4all-backend/ -I../../gpt4all-backend/llama.cpp -I./
-// #cgo CXXFLAGS: -std=c++17 -I../../gpt4all-backend/ -I../../gpt4all-backend/llama.cpp -I./
+// #cgo CFLAGS: -I${SRCDIR}../../gpt4all-backend/ -I${SRCDIR}../../gpt4all-backend/llama.cpp -I./
+// #cgo CXXFLAGS: -std=c++17 -I${SRCDIR}../../gpt4all-backend/ -I${SRCDIR}../../gpt4all-backend/llama.cpp -I./
 // #cgo darwin LDFLAGS: -framework Accelerate
 // #cgo darwin CXXFLAGS: -std=c++17
 // #cgo LDFLAGS: -lgpt4all -lm -lstdc++


### PR DESCRIPTION
## Describe your changes
When using the golang bindings, cgo includes in `gpt4all.go` are relative, this makes any use of the bindings outside of the gpt4all repository fail.

This PR adds `$(SRCDIR)` to the includes so they are absolute.

## Issue ticket number and link
This fixes issue: #614 

## Checklist before requesting a review
- [x ] I have performed a self-review of my code.
- [ x] If it is a core feature, I have added thorough tests.
- [ x] I have added thorough documentation for my code.
- [x ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [X ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

### Steps to Reproduce

Include the bindings in a new golang project.

Try to build:
```
$ make main 
        C_INCLUDE_PATH=/Users/XXX/code/src/github.com/XXX/intelligens/include \
        LIBRARY_PATH=/Users/XXX/code/src/github.com/XXX/intelligens/lib \
        go build
# github.com/nomic-ai/gpt4all/gpt4all-bindings/golang
binding.cpp:1:10: fatal error: '../../gpt4all-backend/llmodel_c.h' file not found
make: *** [main] Error 1
```
