### PR TITLE
Use operator ""_MiB instead of defining MB in each implementation

### DIFF
--- a/gpt4all-backend/gptj.cpp
+++ b/gpt4all-backend/gptj.cpp
@@ -30,8 +30,6 @@
 
 namespace {
 const char *modelType_ = "GPT-J";
-
-static const size_t MB = 1024*1024;
 }
 
 // default hparams (GPT-J 6B)
@@ -139,7 +137,7 @@ static bool kv_cache_init(
     const int64_t n_mem      = (int64_t)n_layer*n_ctx;
     const int64_t n_elements = n_embd*n_mem;
 
-    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2u*MB);
+    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2_MiB);
 
     struct ggml_init_params params;
     params.mem_size   = cache.buf.size;
@@ -501,7 +499,7 @@ bool gptj_eval(
     const int n_vocab = hparams.n_vocab;
     const int n_rot   = hparams.n_rot;
 
-    const size_t init_buf_size = 1024u*MB;
+    const size_t init_buf_size = 1024_MiB;
     if (!model.buf.addr || model.buf.size < init_buf_size)
         model.buf.resize(init_buf_size);
 

--- a/gpt4all-backend/mpt.cpp
+++ b/gpt4all-backend/mpt.cpp
@@ -33,8 +33,6 @@
 
 namespace {
 const char *modelType_ = "MPT";
-
-static const size_t MB = 1024*1024;
 }
 
 // default hparams (MPT 7B)
@@ -134,7 +132,7 @@ static bool kv_cache_init(
     const int64_t n_mem      = (int64_t)n_layer*n_ctx;
     const int64_t n_elements = n_embd*n_mem;
 
-    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2u*MB);
+    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2_MiB);
 
     struct ggml_init_params params;
     params.mem_size   = cache.buf.size;
@@ -455,7 +453,7 @@ bool mpt_eval(
     const int n_head  = hparams.n_head;
     const int n_vocab = hparams.n_vocab;
 
-    const size_t init_buf_size = 1024u*MB;
+    const size_t init_buf_size = 1024_MiB;
     if (!model.buf.addr || model.buf.size < init_buf_size)
         model.buf.resize(init_buf_size);
 

--- a/gpt4all-backend/replit.cpp
+++ b/gpt4all-backend/replit.cpp
@@ -47,7 +47,6 @@ using piece_map_t = std::unordered_map<std::string, piece_t>;
 namespace {
 const char *modelType_ = "Replit";
 
-const size_t MB = 1024*1024;
 const std::string ws_symbol = "\342\226\201";
 }
 
@@ -251,7 +250,7 @@ static bool kv_cache_init(
 
     const int64_t n_mem      = (int64_t)n_layer*n_ctx;
     const int64_t n_elements = n_embd*n_mem;
-    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2u*MB);
+    cache.buf.resize(2u*n_elements*ggml_type_size(wtype) + 2_MiB);
     struct ggml_init_params params;
     params.mem_size   = cache.buf.size;
     params.mem_buffer = cache.buf.addr;

--- a/gpt4all-backend/utils.h
+++ b/gpt4all-backend/utils.h
@@ -9,6 +9,13 @@
 #include <thread>
 
 //
+// General purpose inline functions
+//
+constexpr inline unsigned long long operator ""_MiB(unsigned long long bytes) {
+    return bytes*1024*1024;
+}
+
+//
 // CLI argument parsing
 //
 


### PR DESCRIPTION
This cleans up the code a very tiny bit by removing the `MB` variable from each implementation and instead having an `operator ""_MiB` in `utils.h`.