### PR TITLE
Update llama.cpp.cmake

### DIFF
--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -155,7 +155,7 @@ endif()
 
 if (LLAMA_KOMPUTE)
     find_package(Vulkan COMPONENTS glslc REQUIRED)
-    find_program(glslc_executable NAMES glslc HINTS Vulkan::glslc)
+    find_program(glslc_executable glslc.exe PATHS "$ENV{VULKAN_SDK}Bin" NO_DEFAULT_PATH)
     if (NOT glslc_executable)
         message(FATAL_ERROR "glslc not found")
     endif()


### PR DESCRIPTION
Fix for executable `glscl not found` on win11 when running build_win-mingw.ps1 in gpt4all-binding/csharp directory

Full error message:
`-- Found Vulkan: C:/VulkanSDK/1.3.261.1/Lib/vulkan-1.lib (found version "1.3.261") found components: glslc glslangValidator                                                   CMake Error at llama.cpp.cmake:160 (message):                                                                                                                                   glslc not found                                                                                                                                                             
Call Stack (most recent call first):                                                                                                                                            
CMakeLists.txt:46 (include)`
on win11, from PowerShell run with admin rights
