### PR TITLE
Metal+LLama take two

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/manyoso/llama.cpp.git
 [submodule "llama.cpp-mainline"]
 	path = gpt4all-backend/llama.cpp-mainline
-	url = https://github.com/ggerganov/llama.cpp.git
+	url = https://github.com/nomic-ai/llama.cpp.git

--- a/gpt4all-backend/CMakeLists.txt
+++ b/gpt4all-backend/CMakeLists.txt
@@ -78,6 +78,9 @@ foreach(BUILD_VARIANT IN LISTS BUILD_VARIANTS)
     # Add each individual implementations
     add_library(llamamodel-mainline-${BUILD_VARIANT} SHARED
         llamamodel.cpp llmodel_shared.cpp)
+    if (LLAMA_METAL)
+        target_compile_definitions(llamamodel-mainline-${BUILD_VARIANT} PUBLIC GGML_USE_METAL GGML_METAL_NDEBUG)
+    endif()
     target_compile_definitions(llamamodel-mainline-${BUILD_VARIANT} PRIVATE
         LLAMA_VERSIONS=>=3 LLAMA_DATE=999999)
     prepare_target(llamamodel-mainline llama-mainline)

--- a/gpt4all-backend/CMakeLists.txt
+++ b/gpt4all-backend/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 include(llama.cpp.cmake)
 
 set(BUILD_VARIANTS default avxonly)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(BUILD_VARIANTS ${BUILD_VARIANTS} metal)
+endif()
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -54,10 +57,20 @@ foreach(BUILD_VARIANT IN LISTS BUILD_VARIANTS)
     set(LLAMA_F16C ${GPT4ALL_ALLOW_NON_AVX})
     set(LLAMA_FMA  ${GPT4ALL_ALLOW_NON_AVX})
 
+    if (BUILD_VARIANT STREQUAL metal)
+        set(LLAMA_K_QUANTS YES)
+        set(LLAMA_METAL YES)
+    else()
+        set(LLAMA_K_QUANTS NO)
+        set(LLAMA_METAL NO)
+    endif()
+
     # Include GGML
     include_ggml(llama.cpp-mainline -mainline-${BUILD_VARIANT} ON)
-    include_ggml(llama.cpp-230511 -230511-${BUILD_VARIANT} ON)
-    include_ggml(llama.cpp-230519 -230519-${BUILD_VARIANT} ON)
+    if (NOT LLAMA_METAL)
+        include_ggml(llama.cpp-230511 -230511-${BUILD_VARIANT} ON)
+        include_ggml(llama.cpp-230519 -230519-${BUILD_VARIANT} ON)
+    endif()
 
     # Function for preparing individual implementations
     function(prepare_target TARGET_NAME BASE_LIB)
@@ -78,36 +91,34 @@ foreach(BUILD_VARIANT IN LISTS BUILD_VARIANTS)
     # Add each individual implementations
     add_library(llamamodel-mainline-${BUILD_VARIANT} SHARED
         llamamodel.cpp llmodel_shared.cpp)
-    if (LLAMA_METAL)
-        target_compile_definitions(llamamodel-mainline-${BUILD_VARIANT} PUBLIC GGML_USE_METAL GGML_METAL_NDEBUG)
-    endif()
     target_compile_definitions(llamamodel-mainline-${BUILD_VARIANT} PRIVATE
         LLAMA_VERSIONS=>=3 LLAMA_DATE=999999)
     prepare_target(llamamodel-mainline llama-mainline)
 
-    add_library(llamamodel-230519-${BUILD_VARIANT} SHARED
-        llamamodel.cpp llmodel_shared.cpp)
-    target_compile_definitions(llamamodel-230519-${BUILD_VARIANT} PRIVATE
-        LLAMA_VERSIONS===2 LLAMA_DATE=230519)
-    prepare_target(llamamodel-230519 llama-230519)
+    if (NOT LLAMA_METAL)
+        add_library(llamamodel-230519-${BUILD_VARIANT} SHARED
+            llamamodel.cpp llmodel_shared.cpp)
+        target_compile_definitions(llamamodel-230519-${BUILD_VARIANT} PRIVATE
+            LLAMA_VERSIONS===2 LLAMA_DATE=230519)
+        prepare_target(llamamodel-230519 llama-230519)
+        add_library(llamamodel-230511-${BUILD_VARIANT} SHARED
+            llamamodel.cpp llmodel_shared.cpp)
+        target_compile_definitions(llamamodel-230511-${BUILD_VARIANT} PRIVATE
+            LLAMA_VERSIONS=<=1 LLAMA_DATE=230511)
+        prepare_target(llamamodel-230511 llama-230511)
 
-    add_library(llamamodel-230511-${BUILD_VARIANT} SHARED
-        llamamodel.cpp llmodel_shared.cpp)
-    target_compile_definitions(llamamodel-230511-${BUILD_VARIANT} PRIVATE
-        LLAMA_VERSIONS=<=1 LLAMA_DATE=230511)
-    prepare_target(llamamodel-230511 llama-230511)
+        add_library(gptj-${BUILD_VARIANT} SHARED
+            gptj.cpp utils.h utils.cpp llmodel_shared.cpp)
+        prepare_target(gptj ggml-230511)
 
-    add_library(gptj-${BUILD_VARIANT} SHARED
-        gptj.cpp utils.h utils.cpp llmodel_shared.cpp)
-    prepare_target(gptj ggml-230511)
+        add_library(mpt-${BUILD_VARIANT} SHARED
+            mpt.cpp utils.h utils.cpp llmodel_shared.cpp)
+        prepare_target(mpt ggml-230511)
 
-    add_library(mpt-${BUILD_VARIANT} SHARED
-        mpt.cpp utils.h utils.cpp llmodel_shared.cpp)
-    prepare_target(mpt ggml-230511)
-
-    add_library(replit-${BUILD_VARIANT} SHARED
-        replit.cpp utils.h utils.cpp llmodel_shared.cpp)
-    prepare_target(replit ggml-230511)
+        add_library(replit-${BUILD_VARIANT} SHARED
+            replit.cpp utils.h utils.cpp llmodel_shared.cpp)
+        prepare_target(replit ggml-230511)
+    endif()
 endforeach()
 
 add_library(llmodel

--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -34,6 +34,7 @@ endif()
 #
 # Option list
 #
+# some of the options here are commented out so they can be set "dynamically" before calling include_ggml()
 
 # general
 option(LLAMA_STATIC                 "llama: static link libraries"                          OFF)
@@ -67,7 +68,8 @@ option(LLAMA_ACCELERATE             "llama: enable Accelerate framework"        
 option(LLAMA_OPENBLAS               "llama: use OpenBLAS"                                   OFF)
 #option(LLAMA_CUBLAS                 "llama: use cuBLAS"                                     OFF)
 #option(LLAMA_CLBLAST                "llama: use CLBlast"                                    OFF)
-option(LLAMA_METAL                  "llama: use Metal"                                      OFF)
+#option(LLAMA_METAL                  "llama: use Metal"                                      OFF)
+#option(LLAMA_K_QUANTS               "llama: use k-quants"                                   ON)
 set(LLAMA_BLAS_VENDOR "Generic" CACHE STRING "llama: BLAS library vendor")
 set(LLAMA_CUDA_DMMV_X "32" CACHE STRING "llama: x stride for dmmv CUDA kernels")
 set(LLAMA_CUDA_DMMV_Y "1" CACHE STRING  "llama: y block size for dmmv CUDA kernels")
@@ -264,10 +266,10 @@ function(include_ggml DIRECTORY SUFFIX WITH_LLAMA)
 
     set(GGML_SOURCES_QUANT_K )
     set(GGML_METAL_SOURCES )
-    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/ggml-quants-k.h)
+    if (LLAMA_K_QUANTS)
         set(GGML_SOURCES_QUANT_K
-            ${DIRECTORY}/ggml-quants-k.h
-            ${DIRECTORY}/ggml-quants-k.c)
+            ${DIRECTORY}/k_quants.h
+            ${DIRECTORY}/k_quants.c)
 
         if (LLAMA_METAL)
             find_library(FOUNDATION_LIBRARY         Foundation              REQUIRED)
@@ -291,13 +293,6 @@ function(include_ggml DIRECTORY SUFFIX WITH_LLAMA)
         endif()
     endif()
 
-    set(GGML_SOURCES_QUANT_K )
-    if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/ggml-quants-k.h)
-        set(GGML_SOURCES_QUANT_K
-            ${DIRECTORY}/ggml-quants-k.h
-            ${DIRECTORY}/ggml-quants-k.c)
-    endif()
-
     add_library(ggml${SUFFIX} OBJECT
                 ${DIRECTORY}/ggml.c
                 ${DIRECTORY}/ggml.h
@@ -305,6 +300,10 @@ function(include_ggml DIRECTORY SUFFIX WITH_LLAMA)
                 ${GGML_SOURCES_CUDA}
                 ${GGML_METAL_SOURCES}
                 ${GGML_OPENCL_SOURCES})
+
+    if (LLAMA_K_QUANTS)
+        target_compile_definitions(ggml${SUFFIX} PUBLIC GGML_USE_K_QUANTS)
+    endif()
 
     if (LLAMA_METAL AND GGML_METAL_SOURCES)
         target_compile_definitions(ggml${SUFFIX} PUBLIC GGML_USE_METAL GGML_METAL_NDEBUG)

--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -67,7 +67,7 @@ option(LLAMA_ACCELERATE             "llama: enable Accelerate framework"        
 option(LLAMA_OPENBLAS               "llama: use OpenBLAS"                                   OFF)
 #option(LLAMA_CUBLAS                 "llama: use cuBLAS"                                     OFF)
 #option(LLAMA_CLBLAST                "llama: use CLBlast"                                    OFF)
-#option(LLAMA_METAL                  "llama: use Metal"                                      OFF)
+option(LLAMA_METAL                  "llama: use Metal"                                      OFF)
 set(LLAMA_BLAS_VENDOR "Generic" CACHE STRING "llama: BLAS library vendor")
 set(LLAMA_CUDA_DMMV_X "32" CACHE STRING "llama: x stride for dmmv CUDA kernels")
 set(LLAMA_CUDA_DMMV_Y "1" CACHE STRING  "llama: y block size for dmmv CUDA kernels")

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -115,6 +115,12 @@ bool LLamaModel::loadModel(const std::string &modelPath)
 #if LLAMA_DATE <= 230511
     d_ptr->params.n_parts  = params.n_parts;
 #endif
+#ifdef GGML_USE_METAL
+    std::cerr << "llama.cpp: using Metal" << std::endl;
+    // metal always runs the whole model if n_gpu_layers is not 0, at least
+    // currently
+    d_ptr->params.n_gpu_layers = 1;
+#endif
 
     d_ptr->ctx = llama_init_from_file(modelPath.c_str(), d_ptr->params);
     if (!d_ptr->ctx) {

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -234,7 +234,30 @@ DLL_EXPORT bool magic_match(std::istream& f) {
     // Check version
     uint32_t version = 0;
     f.read(reinterpret_cast<char*>(&version), sizeof(version));
-    return version LLAMA_VERSIONS;
+    if (!(version LLAMA_VERSIONS)) {
+        return false;
+    }
+#ifdef GGML_USE_METAL
+    // Check quant supported on metal
+    // skip fields
+    off_t offset = sizeof(uint32_t) * 6; // n_vocab, n_embd, n_mult, n_head, n_layer, n_rot
+    f.seekg(offset, std::ios_base::cur);
+    uint32_t ftype;
+    f.read(reinterpret_cast<char*>(&ftype), sizeof(ftype)); // ftype
+    switch((enum llama_ftype) ftype) {
+        // currently supported on Metal https://github.com/ggerganov/llama.cpp/blob/ae9663f1887513e152839e91f61c513075a19422/ggml-metal.m#L51-L55
+        case LLAMA_FTYPE_MOSTLY_F16:
+        case LLAMA_FTYPE_MOSTLY_Q2_K:
+        case LLAMA_FTYPE_MOSTLY_Q4_0:
+        case LLAMA_FTYPE_MOSTLY_Q6_K:
+        case LLAMA_FTYPE_MOSTLY_Q4_K_S:
+        case LLAMA_FTYPE_MOSTLY_Q4_K_M:
+            return true;
+        default: // unsupported quant-type for Metal
+            return false;
+    }
+#endif
+    return true;
 }
 
 DLL_EXPORT LLModel *construct() {

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -121,24 +121,30 @@ LLModel *LLModel::construct(const std::string &modelPath, std::string buildVaria
     if (!has_at_least_minimal_hardware())
         return nullptr;
 
-    //TODO: Auto-detect CUDA/OpenCL
-    if (buildVariant == "auto") {
-#if defined(__APPLE__) && defined(__arm64__) // FIXME: See if metal works for intel macs
-        buildVariant = "metal";
-#else
-        if (requires_avxonly()) {
-            buildVariant = "avxonly";
-        } else {
-            buildVariant = "default";
-        }
-#endif
-    }
     // Read magic
     std::ifstream f(modelPath, std::ios::binary);
     if (!f) return nullptr;
     // Get correct implementation
-    auto impl = implementation(f, buildVariant);
-    if (!impl) return nullptr;
+    const LLModel::Implementation* impl = nullptr;
+
+    #if defined(__APPLE__) && defined(__arm64__) // FIXME: See if metal works for intel macs
+        if (buildVariant == "auto") {
+            impl = implementation(f, "metal");
+        }
+    #endif
+
+    if (!impl) {
+        //TODO: Auto-detect CUDA/OpenCL
+        if (buildVariant == "auto") {
+            if (requires_avxonly()) {
+                buildVariant = "avxonly";
+            } else {
+                buildVariant = "default";
+            }
+        }
+        impl = implementation(f, buildVariant);
+        if (!impl) return nullptr;
+    }
     f.close();
     // Construct and return llmodel implementation
     return impl->construct();

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -123,11 +123,15 @@ LLModel *LLModel::construct(const std::string &modelPath, std::string buildVaria
 
     //TODO: Auto-detect CUDA/OpenCL
     if (buildVariant == "auto") {
+#if defined(__APPLE__) && defined(__arm64__) // FIXME: See if metal works for intel macs
+        buildVariant = "metal";
+#else
         if (requires_avxonly()) {
             buildVariant = "avxonly";
         } else {
             buildVariant = "default";
         }
+#endif
     }
     // Read magic
     std::ifstream f(modelPath, std::ios::binary);

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -44,7 +44,7 @@ def copy_prebuilt_C_lib(src_dir, dest_dir, dest_build_dir):
                 d = os.path.join(dest_dir, item)
                 shutil.copy2(s, d)
                 files_copied += 1
-            if item.endswith(lib_ext):
+            if item.endswith(lib_ext) or item.endswith('.metal'):
                 s = os.path.join(dirpath, item)
                 d = os.path.join(dest_build_dir, item)
                 shutil.copy2(s, d)

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -58,6 +58,11 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_subdirectory(../gpt4all-backend llmodel)
 
+set(METAL_SHADER_FILE)
+
+if(LLAMA_METAL)
+set(METAL_SHADER_FILE ../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal)
+endif()
 qt_add_executable(chat
     main.cpp
     chat.h chat.cpp
@@ -72,6 +77,7 @@ qt_add_executable(chat
     server.h server.cpp
     logger.h logger.cpp
     sysinfo.h
+    ${METAL_SHADER_FILE}
 )
 
 qt_add_qml_module(chat
@@ -122,10 +128,6 @@ set_target_properties(chat PROPERTIES
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
-    # TODO this isn't doing the trick for some reason
-    # the file needs to wind up in the bundle's Contents/Resources dir ths CMake docs indicate this *should* do...
-    # https://cmake.org/cmake/help/latest/prop_tgt/RESOURCE.html
-    RESOURCE "../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal"
     WIN32_EXECUTABLE TRUE
     MACOSX_BUNDLE_ICON_FILE "favicon.icns"
 )
@@ -133,6 +135,7 @@ set_target_properties(chat PROPERTIES
 if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
     set_target_properties(chat PROPERTIES
         OUTPUT_NAME gpt4all
+        RESOURCE ${METAL_SHADER_FILE}
     )
 endif()
 

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -142,6 +142,7 @@ if(METAL_SHADER_FILE)
     set_target_properties(chat PROPERTIES
         RESOURCE ${METAL_SHADER_FILE}
     )
+    configure_file(${METAL_SHADER_FILE} bin/ggml-metal.metal COPYONLY)
 endif()
 
 target_compile_definitions(chat

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -59,10 +59,10 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 add_subdirectory(../gpt4all-backend llmodel)
 
 set(METAL_SHADER_FILE)
-
-if(LLAMA_METAL)
-set(METAL_SHADER_FILE ../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal)
+if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
+  set(METAL_SHADER_FILE ../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal)
 endif()
+
 qt_add_executable(chat
     main.cpp
     chat.h chat.cpp

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -135,6 +135,11 @@ set_target_properties(chat PROPERTIES
 if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
     set_target_properties(chat PROPERTIES
         OUTPUT_NAME gpt4all
+    )
+endif()
+
+if(METAL_SHADER_FILE)
+    set_target_properties(chat PROPERTIES
         RESOURCE ${METAL_SHADER_FILE}
     )
 endif()

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -122,6 +122,10 @@ set_target_properties(chat PROPERTIES
     MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
+    # TODO this isn't doing the trick for some reason
+    # the file needs to wind up in the bundle's Contents/Resources dir ths CMake docs indicate this *should* do...
+    # https://cmake.org/cmake/help/latest/prop_tgt/RESOURCE.html
+    RESOURCE "../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal"
     WIN32_EXECUTABLE TRUE
     MACOSX_BUNDLE_ICON_FILE "favicon.icns"
 )


### PR DESCRIPTION
Python binding works now `ggml-metal.metal` is now searched for next to the .so/.dylib by adding https://github.com/ggerganov/llama.cpp/pull/1782 to our fork, the `.metal` file needs to generally be copied along with the llmodel libs with this approach.