### PR TITLE
Fixes batched GPU inference

### DIFF
--- a/gpt4all-api/gpt4all_api/app/api_v1/routes/completions.py
+++ b/gpt4all-api/gpt4all_api/app/api_v1/routes/completions.py
@@ -117,14 +117,13 @@ async def completions(request: CompletionRequest):
         params["num_return_sequences"] = request.n
 
         header = {"Content-Type": "application/json"}
-        payload = {"parameters": params}
         if isinstance(request.prompt, list):
             tasks = []
             for prompt in request.prompt:
+                payload = {"parameters": params}
                 payload["inputs"] = prompt
                 task = gpu_infer(payload, header)
                 tasks.append(task)
-
             results = await asyncio.gather(*tasks)
 
             choices = []
@@ -147,6 +146,7 @@ async def completions(request: CompletionRequest):
             )
 
         else:
+            payload = {"parameters": params}
             # If streaming, we need to return a StreamingResponse
             payload["inputs"] = request.prompt
 


### PR DESCRIPTION
## Describe your changes
Previously, we passed around the same dict object and only updated the `inputs` key/value in the dictionary. But since the call is async, the call would only run with the same dictionary object across all elements in the batch. This creates a new dictionary object for each call to the async function. 
## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
