### PR TITLE
Fix Windows unable to load models on older Windows builds

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -11,8 +11,7 @@
 #include <cstdlib>
 #include <sstream>
 #ifdef _MSC_VER
-#include <windows.h>
-#include <processthreadsapi.h>
+#include <intrin.h>
 #endif
 
 std::string s_implementations_search_path = ".";
@@ -22,7 +21,9 @@ static bool has_at_least_minimal_hardware() {
     #ifndef _MSC_VER
         return __builtin_cpu_supports("avx");
     #else
-        return IsProcessorFeaturePresent(PF_AVX_INSTRUCTIONS_AVAILABLE);
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 1);
+        return cpuInfo[2] & (1 << 28);
     #endif
 #else
     return true; // Don't know how to handle non-x86_64
@@ -34,7 +35,9 @@ static bool requires_avxonly() {
     #ifndef _MSC_VER
         return !__builtin_cpu_supports("avx2");
     #else
-        return !IsProcessorFeaturePresent(PF_AVX2_INSTRUCTIONS_AVAILABLE);
+        int cpuInfo[4];
+        __cpuidex(cpuInfo, 7, 0);
+        return !(cpuInfo[1] & (1 << 5));
     #endif
 #else
     return false; // Don't know how to handle non-x86_64


### PR DESCRIPTION
## Describe your changes
- Replace high-level `IsProcessorFeaturePresent`
- Reintroduce low-level compiler intrinsics implementation

## Issue ticket number and link
- #1288

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
_None_

### Steps to Reproduce
- Try to run GPT4All on an outdated Windows version. It'll fail with the catch-all model load error despite having AVX/AVX2.

- See the comments in linked issue (from [here](https://github.com/nomic-ai/gpt4all/issues/1288#issuecomment-1667241169)); the [test script](https://gist.github.com/cosmic-snow/6c93526ea4c8b5428def2bf63d6be390) returns `False` for all AVX checks even if present.

## Notes
It's quite unfortunate how this all came to be. The previous low-level code was changed in an attempt to fix the Windows AVX-only problem, but that ultimately turned out be caused by an incomplete pre-processor macro. That in turn masked this problem.

The (potential) fix here reintroduces the old low-level code. But because of the bug, this was never really tested to work as it should, although I think several people have looked at it, compared with the documentation, and found no obvious fault: <https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex>

It does work on my machine, but I don't have an AVX-only system to test, nor do I have an older build of Windows 10.