### PR TITLE
Update gpt4all API's docker container to be faster and smaller

### DIFF
--- a/gpt4all-api/README.md
+++ b/gpt4all-api/README.md
@@ -8,9 +8,15 @@ The following tutorial assumes that you have checked out this repo and cd'd into
 
 ### Starting the app
 
-First change your working directory to `gpt4all/gpt4all-api`.
+First, decide what LLM model you'll use in your API and be sure to download or setup your `~/models` folder with the LLM models you'd like to use with the API, like this:
+```bash
+export MODEL_BIN=llama-2-7b-chat.ggmlv3.q8_0.bin
+export MODEL_DIR=$HOME/models
+mkdir -p $MODEL_DIR
+wget https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGML/resolve/main/${MODEL_BIN} -P $MODEL_DIR
+```
 
-Now you can build the FastAPI docker image. You only have to do this on initial build or when you add new dependencies to the requirements.txt file:
+Then, change your working directory to `gpt4all/gpt4all-api` and build the FastAPI docker image. You only have to do this on initial build or when you add new dependencies to the requirements.txt file:
 ```bash
 DOCKER_BUILDKIT=1 docker build -t gpt4all_api --progress plain -f gpt4all_api/Dockerfile.buildkit .
 ```

--- a/gpt4all-api/docker-compose.yaml
+++ b/gpt4all-api/docker-compose.yaml
@@ -9,11 +9,12 @@ services:
       - "4891:4891"
     environment:
       - APP_ENVIRONMENT=dev
-      - WEB_CONCURRENCY=2
+      - WEB_CONCURRENCY=4
       - LOGLEVEL=debug
       - PORT=4891
-      - model=ggml-mpt-7b-chat.bin
+      - model=llama-2-7b-chat.ggmlv3.q8_0.bin
       - inference_mode=cpu
     volumes:
       - './gpt4all_api/app:/app'
+      - '${HOME}/models:/models'
     command: ["/start-reload.sh"]

--- a/gpt4all-api/gpt4all_api/Dockerfile.buildkit
+++ b/gpt4all-api/gpt4all_api/Dockerfile.buildkit
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.0.0-experimental
 FROM tiangolo/uvicorn-gunicorn:python3.11
 
-ARG MODEL_BIN=ggml-mpt-7b-chat.bin
+#ARG MODEL_BIN=ggml-mpt-7b-chat.bin
+ARG MODEL_BIN=llama-2-7b-chat.ggmlv3.q4_0.bin
 
 # Put first so anytime this file changes other cached layers are invalidated.
 COPY gpt4all_api/requirements.txt /requirements.txt
@@ -15,9 +16,14 @@ RUN --mount=type=ssh pip install -r /requirements.txt && \
 # Finally, copy app and client.
 COPY gpt4all_api/app /app
 
-RUN mkdir -p /models
+
+# STOP THIS. ALL MODELS SHOULD BE MOUNTED, NOT COPIED. SHIT.
+# RUN mkdir -p /models
 
 # Include the following line to bake a model into the image and not have to download it on API start.
-RUN wget -q --show-progress=off https://gpt4all.io/models/${MODEL_BIN} -P /models \
-  && md5sum /models/${MODEL_BIN}
+#RUN wget -q --show-progress=off https://gpt4all.io/models/${MODEL_BIN} -P /models \
+#  && md5sum /models/${MODEL_BIN}
+
+# ADD llama-2-7b-chat.ggmlv3.q8_0.bin /models/.
+# RUN md5sum /models/llama-2-7b-chat.ggmlv3.q8_0.bin
 

--- a/gpt4all-api/gpt4all_api/Dockerfile.buildkit
+++ b/gpt4all-api/gpt4all_api/Dockerfile.buildkit
@@ -1,9 +1,6 @@
 # syntax=docker/dockerfile:1.0.0-experimental
 FROM tiangolo/uvicorn-gunicorn:python3.11
 
-#ARG MODEL_BIN=ggml-mpt-7b-chat.bin
-ARG MODEL_BIN=llama-2-7b-chat.ggmlv3.q4_0.bin
-
 # Put first so anytime this file changes other cached layers are invalidated.
 COPY gpt4all_api/requirements.txt /requirements.txt
 
@@ -15,15 +12,3 @@ RUN --mount=type=ssh pip install -r /requirements.txt && \
 
 # Finally, copy app and client.
 COPY gpt4all_api/app /app
-
-
-# STOP THIS. ALL MODELS SHOULD BE MOUNTED, NOT COPIED. SHIT.
-# RUN mkdir -p /models
-
-# Include the following line to bake a model into the image and not have to download it on API start.
-#RUN wget -q --show-progress=off https://gpt4all.io/models/${MODEL_BIN} -P /models \
-#  && md5sum /models/${MODEL_BIN}
-
-# ADD llama-2-7b-chat.ggmlv3.q8_0.bin /models/.
-# RUN md5sum /models/llama-2-7b-chat.ggmlv3.q8_0.bin
-

--- a/gpt4all-api/gpt4all_api/app/main.py
+++ b/gpt4all-api/gpt4all_api/app/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import multiprocessing
 
 import docs
 from api_v1 import events
@@ -37,7 +38,7 @@ async def startup():
         logger.info(f"Downloading/fetching model: {os.path.join(settings.gpt4all_path, settings.model)}")
         from gpt4all import GPT4All
 
-        model = GPT4All(model_name=settings.model, model_path=settings.gpt4all_path)
+        model = GPT4All(n_threads=multiprocessing.cpu_count(), model_name=settings.model, model_path=settings.gpt4all_path)
 
         logger.info(f"GPT4All API is ready to infer from {settings.model} on CPU.")
 


### PR DESCRIPTION
* Stop putting models inside images because they're huge and not part of the code
* Mount an external volume inside the image for models
* Use the system-defined number of virtual threads when starting the API service
* Update README for new models folder setup + mounting
* Update default LLM to latest, `llama-2-7b-chat.ggmlv3.q8_0.bin`

## Describe your changes
In the spirit of docker, let's please not put LLM's inside the image.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added thorough documentation for my code.