### PR TITLE
Fix models not getting downloaded in Python bindings

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -168,10 +168,6 @@ class GPT4All:
 
         # If model file does not exist, download
         elif allow_download:
-            # Make sure valid model filename before attempting download
-
-            if "url" not in config:
-                raise ValueError(f"Model filename not in model list: {model_filename}")
             url = config.pop("url", None)
 
             config["path"] = GPT4All.download_model(

--- a/gpt4all-bindings/python/gpt4all/tests/test_gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/tests/test_gpt4all.py
@@ -1,5 +1,6 @@
 import sys
 from io import StringIO
+from pathlib import Path
 
 from gpt4all import GPT4All, Embed4All
 import time
@@ -114,3 +115,15 @@ def test_empty_embedding():
     embedder = Embed4All()
     with pytest.raises(ValueError):
         output = embedder.embed(text)
+
+def test_download_model(tmp_path: Path):
+    import gpt4all.gpt4all
+    old_default_dir = gpt4all.gpt4all.DEFAULT_MODEL_DIRECTORY
+    gpt4all.gpt4all.DEFAULT_MODEL_DIRECTORY = tmp_path  # temporary pytest directory to ensure a download happens
+    try:
+        model = GPT4All(model_name='ggml-all-MiniLM-L6-v2-f16.bin')
+        model_path = tmp_path / model.config['filename']
+        assert model_path.absolute() == Path(model.config['path']).absolute()
+        assert model_path.stat().st_size == int(model.config['filesize'])
+    finally:
+        gpt4all.gpt4all.DEFAULT_MODEL_DIRECTORY = old_default_dir


### PR DESCRIPTION
## Describe your changes
- Custom callbacks & session improvements PR (v1.0.6) had one too many checks.
- Remove the problematic config['url'] check.
- Add a crude test, which will download the embeddings model into a temporary directory and verify.
- Fixes #1261.

## Issue ticket number and link
- #1261 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Run test, it works:
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/68951958-44de-4aac-bed1-4496daaa8893)

### Steps to Reproduce
Currently, the following won't download a model, if not already present. For example try the following; but it's not limited to the embeddings model. Any model not hosted on an external site (i.e. with a full URL in `models.json`) is affected:
```py
from gpt4all import Embed4All
e4a = Embed4All()
```

## Notes
For now, there's a simple test which actually downloads the model into a temporary directory. I hope I can refine that at some point.
