### PR TITLE
fix llama.cpp k-quants

### DIFF
--- a/gpt4all-backend/CMakeLists.txt
+++ b/gpt4all-backend/CMakeLists.txt
@@ -60,16 +60,16 @@ foreach(BUILD_VARIANT IN LISTS BUILD_VARIANTS)
     set(LLAMA_FMA  ${GPT4ALL_ALLOW_NON_AVX})
 
     if (BUILD_VARIANT STREQUAL metal)
-        set(LLAMA_K_QUANTS YES)
         set(LLAMA_METAL YES)
     else()
-        set(LLAMA_K_QUANTS NO)
         set(LLAMA_METAL NO)
     endif()
 
     # Include GGML
+    set(LLAMA_K_QUANTS YES)
     include_ggml(llama.cpp-mainline -mainline-${BUILD_VARIANT} ON)
     if (NOT LLAMA_METAL)
+        set(LLAMA_K_QUANTS NO)
         include_ggml(llama.cpp-230511 -230511-${BUILD_VARIANT} ON)
         include_ggml(llama.cpp-230519 -230519-${BUILD_VARIANT} ON)
     endif()


### PR DESCRIPTION
- [x] fix loading and running llama model files using the new "k" quantizations - the change here makes them work on non-Metal builds now instead of simply failing to load
- [ ] they load but still generate garbage output on a Metal build, even though a build of the `llama.cpp` we're using's `main` binary can run them on Metal without problems. 
    - it turns out this bug exists upstream if you do what we do and set `n_ctx` to 2048: https://github.com/ggerganov/llama.cpp/issues/1881
