### PR TITLE
Fix Windows MSVC arch detection

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -18,7 +18,7 @@
 std::string s_implementations_search_path = ".";
 
 static bool has_at_least_minimal_hardware() {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(_M_X64)
     #ifndef _MSC_VER
         return __builtin_cpu_supports("avx");
     #else
@@ -30,7 +30,7 @@ static bool has_at_least_minimal_hardware() {
 }
 
 static bool requires_avxonly() {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(_M_X64)
     #ifndef _MSC_VER
         return !__builtin_cpu_supports("avx2");
     #else


### PR DESCRIPTION
## Describe your changes
- fix Windows MSVC arch detection in llmodel.cpp
- to fix AVX-only handling

## Issue ticket number and link
there are several now. probably all of these are about the same bug:
- #965
- #1009 
- #1060 
- #1084
- #1097
- #1175 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo


### Steps to Reproduce
Windows MSVC compiler doesn't have `__x86_64__` for x86-64, but instead: `_M_X64`

## Notes
Hope this finally fixes that.  😅