### PR TITLE
Fix MSVC Build, Update C# Binding Scripts

### DIFF
--- a/gpt4all-backend/dlhandle.h
+++ b/gpt4all-backend/dlhandle.h
@@ -56,6 +56,9 @@ public:
 #include <string>
 #include <exception>
 #include <stdexcept>
+#ifndef NOMINMAX
+    #define NOMINMAX
+#endif
 #include <windows.h>
 #include <libloaderapi.h>
 

--- a/gpt4all-bindings/csharp/build_win-mingw.ps1
+++ b/gpt4all-bindings/csharp/build_win-mingw.ps1
@@ -13,5 +13,4 @@ cmake --build $BUILD_DIR --parallel --config Release
 
 # copy native dlls
 cp "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin\*dll" $LIBS_DIR
-cp "$BUILD_DIR\libllmodel.dll" $LIBS_DIR
-cp "$BUILD_DIR\bin\libllama.dll" $LIBS_DIR
+cp "$BUILD_DIR\*.dll" $LIBS_DIR

--- a/gpt4all-bindings/csharp/build_win-msvc.ps1
+++ b/gpt4all-bindings/csharp/build_win-msvc.ps1
@@ -1,6 +1,5 @@
 Remove-Item -Force -Recurse .\runtimes\win-x64\msvc -ErrorAction SilentlyContinue
 mkdir .\runtimes\win-x64\msvc\build | Out-Null
-cmake -G "Visual Studio 17 2022" -A Win64 -S ..\..\gpt4all-backend -B .\runtimes\win-x64\msvc\build
+cmake -G "Visual Studio 17 2022" -A X64 -S ..\..\gpt4all-backend -B .\runtimes\win-x64\msvc\build
 cmake --build .\runtimes\win-x64\msvc\build --parallel --config Release
-cp .\runtimes\win-x64\msvc\build\Release\llmodel.dll .\runtimes\win-x64\libllmodel.dll
-cp .\runtimes\win-x64\msvc\build\bin\Release\llama.dll .\runtimes\win-x64\libllama.dll
+cp .\runtimes\win-x64\msvc\build\bin\Release\*.dll .\runtimes\win-x64


### PR DESCRIPTION
## Describe your changes
There is one file that was missing a `#define NOMINMAX` when including the windows.h header. This was causing the msvc build to fail, since because the order of operations of how, I believe, it was being compiled, it would include the min/max headers that would break "std::min" and "std::max"

No, I don't get why that is the case.

Adding the definition fixed it.

While I was here, I updated the build scripts to also pull in the new DLLs being generated.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
