### PR TITLE
Fix CLI app.py

### DIFF
--- a/gpt4all-bindings/cli/app.py
+++ b/gpt4all-bindings/cli/app.py
@@ -17,7 +17,7 @@ SPECIAL_COMMANDS = {
     "/help": lambda _: print("Special commands: /reset, /exit, /help and /clear"),
 }
 
-VERSION = "0.1.0"
+VERSION = "0.3.4"
 
 CLI_START_MESSAGE = f"""
     
@@ -32,12 +32,6 @@ Welcome to the GPT4All CLI! Version {VERSION}
 Type /help for special commands.
                                                     
 """
-
-def _cli_override_response_callback(token_id, response):
-    resp = response.decode("utf-8")
-    print(resp, end="", flush=True)
-    return True
-
 
 # create typer app
 app = typer.Typer()
@@ -67,9 +61,6 @@ def repl(
         print(f" {num_threads} threads", end="", flush=True)
     else:
         print(f"\nUsing {gpt4all_instance.model.thread_count()} threads", end="")
-
-    # overwrite _response_callback on model
-    gpt4all_instance.model._response_callback = _cli_override_response_callback
 
     print(CLI_START_MESSAGE)
 
@@ -103,7 +94,7 @@ def repl(
             context_erase=0.0,
             # required kwargs for cli ux (incremental response)
             verbose=False,
-            std_passthrough=True,
+            streaming=True,
         )
         # record assistant's response to messages
         MESSAGES.append(full_response.get("choices")[0].get("message"))
@@ -112,7 +103,7 @@ def repl(
 
 @app.command()
 def version():
-    print("gpt4all-cli v0.1.0")
+    print("gpt4all-cli v0.3.4")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The CLI app.py is currently broken. See discussion starting in this issue here: <https://github.com/nomic-ai/gpt4all/issues/820#issuecomment-1582955946>

## Describe your changes
- the bindings API changed in 057b9, but the CLI was not updated
- change 'std_passthrough' param to the renamed 'streaming'
- remove '_cli_override_response_callback' as it breaks and is no longer needed

## Issue ticket number and link
The bug was discovered as part of a separate/wider issue: https://github.com/nomic-ai/gpt4all/issues/820#issuecomment-1582955946

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
- bug traceback see: <https://github.com/nomic-ai/gpt4all/issues/820#issuecomment-1582955946>

- fixed version (Windows cmd):
  ![image](https://github.com/nomic-ai/gpt4all/assets/134004613/7b8a5f84-7250-43b4-966e-ca12f2962523)

### Steps to Reproduce
try to run, it'll break:
```shell
python -m pip install --user -U gpt4all typer  # installs current gpt4all==0.3.0
python gpt4all-bindings/cli/app.py repl
```

## Notes
I did not yet increase the version number, but that would probably be appropriate. Should it follow the PyPI package versioning?
