### PR TITLE
Always default mlock to true.

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -53,7 +53,7 @@ bool LLamaModel::loadModel(const std::string &modelPath)
     d_ptr->params.seed       = params.seed;
     d_ptr->params.f16_kv     = params.memory_f16;
     d_ptr->params.use_mmap   = params.use_mmap;
-    d_ptr->params.use_mlock  = params.use_mlock;
+    d_ptr->params.use_mlock  = true;
 
     d_ptr->ctx = llama_init_from_file(modelPath.c_str(), d_ptr->params);
     if (!d_ptr->ctx) {


### PR DESCRIPTION
## Describe your changes

Defaults mlock to always true. According to discord:

gonzochess75
why is it default to off?
eachadea
it makes model loading a bit slower sometimes, but mlock has no disadvantages otherwise
eachadea
it's more stable by ensuring the model is always in RAM
and not swapped unless there is truly no RAM available
