### PR TITLE
Allow you to monitor GPT4All-API with Sentry

### DIFF
--- a/gpt4all-api/gpt4all_api/app/api_v1/settings.py
+++ b/gpt4all-api/gpt4all_api/app/api_v1/settings.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     gpt4all_path: str = '/models'
     inference_mode: str = "cpu"
     hf_inference_server_host: str = "http://gpt4all_gpu:80/generate"
+    sentry_dns: str = None
 
     temp: float = 0.18
     top_p: float = 1.0

--- a/gpt4all-api/gpt4all_api/app/main.py
+++ b/gpt4all-api/gpt4all_api/app/main.py
@@ -47,10 +47,22 @@ async def startup():
         logger.info(f"GPT4All API is ready to infer from {settings.model} on CPU.")
 
 
+
 @app.on_event("shutdown")
 async def shutdown():
     logger.info("Shutting down API")
 
+
+if settings.sentry_dns is not None:
+    import sentry_sdk
+
+    def traces_sampler(sampling_context):
+        if 'health' in sampling_context['transaction_context']['name']:
+            return False
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dns, traces_sample_rate=0.1, traces_sampler=traces_sampler, send_default_pii=False
+    )
 
 # This is needed to get logs to show up in the app
 if "gunicorn" in os.environ.get("SERVER_SOFTWARE", ""):


### PR DESCRIPTION
Adds an optional flag into the gpt4all-api start-up that allows you to monitor the API with sentry.