### PR TITLE
Allow to set a SetLibrarySearchPath in the golang bindings

### DIFF
--- a/gpt4all-bindings/golang/README.md
+++ b/gpt4all-bindings/golang/README.md
@@ -45,7 +45,7 @@ To use the bindings in your own software:
 
 - Import `github.com/nomic-ai/gpt4all/gpt4all-bindings/golang`;
 - Compile `libgpt4all.a` (you can use `make libgpt4all.a` in the bindings/go directory);
-- Link your go binary against whisper by setting the environment variables `C_INCLUDE_PATH` and `LIBRARY_PATH` to point to the `binding.h` file directory and `libgpt4all.a` file directory respectively.
+- Link your go binary by setting the environment variables `C_INCLUDE_PATH` and `LIBRARY_PATH` to point to the `binding.h` file directory and `libgpt4all.a` file directory respectively.
 - Note: you need to have *.so/*.dynlib/*.dll files of the implementation nearby the binary produced by the binding in order to make this to work
 
 ## Testing

--- a/gpt4all-bindings/golang/gpt4all.go
+++ b/gpt4all-bindings/golang/gpt4all.go
@@ -10,6 +10,7 @@ package gpt4all
 //                            float top_p, float temp, int n_batch,float ctx_erase);
 // void free_model(void *state_ptr);
 // extern unsigned char getTokenCallback(void *, char *);
+// void llmodel_set_implementation_search_path(const char *path);
 import "C"
 import (
 	"fmt"
@@ -26,6 +27,10 @@ type Model struct {
 
 func New(model string, opts ...ModelOption) (*Model, error) {
 	ops := NewModelOptions(opts...)
+
+	if ops.LibrarySearchPath != "" {
+		C.llmodel_set_implementation_search_path(C.CString(ops.LibrarySearchPath))
+	}
 
 	state := C.load_model(C.CString(model), C.int(ops.Threads))
 

--- a/gpt4all-bindings/golang/options.go
+++ b/gpt4all-bindings/golang/options.go
@@ -24,7 +24,8 @@ var DefaultModelOptions ModelOptions = ModelOptions{
 }
 
 type ModelOptions struct {
-	Threads int
+	Threads           int
+	LibrarySearchPath string
 }
 type ModelOption func(p *ModelOptions)
 
@@ -97,6 +98,13 @@ func NewPredictOptions(opts ...PredictOption) PredictOptions {
 func SetThreads(c int) ModelOption {
 	return func(p *ModelOptions) {
 		p.Threads = c
+	}
+}
+
+// SetLibrarySearchPath sets the dynamic libraries used by gpt4all for the various ggml implementations.
+func SetLibrarySearchPath(t string) ModelOption {
+	return func(p *ModelOptions) {
+		p.LibrarySearchPath = t
 	}
 }
 


### PR DESCRIPTION
This is used to identify the path where all the various implementations are

## Describe your changes

This adds `SetLibrarySearchPath` as model option to search lib path in the specified directory instead of the current work directory.

## Issue ticket number and link

#826 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

Before:

```
11:59AM DBG Loading model in memory from file: /home/mudler/_git/LocalAI/models/ggml-gpt4all-j                                                                                                                       
Debug: New GPT4ALL                                                                                                                                                                                                          
Debug: Library search path: /tmp/localai/backend_data                                                                                                                                                                       
load_gpt4all_model: error 'Success'                                                                                                                                                                                  
11:59AM DBG [gpt4all] Fails: failed loading mode
```

After:
```
gptj_model_load: loading model from '/home/mudler/_git/LocalAI/models/ggml-gpt4all-j' - please wait ...                                                                                                              
gptj_model_load: n_vocab = 50400                                                                                                                                                                                     
gptj_model_load: n_ctx   = 2048                                                                                                                                                                                      
gptj_model_load: n_embd  = 4096
gptj_model_load: n_head  = 16
gptj_model_load: n_layer = 28
gptj_model_load: n_rot   = 64
gptj_model_load: f16     = 2
gptj_model_load: ggml ctx size = 5401.45 MB
gptj_model_load: kv self size  =  896.00 MB
gptj_model_load: ................................... done
gptj_model_load: model size =  3609.38 MB / num tensors = 285
12:01PM DBG [gpt4all] Loads OK
12:01PM DBG Response: {"object":"chat.completion","model":"ggml-gpt4all-j","choices":[{"message":{"role":"assistant","content":"I'm doing well, thank you. How about yourself?"}}],"usage":{"prompt_tokens":0,"comple
tion_tokens":0,"total_tokens":0}}
```

### Steps to Reproduce

This affect only binaries that are not in the same directory within the implementations

## Notes

Without this it's impossible to specify a search path to find the various implementations libs.
