### PR TITLE
Ignore unsuitable models instead of locking up

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -391,7 +391,7 @@ QList<QString> Chat::modelList() const
             QString filePath = exePath + f;
             QFileInfo info(filePath);
             QString name = info.completeBaseName().remove(0, 5);
-            if (info.exists()) {
+            if (info.exists() && !m_modelIgnoreList.contains(name)) {
                 if (name == currentModelName)
                     list.prepend(name);
                 else
@@ -409,7 +409,7 @@ QList<QString> Chat::modelList() const
             QFileInfo info(filePath);
             QString basename = info.completeBaseName();
             QString name = basename.startsWith("ggml-") ? basename.remove(0, 5) : basename;
-            if (info.exists() && !list.contains(name)) { // don't allow duplicates
+            if (info.exists() && !list.contains(name) && !m_modelIgnoreList.contains(name)) { // don't allow duplicates
                 if (name == currentModelName)
                     list.prepend(name);
                 else
@@ -430,6 +430,11 @@ QList<QString> Chat::modelList() const
     }
 
     return list;
+}
+
+void Chat::ignoreModel(const QString &modelName)
+{
+    m_modelIgnoreList.append(modelName);
 }
 
 QList<QString> Chat::collectionList() const

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -82,6 +82,8 @@ public:
     QList<QString> modelList() const;
     bool isServer() const { return m_isServer; }
 
+    void ignoreModel(const QString&);
+
     QList<QString> collectionList() const;
 
     Q_INVOKABLE bool hasCollection(const QString &collection) const;
@@ -132,6 +134,7 @@ private:
     QString m_userName;
     QString m_savedModelName;
     QList<QString> m_collections;
+    QList<QString> m_modelIgnoreList;
     ChatModel *m_chatModel;
     bool m_responseInProgress;
     ResponseState m_responseState;


### PR DESCRIPTION
This change adds models that have failed to load to an ignore list and makes `ChatLLM::loadDefaultModel` iterate over all models found until one has succeeded to load.

It also makes sure to release the modelInfo on load failure in `ChatLLM::loadModel`.