### PR TITLE
Markdown toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,10 @@ cython_debug/
 
 # vs code
 .vscode
+
+# Visual Studio
+.vs
+
 *.bin
 
 .DS_Store

--- a/gpt4all-chat/chatlistmodel.cpp
+++ b/gpt4all-chat/chatlistmodel.cpp
@@ -15,6 +15,7 @@ ChatListModel::ChatListModel(QObject *parent)
     , m_serverChat(nullptr)
     , m_currentChat(nullptr)
     , m_shouldSaveChats(false)
+    , m_renderMarkdown(true)
 {
     addDummyChat();
 
@@ -49,6 +50,19 @@ void ChatListModel::setShouldSaveChatGPTChats(bool b)
         return;
     m_shouldSaveChatGPTChats = b;
     emit shouldSaveChatGPTChatsChanged();
+}
+
+bool ChatListModel::renderMarkdown() const
+{
+    return m_renderMarkdown;
+}
+
+void ChatListModel::setRenderMarkdown(bool b)
+{
+    if (m_renderMarkdown == b)
+        return;
+    m_renderMarkdown = b;
+    emit renderMarkdownChanged();
 }
 
 void ChatListModel::removeChatFile(Chat *chat) const

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -21,6 +21,7 @@ class ChatListModel : public QAbstractListModel
     Q_PROPERTY(Chat *currentChat READ currentChat WRITE setCurrentChat NOTIFY currentChatChanged)
     Q_PROPERTY(bool shouldSaveChats READ shouldSaveChats WRITE setShouldSaveChats NOTIFY shouldSaveChatsChanged)
     Q_PROPERTY(bool shouldSaveChatGPTChats READ shouldSaveChatGPTChats WRITE setShouldSaveChatGPTChats NOTIFY shouldSaveChatGPTChatsChanged)
+    Q_PROPERTY(bool renderMarkdown READ renderMarkdown WRITE setRenderMarkdown NOTIFY renderMarkdownChanged)
 
 public:
     explicit ChatListModel(QObject *parent = nullptr);
@@ -65,6 +66,9 @@ public:
 
     bool shouldSaveChatGPTChats() const;
     void setShouldSaveChatGPTChats(bool b);
+
+    bool renderMarkdown() const;
+    void setRenderMarkdown(bool b);
 
     Q_INVOKABLE void addChat()
     {
@@ -204,6 +208,7 @@ Q_SIGNALS:
     void currentChatChanged();
     void shouldSaveChatsChanged();
     void shouldSaveChatGPTChatsChanged();
+    void renderMarkdownChanged();
 
 private Q_SLOTS:
     void newChatCountChanged()
@@ -245,6 +250,7 @@ private Q_SLOTS:
 private:
     bool m_shouldSaveChats;
     bool m_shouldSaveChatGPTChats;
+    bool m_renderMarkdown;
     Chat* m_newChat;
     Chat* m_dummyChat;
     Chat* m_serverChat;

--- a/gpt4all-chat/main.qml
+++ b/gpt4all-chat/main.qml
@@ -581,10 +581,19 @@ Window {
 
                     delegate: TextArea {
                         text: value + references
+                        // binding 'textFormat' directly is not enough, because switching formats
+                        // is not only a visible change; 'text' is getting changed, too. Reset it
+                        // using the underlying model value:
+                        Component.onCompleted: {
+                            textFormat = LLM.chatListModel.renderMarkdown ? TextEdit.MarkdownText : TextEdit.PlainText;
+                            LLM.chatListModel.onRenderMarkdownChanged.connect(function() {
+                                textFormat = LLM.chatListModel.renderMarkdown ? TextEdit.MarkdownText : TextEdit.PlainText;
+                                text = value + references;
+                            });
+                        }
                         width: listView.width
                         color: theme.textColor
                         wrapMode: Text.WordWrap
-                        textFormat: LLM.chatListModel.renderMarkdown ? TextEdit.MarkdownText : TextEdit.PlainText
                         focus: false
                         readOnly: true
                         font.pixelSize: theme.fontSizeLarge

--- a/gpt4all-chat/main.qml
+++ b/gpt4all-chat/main.qml
@@ -584,7 +584,7 @@ Window {
                         width: listView.width
                         color: theme.textColor
                         wrapMode: Text.WordWrap
-                        textFormat: TextEdit.MarkdownText
+                        textFormat: LLM.chatListModel.renderMarkdown ? TextEdit.MarkdownText : TextEdit.PlainText
                         focus: false
                         readOnly: true
                         font.pixelSize: theme.fontSizeLarge

--- a/gpt4all-chat/qml/SettingsDialog.qml
+++ b/gpt4all-chat/qml/SettingsDialog.qml
@@ -43,6 +43,7 @@ Dialog {
     property int defaultThreadCount: 0
     property bool defaultSaveChats: false
     property bool defaultSaveChatGPTChats: true
+    property bool defaultRenderMarkdown: true
     property bool defaultServerChat: false
     property string defaultPromptTemplate: "### Human:
 %1
@@ -61,6 +62,7 @@ Dialog {
     property alias threadCount: settings.threadCount
     property alias saveChats: settings.saveChats
     property alias saveChatGPTChats: settings.saveChatGPTChats
+    property alias renderMarkdown: settings.renderMarkdown
     property alias serverChat: settings.serverChat
     property alias modelPath: settings.modelPath
     property alias userDefaultModel: settings.userDefaultModel
@@ -75,6 +77,7 @@ Dialog {
         property int threadCount: settingsDialog.defaultThreadCount
         property bool saveChats: settingsDialog.defaultSaveChats
         property bool saveChatGPTChats: settingsDialog.defaultSaveChatGPTChats
+        property bool renderMarkdown: settingsDialog.defaultRenderMarkdown
         property bool serverChat: settingsDialog.defaultServerChat
         property real repeatPenalty: settingsDialog.defaultRepeatPenalty
         property int repeatPenaltyTokens: settingsDialog.defaultRepeatPenaltyTokens
@@ -99,6 +102,7 @@ Dialog {
         settings.modelPath = settingsDialog.defaultModelPath
         settings.threadCount = defaultThreadCount
         settings.saveChats = defaultSaveChats
+        settings.renderMarkdown = defaultRenderMarkdown
         settings.saveChatGPTChats = defaultSaveChatGPTChats
         settings.serverChat = defaultServerChat
         settings.userDefaultModel = defaultUserDefaultModel
@@ -107,6 +111,7 @@ Dialog {
         LLM.serverEnabled = settings.serverChat
         LLM.chatListModel.shouldSaveChats = settings.saveChats
         LLM.chatListModel.shouldSaveChatGPTChats = settings.saveChatGPTChats
+        LLM.chatListModel.renderMarkdown = settings.renderMarkdown
         settings.sync()
     }
 
@@ -115,6 +120,7 @@ Dialog {
         LLM.serverEnabled = settings.serverChat
         LLM.chatListModel.shouldSaveChats = settings.saveChats
         LLM.chatListModel.shouldSaveChatGPTChats = settings.saveChatGPTChats
+        LLM.chatListModel.renderMarkdown = settings.renderMarkdown
         Download.downloadLocalModelsPath = settings.modelPath
     }
 
@@ -766,15 +772,35 @@ Dialog {
                         }
                     }
                     Label {
-                        id: serverChatLabel
-                        text: qsTr("Enable web server:")
+                        id: renderMarkdownLabel
+                        text: qsTr("Render Markdown:")
                         color: theme.textColor
                         Layout.row: 6
                         Layout.column: 0
                     }
                     MyCheckBox {
-                        id: serverChatBox
+                        id: renderMarkdownBox
                         Layout.row: 6
+                        Layout.column: 1
+                        checked: settingsDialog.renderMarkdown
+                        onClicked: {
+                            settingsDialog.renderMarkdown = renderMarkdownBox.checked
+                            LLM.chatListModel.renderMarkdown = renderMarkdownBox.checked
+                            settings.sync()
+                        }
+                        ToolTip.text: qsTr("Interpret all prompts and responses as Markdown formatted text")
+                        ToolTip.visible: hovered
+                    }
+                    Label {
+                        id: serverChatLabel
+                        text: qsTr("Enable web server:")
+                        color: theme.textColor
+                        Layout.row: 7
+                        Layout.column: 0
+                    }
+                    MyCheckBox {
+                        id: serverChatBox
+                        Layout.row: 7
                         Layout.column: 1
                         checked: settings.serverChat
                         onClicked: {
@@ -786,7 +812,7 @@ Dialog {
                         ToolTip.visible: hovered
                     }
                     MyButton {
-                        Layout.row: 7
+                        Layout.row: 8
                         Layout.column: 1
                         Layout.fillWidth: true
                         text: qsTr("Restore Defaults")


### PR DESCRIPTION
## Describe your changes
As mentioned in #864 and https://github.com/nomic-ai/gpt4all/issues/647#issuecomment-1565852945 Markdown rendering can make some content invisible.

To address that, I've added a setting to toggle the state of Markdown rendering.

Note: It's been years since I've touched C++ and Qt. Although the changes didn't seem very complicated, there's no guarantee I got everything right.

## Issue ticket number and link
https://github.com/nomic-ai/gpt4all/issues/864

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Here is what it looks like with the fixes:

https://github.com/nomic-ai/gpt4all/assets/134004613/2cefa5c2-2825-458b-854d-d2aabcebc328

### Steps to Reproduce
Simply try entering something like `<this could be interpreted as HTML>` as prompt, or get the model to respond with something like that to trigger the issue.

## Notes
Created as a draft because it's adding a setting. There might be alternative ways to address it.