### PR TITLE
Change the default values for generation in GUI

### DIFF
--- a/gpt4all-chat/qml/SettingsDialog.qml
+++ b/gpt4all-chat/qml/SettingsDialog.qml
@@ -32,12 +32,12 @@ Dialog {
         id: theme
     }
 
-    property real defaultTemperature: 0.28
-    property real defaultTopP: 0.95
+    property real defaultTemperature: 0.7
+    property real defaultTopP: 0.1
     property int defaultTopK: 40
     property int defaultMaxLength: 4096
-    property int defaultPromptBatchSize: 9
-    property real defaultRepeatPenalty: 1.10
+    property int defaultPromptBatchSize: 128
+    property real defaultRepeatPenalty: 1.18
     property int defaultRepeatPenaltyTokens: 64
     property int defaultThreadCount: 0
     property bool defaultSaveChats: false


### PR DESCRIPTION
the defaults that we have right now aren't ideal, i tried many models(nous-vicuna, snoozy, groovy....) with the values given here: https://www.reddit.com/r/LocalLLaMA/wiki/index/#wiki_prompting , i used the "Precise" preset, and all of the models gave much better results.
Amount of times the models got stuck in a loop writing the same thing over and over significantly decreased using the new values, that allowed to make them write more longer responses, and follow the conversation for longer, without going schitzo.
And i believe the newcomers will appreciate not having to figure out why the models are constantly getting stuck in loops whenever the conversation gets a little long.

Also changed the `batch size` from `9` to `128`, 9 is too conservative imo.