### PR TITLE
Monospace text for codeblocks

### DIFF
--- a/gpt4all-chat/responsetext.cpp
+++ b/gpt4all-chat/responsetext.cpp
@@ -616,7 +616,17 @@ void ResponseText::handleCodeBlocks()
         QTextCursor codeCellCursor = codeCell.firstCursorPosition();
         QTextTable *codeTable = codeCellCursor.insertTable(1, 1, codeBlockTableFormat);
         QTextTableCell code = codeTable->cellAt(0, 0);
+
+        QTextCharFormat codeBlockCharFormat;
+        QFont monospaceFont("Courier");
+        if (monospaceFont.family() != "Courier") {
+            monospaceFont.setFamily("Monospace"); // Fallback if Courier isn't available
+        }
+
         QTextCursor codeCursor = code.firstCursorPosition();
+        codeBlockCharFormat.setFont(monospaceFont); // Update the font for the codeblock
+        codeCursor.setCharFormat(codeBlockCharFormat);
+
         if (!codeLanguage.isEmpty()) {
             codeCursor.block().setUserState(stringToLanguage(codeLanguage));
             for (const QString &line : lines) {


### PR DESCRIPTION
## Describe your changes
Makes it so the codeblock is output in a monospaced font which is suitable for code (for readability)

## Issue ticket number and link
https://github.com/nomic-ai/gpt4all/issues/1026

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
~- If it is a core feature, I have added thorough tests.~ (not a core feature)
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
After:
<img width="629" alt="image" src="https://github.com/nomic-ai/gpt4all/assets/31350541/39d200a3-2f66-4ff6-a4c3-d4a9241767d3">

Before:
![image](https://github.com/nomic-ai/gpt4all/assets/31350541/abdd0acc-b90d-455b-b682-e9e059aa451c)

### Steps to Reproduce
Prompt: `﻿Write a simple hello world in python`

## Notes
Nothing of note