### PR TITLE
falcon: make eval buf bigger

### DIFF
--- a/gpt4all-backend/falcon.cpp
+++ b/gpt4all-backend/falcon.cpp
@@ -464,7 +464,7 @@ bool falcon_model_load(const std::string & fname, falcon_model & model, gpt_voca
 
     fin.close();
 
-    model.eval_buf_size = 256u * 1024 * 1024;
+    model.eval_buf_size = 1536u * 1024 * 1024;
     model.eval_buf = malloc(model.eval_buf_size);
     model.scr0_buf_size = 256u * 1024 * 1024;
     model.scr0_buf = malloc(model.scr0_buf_size);


### PR DESCRIPTION
falcon has a larger than usual number of `ggml_tensor*`s so the `eval` buffer (which is used for all tensors, scratch buffers only contain *data*) needs to be bigger especially for large inputs (large prompt w/ large prompt batch size)

empirically this size avoid crashing up to ~ prompt batch size 128 - it should not need to be this big for smaller 'prompt batch size's but making it dynamically sized would need to be undone later if we wanted to support falcon on the metal backend which does not allow resizing buffers after allocation
