### PR TITLE
Java bindings update with support for gpt4all 2.4.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ CMakeLists.txt.user
 gpt4all-chat/models/*
 build_*
 build-*
+
+# IntelliJ
+.idea/

--- a/gpt4all-bindings/java/.gitignore
+++ b/gpt4all-bindings/java/.gitignore
@@ -1,2 +1,5 @@
 # Make sure native directory never gets commited to git for the project.
 /src/main/resources/native
+
+# IntelliJ project file
+*.iml

--- a/gpt4all-bindings/java/Developer_docs.md
+++ b/gpt4all-bindings/java/Developer_docs.md
@@ -1,0 +1,80 @@
+# Java Bindings Developer documents.
+
+This document is meant to anyone looking to build the Java bindings from source, test a build locally and perform a release.
+
+## Building locally
+
+Maven is the build tool used by the project. Maven version of 3.8 or higher is recommended. Make sure the **mvn** 
+is available on the command path.
+
+The project builds to Java version 11 target so make sure that a JDK at version 11 or newer is installed.
+
+### Setting up location of native shared libraries
+The property **native.libs.location** in pom.xml may need to be set:
+```
+    <properties>
+        ...
+        <native.libs.location>C:\Users\felix\dev\gpt4all_java_bins\release_1_1_3_Jun22_2023</native.libs.location>
+    </properties>
+```
+All the native shared libraries bundled with the Java binding jar will be copied from this location.
+The directory structure is **native/linux**, **native/macos**, **native/windows**. These directories are copied
+into the **src/main/resources** folder during the build process.
+
+For the purposes of local testing, none of these directories have to be present or just one OS type may be present.
+
+If none of the native libraries are present in **native.libs.location** the shared libraries will be searched for
+in location path set by **LLModel.LIBRARY_SEARCH_PATH** static variable in Java source code that is using the bindings.
+
+Alternately you can copy the shared libraries into the **src/resources/native/linux** before 
+you build, but note **src/main/resources/native** is on the .gitignore, so it will not be committed to sources.
+
+### Building
+
+To package the bindings jar run:
+```
+mvn package
+```
+This will build two jars. One has only the Java bindings and the other is a fat jar that will have required dependencies included as well.
+
+To package and install the Java bindings to your local maven repository run:
+```
+mvn install
+```
+
+### Using in a sample application
+
+You can check out a sample project that uses the java bindings here:
+https://github.com/felix-zaslavskiy/gpt4all-java-bindings-sample.git
+
+1. First, update the dependency of java bindings to whatever you have installed in local repository such as **1.1.4-SNAPSHOT**
+2. Second, update **Main.java** and set **baseModelPath** to the correct location of model weight files.
+
+3. To make a runnable jar run:
+```
+mvn package
+```
+
+A fat jar is also created which is easy to run from command line:
+```
+java -jar target/gpt4all-java-bindings-sample-1.0-SNAPSHOT-jar-with-dependencies.jar
+```
+
+### Publish a public release.
+
+For publishing a new version to maven central repository requires password and signing keys which F.Z. currently maintains, so
+he is responsible for making a public release.
+
+The procedure is as follows:
+
+For a snapshot release
+Run:
+```
+mvn deploy -P signing-profile
+```
+
+For a non-snapshot release
+Run:
+```
+mvn clean deploy -P signing-profile,release
+```

--- a/gpt4all-bindings/java/README.md
+++ b/gpt4all-bindings/java/README.md
@@ -118,4 +118,7 @@ If this is the case you can easily download and install the latest x64 Microsoft
    - Add static GPT4ALL_VERSION to signify gpt4all version of the bindings
    - Add PromptIsTooLongException for prompts that are longer than context size.
    - Replit model support to include Metal Mac hardware support.
+3. Version **1.1.4**:
+   - Java bindings is compatible with gpt4all version 2.4.11
+   - Falcon model support included.
    

--- a/gpt4all-bindings/java/pom.xml
+++ b/gpt4all-bindings/java/pom.xml
@@ -6,13 +6,14 @@
 
     <groupId>com.hexadevlabs</groupId>
     <artifactId>gpt4all-java-binding</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <native.libs.location>C:\Users\felix\dev\gpt4all_java_bins\release_1_1_4_July8_2023</native.libs.location>
     </properties>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -117,7 +118,7 @@
                             <outputDirectory>${project.build.directory}/generated-resources</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>C:\Users\felix\dev\gpt4all_java_bins\release_1_1_3_Jun22_2023</directory>
+                                    <directory>${native.libs.location}</directory>
                                 </resource>
                             </resources>
                         </configuration>
@@ -172,11 +173,6 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.hexadevlabs.gpt4allsample.Example4</mainClass>
-                        </manifest>
-                    </archive>
                 </configuration>
                 <executions>
                     <execution>
@@ -189,7 +185,6 @@
                 </executions>
             </plugin>
          </plugins>
-
 
     </build>
 

--- a/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/LLModel.java
+++ b/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/LLModel.java
@@ -117,8 +117,10 @@ public  class LLModel implements AutoCloseable {
 
     /**
      * This may be set before any Model instance classes are instantiated to
-     * set where the model may be found. This may be needed if setting
-     * library search path by standard means is not available.
+     * set where the native shared libraries are to be found.
+     * <p>
+     * This may be needed if setting library search path by standard means is not available
+     * or the libraries loaded from the temp folder bundled with the binding jar is not desirable.
      */
     public static String LIBRARY_SEARCH_PATH;
 
@@ -138,7 +140,7 @@ public  class LLModel implements AutoCloseable {
      * GPT4ALL native libraries. The binding may work for older
      * versions but that is not guaranteed.
      */
-    public static final String GPT4ALL_VERSION = "2.4.8";
+    public static final String GPT4ALL_VERSION = "2.4.11";
 
     protected static LLModelLibrary library;
 

--- a/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/Util.java
+++ b/gpt4all-bindings/java/src/main/java/com/hexadevlabs/gpt4all/Util.java
@@ -83,7 +83,8 @@ public class Util {
                     "llamamodel-mainline-metal",
                     "replit-mainline-default",
                     "replit-mainline-metal",
-                    "ggml-metal.metal"
+                    "ggml-metal.metal",
+                    "falcon-default"
             };
 
             for (String libraryName : libraryNames) {


### PR DESCRIPTION

## Describe your changes
The bindings version changed to 1.1.4
Update Java bindings to be compatible with gpt4all 2.4.11
falcon model support.
Developer docs included for Java bindings with instructions on how to build Java bindings.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

