### PR TITLE
Allow setting implementation search path without env var

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <cstdlib>
 
+std::string LLModel::m_implementations_search_path = ".";
+
 static bool requires_avxonly() {
 #ifdef __x86_64__
     #ifndef _MSC_VER
@@ -75,8 +77,7 @@ const std::vector<LLModel::Implementation> &LLModel::implementationList() {
             }
         };
 
-        const char *custom_impl_lookup_path = getenv("GPT4ALL_IMPLEMENTATIONS_PATH");
-        search_in_directory(custom_impl_lookup_path?custom_impl_lookup_path:".");
+        search_in_directory(m_implementations_search_path);
 #if defined(__APPLE__)
         search_in_directory("../../../");
 #endif

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -76,8 +76,17 @@ public:
     static const Implementation *implementation(std::ifstream& f, const std::string& buildVariant);
     static LLModel *construct(const std::string &modelPath, std::string buildVariant = "default");
 
+    static inline void setImplementationsSearchPath(const std::string& path) {
+        m_implementations_search_path = path;
+    }
+    static inline const std::string& implementationsSearchPath() {
+        return m_implementations_search_path;
+    }
+
 protected:
     const Implementation *m_implementation = nullptr;
+
+    static std::string m_implementations_search_path;
 
     void recalculateContext(PromptContext &promptCtx, std::function<bool(bool)> recalculate);
 };

--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -162,3 +162,13 @@ int32_t llmodel_threadCount(llmodel_model model)
     LLModelWrapper *wrapper = reinterpret_cast<LLModelWrapper*>(model);
     return wrapper->llModel->threadCount();
 }
+
+void llmodel_set_implementation_search_path(const char *path)
+{
+    LLModel::setImplementationsSearchPath(path);
+}
+
+const char *llmodel_get_implementation_search_path()
+{
+    return LLModel::implementationsSearchPath().c_str();
+}

--- a/gpt4all-backend/llmodel_c.h
+++ b/gpt4all-backend/llmodel_c.h
@@ -177,6 +177,19 @@ void llmodel_setThreadCount(llmodel_model model, int32_t n_threads);
  */
 int32_t llmodel_threadCount(llmodel_model model);
 
+/**
+ * Set llmodel implementation search path.
+ * Default is "."
+ * @param path The path to the llmodel implementation shared objects.
+ */
+void llmodel_set_implementation_search_path(const char *path);
+
+/**
+ * Get llmodel implementation search path.
+ * @return The current search path; lifetime ends on next set llmodel_set_implementation_search_path() call.
+ */
+const char *llmodel_get_implementation_search_path();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The `GPT4ALL_IMPLEMENTATIONS_PATH` environment variable is ignored now
