### PR TITLE
llmodel_model_create prints error on failure

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -120,8 +120,10 @@ const LLModel::Implementation* LLModel::Implementation::implementation(std::ifst
 
 LLModel *LLModel::Implementation::construct(const std::string &modelPath, std::string buildVariant) {
 
-    if (!has_at_least_minimal_hardware())
+    if (!has_at_least_minimal_hardware()) {
+        fprintf(stderr, "has_at_least_minimal_hardware check failed\n");
         return nullptr;
+    }
 
     // Read magic
     std::ifstream f(modelPath, std::ios::binary);
@@ -159,7 +161,10 @@ LLModel *LLModel::Implementation::construct(const std::string &modelPath, std::s
             }
         }
         impl = implementation(f, buildVariant);
-        if (!impl) return nullptr;
+        if (!impl) {
+            fprintf(stderr, "failed: implementation not found\n");
+            return nullptr;
+        }
     }
     f.close();
 

--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -17,9 +17,11 @@ thread_local static std::string last_error_message;
 
 
 llmodel_model llmodel_model_create(const char *model_path) {
-    auto fres = llmodel_model_create2(model_path, "auto", nullptr);
+    llmodel_error err = { 0 };
+    auto fres = llmodel_model_create2(model_path, "auto", &err);
     if (!fres) {
         fprintf(stderr, "Invalid model file\n");
+        fprintf(stderr, "Error code: %d Error: %s message: %s\n", err.code, strerror(err.code), err.message);
     }
     return fres;
 }


### PR DESCRIPTION
`llmodel_model_create` calls `llmodel_model_create2` and ignore it's error reporting. So any error spit by `llmodel_model_create2` would not be reflected to the user. this fix it. there are plenty of users online who wonder why their setup doesn't open models. now they will know exactly why =)