### PR TITLE
Support loading files if 'ggml' is found anywhere in the name not jus…

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -399,8 +399,16 @@ QList<QString> Chat::modelList() const
 
     {
         QDir dir(exePath);
-        dir.setNameFilters(QStringList() << "ggml-*.bin");
-        QStringList fileNames = dir.entryList();
+        QStringList allFiles = dir.entryList(QDir::Files);
+
+        // All files that end with .bin and have 'ggml' somewhere in the name
+        QStringList fileNames;
+        for(const QString& filename : allFiles) {
+            if (filename.endsWith(".bin") && filename.contains("ggml")) {
+                fileNames.append(filename);
+            }
+        }
+
         for (const QString& f : fileNames) {
             QString filePath = exePath + f;
             QFileInfo info(filePath);
@@ -416,8 +424,15 @@ QList<QString> Chat::modelList() const
 
     if (localPath != exePath) {
         QDir dir(localPath);
-        dir.setNameFilters(QStringList() << "ggml-*.bin" << "chatgpt-*.txt");
-        QStringList fileNames = dir.entryList();
+        QStringList allFiles = dir.entryList(QDir::Files);
+        QStringList fileNames;
+        for(const QString& filename : allFiles) {
+            if ((filename.endsWith(".bin") && filename.contains("ggml"))
+                || (filename.endsWith(".txt") && filename.startsWith("chatgpt-"))) {
+                fileNames.append(filename);
+            }
+        }
+
         for (const QString &f : fileNames) {
             QString filePath = localPath + f;
             QFileInfo info(filePath);

--- a/gpt4all-chat/download.h
+++ b/gpt4all-chat/download.h
@@ -23,6 +23,7 @@ struct ModelInfo {
     Q_PROPERTY(bool isChatGPT MEMBER isChatGPT)
     Q_PROPERTY(QString description MEMBER description)
     Q_PROPERTY(QString requiresVersion MEMBER requiresVersion)
+    Q_PROPERTY(QString deprecatedVersion MEMBER deprecatedVersion)
     Q_PROPERTY(QString url MEMBER url)
 
 public:
@@ -38,6 +39,7 @@ public:
     bool isChatGPT = false;
     QString description;
     QString requiresVersion;
+    QString deprecatedVersion;
     QString url;
 };
 Q_DECLARE_METATYPE(ModelInfo)

--- a/gpt4all-chat/server.cpp
+++ b/gpt4all-chat/server.cpp
@@ -13,10 +13,10 @@
 static inline QString modelToName(const ModelInfo &info)
 {
     QString modelName = info.filename;
-    Q_ASSERT(modelName.startsWith("ggml-"));
-    modelName = modelName.remove(0, 5);
-    Q_ASSERT(modelName.endsWith(".bin"));
-    modelName.chop(4);
+    if (modelName.startsWith("ggml-"))
+        modelName = modelName.remove(0, 5);
+    if (modelName.endsWith(".bin"))
+        modelName.chop(4);
     return modelName;
 }
 


### PR DESCRIPTION
…t at

the beginning and add deprecated flag to models.json so older versions will show a model, but later versions don't. This will allow us to transition away from models < ggmlv2 and still allow older installs of gpt4all to work.

