### PR TITLE
Allow Cross-Origin Resource Sharing (CORS)

### DIFF
--- a/gpt4all-chat/server.cpp
+++ b/gpt4all-chat/server.cpp
@@ -141,6 +141,11 @@ void Server::start()
         }
     );
 
+    m_server->afterRequest([] (QHttpServerResponse &&resp) {
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+        return std::move(resp);
+    });
+
     connect(this, &Server::requestServerNewPromptResponsePair, m_chat,
         &Chat::serverNewPromptResponsePair, Qt::BlockingQueuedConnection);
 }


### PR DESCRIPTION
## Describe your changes
Add the `Access-Control-Allow-Origin` header to the chat GUI's web API to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).

## Issue ticket number and link
It was mentioned in <https://github.com/nomic-ai/gpt4all/issues/941> _"Introduce a button in the UI Settings to enable CORS for the Web Server Mode of GPT4ALL UI."_

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Using the following example HTML document:
```html
<html><head><title>CORS test</title></head>
<body>
    <script type="text/javascript">
        function foo() {
            console.log("start click handler");
            function xhrHandler(e) {
                console.log("handled.")
                console.log(e);
            };
            var xhr = new XMLHttpRequest();
            xhr.addEventListener("load", xhrHandler);
            xhr.open("GET", "http://localhost:4891/v1/models");
            xhr.send();
            console.log("end click handler");
        }
    </script>
    <input type="button" onclick="foo()" value="click me!"></input>
</body>
</html>
```

#### Without the CORS header:
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/4c77b30d-b394-4f80-b240-63c48d817f5e)

#### With the CORS header:
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/e38a5370-4009-485a-9136-2c9347e362bc)


### Steps to Reproduce
- Use the example HTML
- Start the web server in the chat GUI
- The request is not allowed without a CORS header

## Notes
C++ is not my strength, but I followed the example in the docs and it seemed straight-forward.
Please have a close look, though.

The linked issue requests a button to add to the UI. I simply enabled the header for everyone. I could make the PR more sophisticated, if necessary/desired.