### PR TITLE
Improved implementation management code

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -4,15 +4,27 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <algorithm>
 #include <filesystem>
 
 
 
 static
-Dlhandle *get_implementation(std::ifstream& f, const std::string& buildVariant) {
-    // Collect all model implementation libraries
-    static auto libs = [] () {
-        std::vector<Dlhandle> fres;
+bool requires_avxonly() {
+#ifdef __x86_64__
+    return !__builtin_cpu_supports("avx2") && !__builtin_cpu_supports("fma");
+#else
+    return false;  // Don't know how to handle ARM
+#endif
+}
+
+
+std::vector<Dlhandle> LLModel::implementations = {{}};
+
+void LLModel::loadImplementationList() {
+    // Collect all model implementation libraries if that hasn't been done yet
+    if (!implementations[0].is_valid()) {
+        implementations.clear();
         // Iterate over all libraries
         for (const auto& f : std::filesystem::directory_iterator(".")) {
             // Get path
@@ -23,14 +35,17 @@ Dlhandle *get_implementation(std::ifstream& f, const std::string& buildVariant) 
             try {
                 Dlhandle dl(p);
                 if (dl.get<bool(uint32_t)>("is_g4a_backend_model_implementation")) {
-                    fres.emplace_back(std::move(dl));
+                    implementations.emplace_back(std::move(dl));
                 }
             } catch (...) {}
         }
-        return fres;
-    }();
+    }
+}
+
+Dlhandle *LLModel::getImplementation(std::ifstream& f, const std::string& buildVariant) {
+    loadImplementationList();
     // Iterate over all libraries
-    for (auto& dl : libs) {
+    for (auto& dl : implementations) {
         f.seekg(0);
         // Check that magic matches
         auto magic_match = dl.get<bool(std::ifstream&)>("magic_match");
@@ -49,13 +64,24 @@ Dlhandle *get_implementation(std::ifstream& f, const std::string& buildVariant) 
     return nullptr;
 }
 
-static
-bool requires_avxonly() {
-#ifdef __x86_64__
-    return !__builtin_cpu_supports("avx2") && !__builtin_cpu_supports("fma");
-#else
-    return false;  // Don't know how to handle ARM
-#endif
+std::vector<std::string_view> LLModel::getBuildVariantList() {
+    std::vector<std::string_view> fres;
+    loadImplementationList();
+    // Collect all build variants
+    for (auto& dl : implementations) {
+        // Get build variant getter
+        auto get_build_variant = dl.get<const char *()>("get_build_variant");
+        if (!get_build_variant) continue;
+        // Get build variant
+        std::string_view build_variant = get_build_variant();
+        // Make sure it's not listed yet
+        if (std::find(fres.begin(), fres.end(), build_variant) != fres.end())
+            continue;
+        // Add it to list
+        fres.push_back(build_variant);
+    }
+    // Return final list
+    return fres;
 }
 
 LLModel *LLModel::construct(const std::string &modelPath, std::string buildVariant) {
@@ -71,7 +97,7 @@ LLModel *LLModel::construct(const std::string &modelPath, std::string buildVaria
     std::ifstream f(modelPath, std::ios::binary);
     if (!f) return nullptr;
     // Get correct implementation
-    auto impl = get_implementation(f, buildVariant);
+    auto impl = getImplementation(f, buildVariant);
     if (!impl) return nullptr;
     f.close();
     // Get inference constructor

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -1,8 +1,11 @@
 #ifndef LLMODEL_H
 #define LLMODEL_H
+#include "dlhandle.h"
+
 #include <string>
 #include <functional>
 #include <vector>
+#include <string_view>
 #include <cstdint>
 
 
@@ -10,8 +13,6 @@ class LLModel {
 public:
     explicit LLModel() {}
     virtual ~LLModel() {}
-
-    static LLModel *construct(const std::string &modelPath, std::string buildVariant = "default");
 
     virtual bool loadModel(const std::string &modelPath) = 0;
     virtual bool isModelLoaded() const = 0;
@@ -45,11 +46,18 @@ public:
         return modelType;
     }
 
-protected:
+    static LLModel *construct(const std::string &modelPath, std::string buildVariant = "default");
+
+protected:    
     virtual void recalculateContext(PromptContext &promptCtx,
         std::function<bool(bool)> recalculate) = 0;
 
     const char *modelType;
+
+    static std::vector<Dlhandle> implementations;
+    static void loadImplementationList();
+    static Dlhandle *getImplementation(std::ifstream& f, const std::string& buildVariant);
+    static std::vector<std::string_view> getBuildVariantList();
 };
 
 #endif // LLMODEL_H


### PR DESCRIPTION
This change improves the way llmodel handles the different available build variants by:
 * Moving static functions into `LLModel` class
 * Seperating implementation list from `get_implementation()` (now `LLModel::getImplementation()`)
 * Allowing to `getBuildVariantList()` (for GUI)