### PR TITLE
Correctly find models in subdirs of model dir

### DIFF
--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -821,7 +821,7 @@ void ModelList::updateModelsFromDirectory()
                     for (const QString &id : modelsById) {
                         updateData(id, FilenameRole, filename);
                         updateData(id, ChatGPTRole, filename.startsWith("chatgpt-"));
-                        updateData(id, DirpathRole, path);
+                        updateData(id, DirpathRole, info.dir().absolutePath() + "/");
                         updateData(id, FilesizeRole, toFileSize(info.size()));
                     }
                 }


### PR DESCRIPTION
QDirIterator doesn't seem subdir aware, its path() returns
the iterated dir. This was the simplest way I found to get this right.
