### PR TITLE
Improved the way callbacks are passed around and handled in general

### DIFF
--- a/gpt4all-backend/gptj.cpp
+++ b/gpt4all-backend/gptj.cpp
@@ -890,11 +890,8 @@ size_t GPTJ::restoreState(const uint8_t *src)
     return gptj_set_state_data(d_ptr->model, &d_ptr->rng, src);
 }
 
-void GPTJ::prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &promptCtx) {
+void GPTJ::prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &promptCtx) {
+    cbs.should_stop = false;
 
     if (!isModelLoaded()) {
         std::cerr << "GPT-J ERROR: prompt won't work with an unloaded model!\n";
@@ -908,7 +905,7 @@ void GPTJ::prompt(const std::string &prompt,
     promptCtx.n_ctx = d_ptr->model->hparams.n_ctx;
 
     if ((int) embd_inp.size() > promptCtx.n_ctx - 4) {
-        responseCallback(-1, "ERROR: The prompt size exceeds the context window size and cannot be processed.");
+        cbs.responseCallback(-1, "ERROR: The prompt size exceeds the context window size and cannot be processed.");
         std::cerr << "GPT-J ERROR: The prompt is" << embd_inp.size() <<
             "tokens and the context window is" << promptCtx.n_ctx << "!\n";
         return;
@@ -928,6 +925,7 @@ void GPTJ::prompt(const std::string &prompt,
     }
 
     // process the prompt in batches
+    reportPromptBeginning(cbs);
     size_t i = 0;
     while (i < embd_inp.size()) {
         size_t batch_end = std::min(i + promptCtx.n_batch, embd_inp.size());
@@ -940,7 +938,7 @@ void GPTJ::prompt(const std::string &prompt,
             std::cerr << "GPTJ: reached the end of the context window so resizing\n";
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
-            recalculateContext(promptCtx, recalculateCallback);
+            recalculateContext(promptCtx, cbs);
             assert(promptCtx.n_past + int32_t(batch.size()) <= promptCtx.n_ctx);
         }
 
@@ -950,17 +948,22 @@ void GPTJ::prompt(const std::string &prompt,
             return;
         }
 
+        reportPromptProgress(cbs, i, embd_inp.size());
+
         size_t tokens = batch_end - i;
         for (size_t t = 0; t < tokens; ++t) {
             if (int32_t(promptCtx.tokens.size()) == promptCtx.n_ctx)
                 promptCtx.tokens.erase(promptCtx.tokens.begin());
             promptCtx.tokens.push_back(batch.at(t));
-            if (!promptCallback(batch.at(t)))
+            cbs.promptCallback(batch.at(t));
+            if (cbs.should_stop)
                 return;
         }
         promptCtx.n_past += batch.size();
         i = batch_end;
     }
+
+    reportPromptCompletion(cbs);
 
     std::string cachedResponse;
     std::vector<gpt_vocab::id> cachedTokens;
@@ -991,7 +994,7 @@ void GPTJ::prompt(const std::string &prompt,
             std::cerr << "GPTJ: reached the end of the context window so resizing\n";
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
-            recalculateContext(promptCtx, recalculateCallback);
+            recalculateContext(promptCtx, cbs);
             assert(promptCtx.n_past + 1 <= promptCtx.n_ctx);
         }
 
@@ -1035,14 +1038,15 @@ void GPTJ::prompt(const std::string &prompt,
             if (int32_t(promptCtx.tokens.size()) == promptCtx.n_ctx)
                 promptCtx.tokens.erase(promptCtx.tokens.begin());
             promptCtx.tokens.push_back(t);
-            if (!responseCallback(t, d_ptr->vocab.id_to_token[t]))
+            cbs.responseCallback(t, d_ptr->vocab.id_to_token[t]);
+            if (cbs.should_stop)
                 return;
         }
         cachedTokens.clear();
     }
 }
 
-void GPTJ::recalculateContext(PromptContext &promptCtx, std::function<bool(bool)> recalculate)
+void GPTJ::recalculateContext(PromptContext &promptCtx, PromptCallbacks& cbs)
 {
     size_t i = 0;
     promptCtx.n_past = 0;
@@ -1058,14 +1062,15 @@ void GPTJ::recalculateContext(PromptContext &promptCtx, std::function<bool(bool)
             goto stop_generating;
         }
         promptCtx.n_past += batch.size();
-        if (!recalculate(true))
+        cbs.recalculateCallback(true);
+        if (cbs.should_stop)
             goto stop_generating;
         i = batch_end;
     }
     assert(promptCtx.n_past == int32_t(promptCtx.tokens.size()));
 
 stop_generating:
-    recalculate(false);
+    cbs.recalculateCallback(false);
 }
 
 #if defined(_WIN32)

--- a/gpt4all-backend/gptj_impl.h
+++ b/gpt4all-backend/gptj_impl.h
@@ -20,17 +20,12 @@ public:
     size_t stateSize() const override;
     size_t saveState(uint8_t *dest) const override;
     size_t restoreState(const uint8_t *src) override;
-    void prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &ctx) override;
+    void prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &ctx) override;
     void setThreadCount(int32_t n_threads) override;
     int32_t threadCount() const override;
 
 protected:
-    void recalculateContext(PromptContext &promptCtx,
-        std::function<bool(bool)> recalculate) override;
+    void recalculateContext(PromptContext &promptCtx, PromptCallbacks&) override;
 
 private:
     GPTJPrivate *d_ptr;

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -159,11 +159,8 @@ size_t LLamaModel::restoreState(const uint8_t *src)
     return llama_set_state_data(d_ptr->ctx, const_cast<uint8_t*>(src));
 }
 
-void LLamaModel::prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &promptCtx) {
+void LLamaModel::prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &promptCtx) {
+    cbs.should_stop = false;
 
     if (!isModelLoaded()) {
         std::cerr << "LLAMA ERROR: prompt won't work with an unloaded model!\n";
@@ -187,7 +184,7 @@ void LLamaModel::prompt(const std::string &prompt,
     promptCtx.n_ctx = llama_n_ctx(d_ptr->ctx);
 
     if ((int) embd_inp.size() > promptCtx.n_ctx - 4) {
-        responseCallback(-1, "The prompt size exceeds the context window size and cannot be processed.");
+        cbs.responseCallback(-1, "The prompt size exceeds the context window size and cannot be processed.");
         std::cerr << "LLAMA ERROR: The prompt is" << embd_inp.size() <<
             "tokens and the context window is" << promptCtx.n_ctx << "!\n";
         return;
@@ -200,6 +197,7 @@ void LLamaModel::prompt(const std::string &prompt,
     params.n_keep = (int)embd_inp.size();
 
     // process the prompt in batches
+    reportPromptBeginning(cbs);
     size_t i = 0;
     while (i < embd_inp.size()) {
         size_t batch_end = std::min(i + promptCtx.n_batch, embd_inp.size());
@@ -212,7 +210,7 @@ void LLamaModel::prompt(const std::string &prompt,
             std::cerr << "LLAMA: reached the end of the context window so resizing\n";
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
-            recalculateContext(promptCtx, recalculateCallback);
+            recalculateContext(promptCtx, cbs);
             assert(promptCtx.n_past + int32_t(batch.size()) <= promptCtx.n_ctx);
         }
 
@@ -221,17 +219,22 @@ void LLamaModel::prompt(const std::string &prompt,
             return;
         }
 
+        reportPromptProgress(cbs, i, embd_inp.size());
+
         size_t tokens = batch_end - i;
         for (size_t t = 0; t < tokens; ++t) {
             if (int32_t(promptCtx.tokens.size()) == promptCtx.n_ctx)
                 promptCtx.tokens.erase(promptCtx.tokens.begin());
             promptCtx.tokens.push_back(batch.at(t));
-            if (!promptCallback(batch.at(t)))
+            cbs.promptCallback(batch.at(t));
+            if (cbs.should_stop)
                 return;
         }
         promptCtx.n_past += batch.size();
         i = batch_end;
     }
+
+    reportPromptCompletion(cbs);
 
     std::string cachedResponse;
     std::vector<llama_token> cachedTokens;
@@ -254,7 +257,7 @@ void LLamaModel::prompt(const std::string &prompt,
             std::cerr << "LLAMA: reached the end of the context window so resizing\n";
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
-            recalculateContext(promptCtx, recalculateCallback);
+            recalculateContext(promptCtx, cbs);
             assert(promptCtx.n_past + 1 <= promptCtx.n_ctx);
         }
 
@@ -298,14 +301,15 @@ void LLamaModel::prompt(const std::string &prompt,
             if (int32_t(promptCtx.tokens.size()) == promptCtx.n_ctx)
                 promptCtx.tokens.erase(promptCtx.tokens.begin());
             promptCtx.tokens.push_back(t);
-            if (!responseCallback(t, llama_token_to_str(d_ptr->ctx, t)))
+            cbs.responseCallback(t, llama_token_to_str(d_ptr->ctx, t));
+            if (cbs.should_stop)
                 return;
         }
         cachedTokens.clear();
     }
 }
 
-void LLamaModel::recalculateContext(PromptContext &promptCtx, std::function<bool(bool)> recalculate)
+void LLamaModel::recalculateContext(PromptContext &promptCtx, PromptCallbacks& cbs)
 {
     size_t i = 0;
     promptCtx.n_past = 0;
@@ -320,14 +324,15 @@ void LLamaModel::recalculateContext(PromptContext &promptCtx, std::function<bool
             goto stop_generating;
         }
         promptCtx.n_past += batch.size();
-        if (!recalculate(true))
+        cbs.recalculateCallback(true);
+        if (cbs.should_stop)
             goto stop_generating;
         i = batch_end;
     }
     assert(promptCtx.n_past == int32_t(promptCtx.tokens.size()));
 
 stop_generating:
-    recalculate(false);
+    cbs.recalculateCallback(false);
 }
 
 #if defined(_WIN32)

--- a/gpt4all-backend/llamamodel_impl.h
+++ b/gpt4all-backend/llamamodel_impl.h
@@ -20,17 +20,12 @@ public:
     size_t stateSize() const override;
     size_t saveState(uint8_t *dest) const override;
     size_t restoreState(const uint8_t *src) override;
-    void prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &ctx) override;
+    void prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &ctx) override;
     void setThreadCount(int32_t n_threads) override;
     int32_t threadCount() const override;
 
 protected:
-    void recalculateContext(PromptContext &promptCtx,
-        std::function<bool(bool)> recalculate) override;
+    void recalculateContext(PromptContext &promptCtx, PromptCallbacks& cbs) override;
 
 private:
     LLamaPrivate *d_ptr;

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -114,3 +114,17 @@ LLModel *LLModel::construct(const std::string &modelPath, std::string buildVaria
     // Construct and return llmodel implementation
     return impl->construct();
 }
+
+void LLModel::prompt(const std::string &prompt_, std::function<bool (int32_t)> promptCallback, std::function<bool (int32_t, const std::string &)> responseCallback, std::function<bool (bool)> recalculateCallback, PromptContext &ctx) {
+    PromptCallbacks cbs;
+    cbs.promptCallback = [&] (int32_t v) {
+        cbs.should_stop = !promptCallback(v);
+    };
+    cbs.responseCallback = [&] (int32_t v, const std::string& s) {
+        cbs.should_stop = !responseCallback(v, s);
+    };
+    cbs.recalculateCallback = [&] (bool v) {
+        cbs.should_stop = !recalculateCallback(v);
+    };
+    prompt(prompt_, cbs, ctx);
+}

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -1,8 +1,8 @@
 #ifndef LLMODEL_H
 #define LLMODEL_H
+#include "dlhandle.h"
 
-#include "dlhandle.h" // FIXME: would be nice to move this into implementation file
-
+#include <iostream>
 #include <string>
 #include <functional>
 #include <vector>
@@ -45,7 +45,29 @@ public:
         float   repeat_penalty = 1.10f;
         int32_t repeat_last_n = 64;     // last n tokens to penalize
         float   contextErase = 0.75f;   // percent of context to erase if we exceed the context
-            // window
+                                        // window
+    };
+
+    struct PromptCallbacks {
+        friend class LLModel;
+
+        // Executed whenever given token has been evaluated
+        std::function<void(int32_t)> promptCallback = [] (int32_t) {};
+        // Executed whenever given token has been generated (string is token as string)
+        std::function<void(int32_t, const std::string&)> responseCallback = [] (int32_t, const std::string&) {};
+        // Executed given `true` whenever context recalculation is running, `false` on completion
+        std::function<void(bool)> recalculateCallback = [] (bool) {};
+        // Executed whenever progress has been made in evaluating tokens, given float is percentage
+        std::function<void(float)> promptProgressCallback = [] (float progress) {
+            std::cout << "\r" << unsigned(progress) << "% " << std::flush;
+        };
+        // Should not be touched outside a model implementation; will be reset by prompt()
+        bool should_stop = false;
+
+        // To be called whenever you want prompt() to stop asap
+        void stop() {
+            should_stop = true;
+        }
     };
 
     explicit LLModel() {}
@@ -56,18 +78,22 @@ public:
     virtual size_t stateSize() const { return 0; }
     virtual size_t saveState(uint8_t */*dest*/) const { return 0; }
     virtual size_t restoreState(const uint8_t */*src*/) { return 0; }
-    virtual void prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &ctx) = 0;
-    virtual void setThreadCount(int32_t /*n_threads*/) {}
-    virtual int32_t threadCount() const { return 1; }
 
     // FIXME: This is unused??
     const Implementation& getImplementation() const {
         return *implementation;
     }
+
+    virtual void prompt(const std::string &prompt, PromptCallbacks&, PromptContext &) = 0;
+    virtual void setThreadCount(int32_t /*n_threads*/) {}
+    virtual int32_t threadCount() const { return 1; }
+
+    [[deprecated("Use `prompt(const std::string &, PromptCallbacks&, PromptContext &)` instead.")]]
+    void prompt(const std::string &prompt_,
+                std::function<bool(int32_t)> promptCallback,
+                std::function<bool(int32_t, const std::string&)> responseCallback,
+                std::function<bool(bool)> recalculateCallback,
+                PromptContext &ctx);
 
     // FIXME: Maybe have an 'ImplementationInfo' class for the GUI here, but the DLHandle stuff should
     // be hidden in cpp file
@@ -79,7 +105,19 @@ public:
 protected:
     const Implementation *implementation; // FIXME: This is dangling! You don't initialize it in ctor either
 
-    virtual void recalculateContext(PromptContext &promptCtx,
-        std::function<bool(bool)> recalculate) = 0;
+    virtual void recalculateContext(PromptContext &promptCtx, PromptCallbacks&) = 0;
+
+    // Would like to have this function directly in class PromptCallbacks, but I'd be forced to make them public...
+    void reportPromptProgress(PromptCallbacks& cbs, std::size_t index, std::size_t size) {
+        cbs.promptProgressCallback(float(index) / size * 100.f);
+    }
+    void reportPromptBeginning(PromptCallbacks& cbs) {
+        cbs.promptProgressCallback(0.f);
+    }
+    void reportPromptCompletion(PromptCallbacks& cbs) {
+        cbs.promptProgressCallback(100.f);
+    }
+
+    const char *modelType;
 };
 #endif // LLMODEL_H

--- a/gpt4all-backend/mpt_impl.h
+++ b/gpt4all-backend/mpt_impl.h
@@ -20,17 +20,12 @@ public:
     size_t stateSize() const override;
     size_t saveState(uint8_t *dest) const override;
     size_t restoreState(const uint8_t *src) override;
-    void prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &ctx) override;
+    void prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &ctx) override;
     void setThreadCount(int32_t n_threads) override;
     int32_t threadCount() const override;
 
 protected:
-    void recalculateContext(PromptContext &promptCtx,
-        std::function<bool(bool)> recalculate) override;
+    void recalculateContext(PromptContext &promptCtx, PromptCallbacks&) override;
 
 private:
     MPTPrivate *d_ptr;

--- a/gpt4all-chat/chatgpt.h
+++ b/gpt4all-chat/chatgpt.h
@@ -19,11 +19,7 @@ public:
     size_t stateSize() const override;
     size_t saveState(uint8_t *dest) const override;
     size_t restoreState(const uint8_t *src) override;
-    void prompt(const std::string &prompt,
-        std::function<bool(int32_t)> promptCallback,
-        std::function<bool(int32_t, const std::string&)> responseCallback,
-        std::function<bool(bool)> recalculateCallback,
-        PromptContext &ctx) override;
+    void prompt(const std::string &prompt, PromptCallbacks& cbs, PromptContext &ctx) override;
     void setThreadCount(int32_t n_threads) override;
     int32_t threadCount() const override;
 
@@ -34,8 +30,7 @@ public:
     void setContext(const QList<QString> &context) { m_context = context; }
 
 protected:
-    void recalculateContext(PromptContext &promptCtx,
-        std::function<bool(bool)> recalculate) override {}
+    void recalculateContext(PromptContext &promptCtx, PromptCallbacks&) override {}
 
 private Q_SLOTS:
     void handleFinished();
@@ -44,7 +39,7 @@ private Q_SLOTS:
 
 private:
     PromptContext *m_ctx;
-    std::function<bool(int32_t, const std::string&)> m_responseCallback;
+    LLModel::PromptCallbacks *callbacks;
     QString m_modelName;
     QString m_apiKey;
     QList<QString> m_context;


### PR DESCRIPTION
Originally, I only wanted to prompt evaluation progress reporting, however on the way there I noticed the whole callback thing isn't currently implemented particularly well.

I have:
 - Reworked the `prompt()` functions to accept a struct of callbacks instead
 - Made the callbacks return `void` instead of `bool` and provide a `stop()` function
 - Reimplemented the old `prompt()` function with the same signature to "redirect" to the new one.
   - Exactly the same behaviour as the original old one
   - Marked as deprecated
 - Added a prompt evaluation progress reporting callback

From the API user facing side, this isn't a breaking change. However, from the implementation facing side, it is.

I believe this change is important to make sure future additions of callbacks *don't* break the API. Also, it decreases code complexity for the API user by allowing that Callback struct to be constructed once and to then be just passed around.

Before, returning `false` from a callback didn't necessarily cause `prompt()` to stop. Calling `stop()` however *always* does, earlier or later.

Todo:
 - [x] Update all calls made from `llmodel_c` to the old `prompt()` function to the new one