### PR TITLE
set n_threads in GPT4All python bindings

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -22,7 +22,7 @@ class GPT4All():
         model: Pointer to underlying C model.
     """
 
-    def __init__(self, model_name: str, model_path: str = None, model_type: str = None, allow_download = True):
+    def __init__(self, model_name: str, model_path: str = None, model_type: str = None, allow_download = True, n_threads = 4):
         """
         Constructor
 
@@ -33,12 +33,15 @@ class GPT4All():
             model_type: Model architecture. This argument currently does not have any functionality and is just used as
                 descriptive identifier for user. Default is None.
             allow_download: Allow API to download models from gpt4all.io. Default is True. 
+            n_threads: number of CPU threads used by GPT4All
         """
         self.model_type = model_type
         self.model = pyllmodel.LLModel()
         # Retrieve model and download if allowed
         model_dest = self.retrieve_model(model_name, model_path=model_path, allow_download=allow_download)
         self.model.load_model(model_dest)
+        # Set n_threads
+        self.model.set_thread_count(n_threads)
 
     @staticmethod
     def list_models():

--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -22,7 +22,7 @@ class GPT4All():
         model: Pointer to underlying C model.
     """
 
-    def __init__(self, model_name: str, model_path: str = None, model_type: str = None, allow_download = True, n_threads = 4):
+    def __init__(self, model_name: str, model_path: str = None, model_type: str = None, allow_download = True, n_threads = None):
         """
         Constructor
 
@@ -33,7 +33,7 @@ class GPT4All():
             model_type: Model architecture. This argument currently does not have any functionality and is just used as
                 descriptive identifier for user. Default is None.
             allow_download: Allow API to download models from gpt4all.io. Default is True. 
-            n_threads: number of CPU threads used by GPT4All
+            n_threads: number of CPU threads used by GPT4All. Default is None, than the number of threads are determined automatically.
         """
         self.model_type = model_type
         self.model = pyllmodel.LLModel()
@@ -41,7 +41,8 @@ class GPT4All():
         model_dest = self.retrieve_model(model_name, model_path=model_path, allow_download=allow_download)
         self.model.load_model(model_dest)
         # Set n_threads
-        self.model.set_thread_count(n_threads)
+        if n_threads != None:
+            self.model.set_thread_count(n_threads)
 
     @staticmethod
     def list_models():


### PR DESCRIPTION
## Describe your changes
Change **python bindings**
Added possibility to set number of cpu threads `n_threads` directly in class GPT4All, when instantiating.

`mpt = gpt4all.GPT4All(model_name = "ggml-mpt-7b-chat",  model_path = "D:/00613/nomic.ai/GPT4all", allow_download=False, n_threads=6)`

It seems to me, that the class GPT4All works as an interface to the python user. So the python user should be able to set the number of threads directly with a method of GPT4All.

## Issue ticket number and link
#1029 Add the possibility to set the number of CPU threads (n_threads) with the python bindings
when instantiating.


## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
![grafik](https://github.com/nomic-ai/gpt4all/assets/55889795/9a5b0fc8-c08c-40f7-8ca3-9d27f1a7e380)

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
