### PR TITLE
Typo, ignore list 

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = blong, belong
+ignore-words-list = blong, belong, AfterAll
 skip = .git,*.pdf,*.svg,*.lock

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = blong, belong, AfterAll
+ignore-words-list = blong, belong, afterall
 skip = .git,*.pdf,*.svg,*.lock

--- a/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/LLModel.java
+++ b/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/LLModel.java
@@ -108,7 +108,7 @@ public  class LLModel implements AutoCloseable {
     }
 
     /**
-     * This may be set before any Model instance classe are instantiated to
+     * This may be set before any Model instance classes are instantiated to
      * set where the model may be found. This may be needed if setting
      * library search path by standard means is not available.
      */


### PR DESCRIPTION
Fix typo in javadoc,
Add word to ignore list for codespellrc
