### PR TITLE
bindings/python: fix typo

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -196,7 +196,7 @@ class GPT4All:
             repeat_penalty: Penalize the model for repetition. Higher values result in less repetition.
             repeat_last_n: How far in the models generation history to apply the repeat penalty.
             n_batch: Number of prompt tokens processed in parallel. Larger values decrease latency but increase resource requirements.
-            n_predict: Equivalent to max_tokens, exists for backwards compatability.
+            n_predict: Equivalent to max_tokens, exists for backwards compatibility.
             streaming: If True, this method will instead return a generator that yields tokens as the model generates them.
 
         Returns:


### PR DESCRIPTION
so that codespell doesn't start yelling at everyone again