### PR TITLE
Fix CLI to work with 1.x.y version of the Python bindings

### DIFF
--- a/gpt4all-bindings/cli/app.py
+++ b/gpt4all-bindings/cli/app.py
@@ -4,6 +4,7 @@ The GPT4All CLI is a self-contained script based on the `gpt4all` and `typer` pa
 REPL to communicate with a language model similar to the chat GUI application, but more basic.
 """
 
+import pkg_resources  # should be present as a dependency of gpt4all
 import sys
 import typer
 
@@ -26,7 +27,7 @@ SPECIAL_COMMANDS = {
 }
 
 VersionInfo = namedtuple('VersionInfo', ['major', 'minor', 'micro'])
-VERSION_INFO = VersionInfo(0, 3, 5)
+VERSION_INFO = VersionInfo(1, 0, 1)
 VERSION = '.'.join(map(str, VERSION_INFO))  # convert to string form, like: '1.2.3'
 
 CLI_START_MESSAGE = f"""
@@ -75,6 +76,21 @@ def repl(
 
     print(CLI_START_MESSAGE)
 
+    use_new_loop = False
+    try:
+        version = pkg_resources.Environment()['gpt4all'][0].version
+        version_major = int(version.split('.')[0])
+        if version_major >= 1:
+            use_new_loop = True
+    except:
+        pass  # fall back to old loop
+    if use_new_loop:
+        _new_loop(gpt4all_instance)
+    else:
+        _old_loop(gpt4all_instance)
+
+
+def _old_loop(gpt4all_instance):
     while True:
         message = input(" ⇢  ")
 
@@ -110,6 +126,39 @@ def repl(
         # record assistant's response to messages
         MESSAGES.append(full_response.get("choices")[0].get("message"))
         print() # newline before next prompt
+
+
+def _new_loop(gpt4all_instance):
+    with gpt4all_instance.chat_session():
+        while True:
+            message = input(" ⇢  ")
+
+            # Check if special command and take action
+            if message in SPECIAL_COMMANDS:
+                SPECIAL_COMMANDS[message](MESSAGES)
+                continue
+
+            # if regular message, append to messages
+            MESSAGES.append({"role": "user", "content": message})
+
+            # execute chat completion and ignore the full response since 
+            # we are outputting it incrementally
+            full_response = gpt4all_instance.generate(
+                MESSAGES,
+                # preferential kwargs for chat ux
+                max_tokens=200,
+                temp=0.9,
+                top_k=40,
+                top_p=0.9,
+                repeat_penalty=1.1,
+                repeat_last_n=64,
+                n_batch=9,
+                # required kwargs for cli ux (incremental response)
+                streaming=True,
+            )
+            # record assistant's response to messages
+            MESSAGES.append(full_response.get("choices")[0].get("message"))
+            print() # newline before next prompt
 
 
 @app.command()

--- a/gpt4all-bindings/cli/app.py
+++ b/gpt4all-bindings/cli/app.py
@@ -28,7 +28,7 @@ SPECIAL_COMMANDS = {
 }
 
 VersionInfo = namedtuple('VersionInfo', ['major', 'minor', 'micro'])
-VERSION_INFO = VersionInfo(1, 0, 1)
+VERSION_INFO = VersionInfo(1, 0, 2)
 VERSION = '.'.join(map(str, VERSION_INFO))  # convert to string form, like: '1.2.3'
 
 CLI_START_MESSAGE = f"""


### PR DESCRIPTION
## Describe your changes
- Adapted to Python bindings API changes
- Version selection based on package information
- Does not currently work with `1.0.1` however, as it's not fully implemented:
  ```
  NotImplementedError: Streaming tokens in a chat session is not currently supported.
  ```
  - Does, however, work with `main`.

## Issue ticket number and link
- in the meantime, someone reported it as: #1123 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/24f96ef7-5167-4f02-bb46-bbc15913a57b)
(Commited version doesn't include the message `version 1.0.1, using new loop`)

### Steps to Reproduce
- CLI is currently broken with Python bindings v1.0.0 & v1.0.1; just try to run it
- ~~This PR won't fix that yet, but it should once streaming with chat session is supported.~~ It is and it works.

## Notes
- Alternative ideas to fix it? Maybe I didn't understand the new API completely?
- It's mostly a hack for now in any case. Fixing it is first priority, we can talk about improvements later.