### PR TITLE
Handle edge cases when generating embeddings

### DIFF
--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -168,10 +168,14 @@ void llmodel_prompt(llmodel_model model, const char *prompt,
 
 float *llmodel_embedding(llmodel_model model, const char *text, size_t *embedding_size)
 {
+    if (model == nullptr || text == nullptr || !strlen(text)) {
+        *embedding_size = 0;
+        return nullptr;
+    }
     LLModelWrapper *wrapper = reinterpret_cast<LLModelWrapper*>(model);
     std::vector<float> embeddingVector = wrapper->llModel->embedding(text);
     float *embedding = (float *)malloc(embeddingVector.size() * sizeof(float));
-    if(embedding == nullptr) {
+    if (embedding == nullptr) {
         *embedding_size = 0;
         return nullptr;
     }

--- a/gpt4all-bindings/python/gpt4all/tests/test_gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/tests/test_gpt4all.py
@@ -107,3 +107,9 @@ def test_embedding():
     #for i, value in enumerate(output):
         #print(f'Value at index {i}: {value}')
     assert len(output) == 384
+
+def test_empty_embedding():
+    text = ''
+    embedder = Embed4All()
+    output = embedder.embed(text)
+    assert len(output) == 0


### PR DESCRIPTION
## Describe your changes
- Change to `llmodel_embedding()` to behave more gracefully when receiving unexpected input.
- Instead of crashing, receiving `NULL` for the model or text, or getting an empty string returns `NULL`.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
On Windows:
```py
\> py
Python 3.11.3 (tags/v3.11.3:f3909b8, Apr  4 2023, 23:49:59) [MSC v.1934 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from gpt4all import GPT4All, Embed4All
>>> text = ''
>>> embedder = Embed4All()
Found model file at  <...>\\ggml-all-MiniLM-L6-v2-f16.bin
>>> output = embedder.embed(text)
>>> print(output)
[]
```

### Steps to Reproduce
Try the above without the patch. It doesn't like it very much.

## Notes
I could do some error codes and messages instead, if desired (might be more appropriate if `model == nullptr`.