### PR TITLE
Integrate OpenAI Chat Models into GPT4All Python bindings

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -19,8 +19,8 @@ DEFAULT_MODEL_DIRECTORY = os.path.join(str(Path.home()), ".cache", "gpt4all").re
 
 class GPT4All():
     """Python API for retrieving and interacting with GPT4All models.
-
-    Attribuies:
+    
+    Attributes:
         model: Pointer to underlying C model.
     """
     def __init__(self, model_name: str, api_key: str = None, model_path: str = None, model_type: str = None, allow_download = True):


### PR DESCRIPTION
This commit includes updates to the GPT4All Python API for handling both GPT4All models and OpenAI chat models.

Key changes include:

1. Modified the GPT4All constructor to recognize if an OpenAI API key is provided. If a key is present, the code will use OpenAI's models instead of downloading a model locally.

2. The `generate` function is updated to accept a list of messages compatible with OpenAI's chat models when the OpenAI API key is set.

3. Adjusted the `chat_completion` method to work with the updated `generate` function. It no longer rebuilds the prompt twice, and it correctly handles the return structure from OpenAI's ChatCompletion.

4. Enhanced error handling and added extensive docstrings for better code clarity and understanding.

With these updates, users of GPT4All API can now seamlessly switch between using GPT4All models and OpenAI chat models, providing more flexibility and options for their AI applications.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
