### PR TITLE
Fix Windows MSVC AVX builds

### DIFF
--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -372,7 +372,7 @@ function(include_ggml DIRECTORY SUFFIX WITH_LLAMA)
         message(STATUS "x86 detected")
         if (MSVC)
             if (LLAMA_AVX512)
-                target_compile_definitions(ggml${SUFFIX} PRIVATE
+                target_compile_options(ggml${SUFFIX} PRIVATE
                     $<$<COMPILE_LANGUAGE:C>:/arch:AVX512>
                     $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX512>)
                 # MSVC has no compile-time flags enabling specific
@@ -390,11 +390,11 @@ function(include_ggml DIRECTORY SUFFIX WITH_LLAMA)
                         $<$<COMPILE_LANGUAGE:CXX>:__AVX512VNNI__>)
                 endif()
             elseif (LLAMA_AVX2)
-                target_compile_definitions(ggml${SUFFIX} PRIVATE
+                target_compile_options(ggml${SUFFIX} PRIVATE
                     $<$<COMPILE_LANGUAGE:C>:/arch:AVX2>
                     $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX2>)
             elseif (LLAMA_AVX)
-                target_compile_definitions(ggml${SUFFIX} PRIVATE
+                target_compile_options(ggml${SUFFIX} PRIVATE
                     $<$<COMPILE_LANGUAGE:C>:/arch:AVX>
                     $<$<COMPILE_LANGUAGE:CXX>:/arch:AVX>)
             endif()


### PR DESCRIPTION
- A bug introduced in 0cb2b86730a56cee7460b0582418228e8049d3ef breaks AVX on Windows with MSVC
- currently getting: `warning C5102: ignoring invalid command-line macro definition '/arch:AVX2'`

## Describe your changes
- The solution is to use `_options(...)` not `_definitions(...)`

## Issue ticket number and link
- https://github.com/nomic-ai/gpt4all/issues/923

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Description of the problem is in the accompanying issue: #923 

### Steps to Reproduce
Build on Windows without the fix produces warnings like:
```
command line : warning C5102: ignoring invalid command-line macro definition '/arch:AVX2' ...
```