### PR TITLE
Add flatpak manifest

### DIFF
--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+    <id>io.gpt4all.gpt4all</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>MIT License</project_license>
+    <name>GPT4ALL</name>
+    <summary>Open-source assistant-style large language models that run locally on your CPU</summary>
+    <description>
+        <p>Cross platform Qt based GUI for GPT4All versions with GPT-J as the base model.</p>
+        <ul>
+            <li>Fast CPU and GPU based inference using ggml for GPT-J and LLaMA based models</li>
+            <li>The UI is made to look and feel like you've come to expect from a chatty gpt</li>
+            <li>Check for updates so you can always stay fresh with latest models</li>
+            <li>Easy to install with precompiled binaries available for all three major desktop platforms</li>
+            <li>Multi-model - Ability to load more than one model and switch between them</li>
+            <li>Supports both llama.cpp and gptj.cpp style models</li>
+            <li>Model downloader in GUI featuring many popular open source models</li>
+            <li>Settings dialog to change temp, top_p, top_k, threads, etc</li>
+            <li>Copy your conversation to clipboard</li>
+        </ul>
+    </description>
+    <screenshots>
+        <screenshot type="default">
+            <caption>Main Window</caption>
+            <image>https://user-images.githubusercontent.com/50458173/231464085-da9edff6-a593-410e-8f38-7513f75c8aab.png</image>
+        </screenshot>
+    </screenshots>
+    <url type="homepage">https://gpt4all.io</url>
+    <url type="bugtracker">https://github.com/nomic-ai/gpt4all/issues</url>
+    <url type="vcs-browser">https://github.com/nomic-ai/gpt4all</url>
+    <releases>
+      <release version="2.4.17" date="2023-09-14">
+        <description>
+          <p>
+            <ul>
+              <li>Add Vulkan GPU backend which allows inference on AMD, Intel and NVIDIA GPUs</li>
+              <li>Add ability to switch font sizes</li>
+              <li>Various bug fixes</li>
+            </ul>
+          </p>
+        </description>
+        </release>              
+    </releases>
+    <launchable type="desktop-id">io.gpt4all.gpt4all.desktop</launchable>
+    <content_rating type="oars-1.0">
+        <content_attribute id="language-profanity">mild</content_attribute>
+        <content_attribute id="language-humor">moderate</content_attribute>
+        <content_attribute id="language-discrimination">mild</content_attribute>
+    </content_rating>
+</component>

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
@@ -4,11 +4,11 @@
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>MIT License</project_license>
     <name>GPT4ALL</name>
-    <summary>Open-source assistant-style large language models that run locally on your CPU</summary>
+    <summary>Open-source assistant-style large language models that run locally on your CPU and GPU</summary>
     <description>
-        <p>Cross platform Qt based GUI for GPT4All versions with GPT-J as the base model.</p>
+        <p>Cross platform Qt based GUI for GPT4All</p>
         <ul>
-            <li>Fast CPU and GPU based inference using ggml for GPT-J and LLaMA based models</li>
+            <li>Fast CPU and GPU based inference using ggml for open source LLM's</li>
             <li>The UI is made to look and feel like you've come to expect from a chatty gpt</li>
             <li>Check for updates so you can always stay fresh with latest models</li>
             <li>Easy to install with precompiled binaries available for all three major desktop platforms</li>

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.appdata.xml
@@ -29,13 +29,11 @@
     <url type="bugtracker">https://github.com/nomic-ai/gpt4all/issues</url>
     <url type="vcs-browser">https://github.com/nomic-ai/gpt4all</url>
     <releases>
-      <release version="2.4.17" date="2023-09-14">
+      <release version="2.4.19" date="2023-09-16">
         <description>
           <p>
             <ul>
-              <li>Add Vulkan GPU backend which allows inference on AMD, Intel and NVIDIA GPUs</li>
-              <li>Add ability to switch font sizes</li>
-              <li>Various bug fixes</li>
+              <li>A bugfix for crashes on systems that have a corrupted Vulkan driver or a corrupted version of the Vulkan shared library</li>
             </ul>
           </p>
         </description>

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.desktop
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=GPT4ALL
+GenericName=Open-source assistant-style large language models that run locally on your CPU
+Comment=Run any GPT4All model natively on your home desktop with the auto-updating desktop chat client. See GPT4All Website for a full list of open-source models you can run with this powerful desktop application.
+Exec=chat
+Icon=io.gpt4all.gpt4all
+Type=Application
+Categories=Utility;Office;
+Keywords=GPT,Chat;AI

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
@@ -1,0 +1,169 @@
+app-id: io.gpt4all.gpt4all
+default-branch: stable
+runtime: org.kde.Platform
+runtime-version: '6.5'
+x-gl-version: &gl-version '1.4'
+x-gl-versions: &gl-versions 23.08;23.08-extra;1.4
+x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
+sdk: org.kde.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node14
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --share=network
+  - --device=dri
+  - --env=LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/app/lib/x86_64-linux-gnu/
+  - --filesystem=xdg-documents:ro
+command: chat
+cleanup:
+  - /include
+
+modules:
+  - name: qthttpserver
+    buildsystem: cmake
+    sources:
+      - type: archive
+        url: https://invent.kde.org/qt/qt/qthttpserver/-/archive/6.5.2/qthttpserver-6.5.2.zip
+        sha256: 9fb7b14774b4ed62fe9097e13fa593af06ba75537783fc62f34652bada26abee
+
+  - name: python-html5lib
+    buildsystem: simple
+    build-commands:
+    - 'pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "html5lib" --no-build-isolation'
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+        sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
+        x-checker-data:
+            type: pypi
+            name: webencodings
+            packagetype: bdist_wheel
+      - type: file
+        url: https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl
+        sha256: 0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d
+        x-checker-data:
+            type: pypi
+            name: html5lib
+            packagetype: bdist_wheel
+    cleanup:
+    - '*'
+
+  - name: qtwebengine
+    buildsystem: cmake
+    builddir: true
+    config-opts:
+      - -DQT_FEATURE_qtwebengine_build=OFF
+      - -DQT_FEATURE_qtpdf_build=ON
+    build-options:
+      append-path: /usr/lib/sdk/node14/bin
+      env:
+        - npm_config_nodedir=/usr/lib/sdk/node14
+    sources:
+      - type: git
+        url: https://invent.kde.org/qt/qt/qtwebengine.git
+        tag: v6.5.2
+        commit: ac887518e8243828333e923b5a1e61a007babde5
+  
+  - name: vulkan-headers
+    buildsystem: cmake
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/KhronosGroup/Vulkan-Headers.git
+        tag: v1.3.224
+        commit: 2b55157592bf4c639b76cc16d64acaef565cc4b5
+
+  - name: fmt
+    buildsystem: cmake
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/fmtlib/fmt.git
+        tag: 10.1.1
+        commit: f5e54359df4c26b6230fc61d38aa294581393084
+
+  - name: vulkan-tools
+    buildsystem: cmake
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/KhronosGroup/Vulkan-Tools.git
+        tag: v1.3.224
+        commit: 497f232680b046db34ba9e9da065e6303a125851
+
+    
+
+    modules:
+      - name: shaderc
+        buildsystem: cmake-ninja
+        builddir: true
+        config-opts:
+          - -DSHADERC_SKIP_COPYRIGHT_CHECK=ON
+          - -DSHADERC_SKIP_EXAMPLES=ON
+          - -DSHADERC_SKIP_TESTS=ON
+          - -DSPIRV_SKIP_EXECUTABLES=ON
+          - -DENABLE_GLSLANG_BINARIES=OFF
+        cleanup:
+          - /bin
+          - /include
+          - /lib/cmake
+          - /lib/pkgconfig
+        sources:
+          - type: git
+            url: https://github.com/google/shaderc.git
+            tag: v2023.4
+            commit: 45b735dfddefe26a99b77e5a74e30d860713ac64
+#           x-checker-data:
+#             type: git
+#             tag-pattern: ^v(\d{4}\.\d{1,2})$
+          - type: git
+            url: https://github.com/KhronosGroup/SPIRV-Tools.git
+            tag: v2023.2
+            commit: 44d72a9b36702f093dd20815561a56778b2d181e
+            dest: third_party/spirv-tools
+            x-checker-data:
+              type: git
+              tag-pattern: ^v(\d{4}\.\d{1})$
+          - type: git
+            url: https://github.com/KhronosGroup/SPIRV-Headers.git
+            tag: sdk-1.3.250.1
+            commit: 268a061764ee69f09a477a695bf6a11ffe311b8d
+            dest: third_party/spirv-headers
+            x-checker-data:
+              type: git
+              tag-pattern: ^sdk-([\d.]+)$
+          - type: git
+            url: https://github.com/KhronosGroup/glslang.git
+            tag: 12.2.0
+            commit: d1517d64cfca91f573af1bf7341dc3a5113349c0
+            dest: third_party/glslang
+          
+          
+
+
+  - name: gpt4all
+    buildsystem: simple
+    build-commands:
+      - git submodule update --init --recursive
+      - mkdir build
+      - cmake  -S ./gpt4all-chat -B build -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF -DKOMPUTE_OPT_USE_BUILT_IN_FMT=OFF -DCMAKE_INSTALL_PREFIX=/app
+      - cmake --build build --config Release -- -j
+      - cmake --install build --prefix "/app"
+      - install -Dm644 logo.svg /app/share/icons/hicolor/scalable/apps/io.gpt4all.gpt4all.svg
+      - install -Dm644 io.gpt4all.gpt4all.desktop /app/share/applications/io.gpt4all.gpt4all.desktop
+      - install -Dm644 io.gpt4all.gpt4all.appdata.xml  /app/share/appdata/io.gpt4all.gpt4all.appdata.xml
+    sources:
+      - type: git
+        url: https://github.com/nomic-ai/gpt4all
+        tag: v2.4.17
+        commit: aa33419c6ece48ea0c3c655044089841f4f02530
+      - type: file
+        url: https://raw.githubusercontent.com/nomic-ai/gpt4all/main/gpt4all-chat/icons/logo.svg
+        sha256: 4c4e8476d0e2020585b69c6e2fc9e7d0cb12cbb36aa7b83c3a2e48ed4a9a424c
+      - type: file
+        path: io.gpt4all.gpt4all.desktop
+      - type: file
+        path: io.gpt4all.gpt4all.appdata.xml
+

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
@@ -2,9 +2,6 @@ app-id: io.gpt4all.gpt4all
 default-branch: stable
 runtime: org.kde.Platform
 runtime-version: '6.5'
-x-gl-version: &gl-version '1.4'
-x-gl-versions: &gl-versions 23.08;23.08-extra;1.4
-x-gl-merge-dirs: &gl-merge-dirs vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node14

--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.yml
@@ -154,8 +154,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nomic-ai/gpt4all
-        tag: v2.4.17
-        commit: aa33419c6ece48ea0c3c655044089841f4f02530
+        tag: v2.4.19
+        commit: 84905aa28171545542fc653dbeca501ae5af383e
       - type: file
         url: https://raw.githubusercontent.com/nomic-ai/gpt4all/main/gpt4all-chat/icons/logo.svg
         sha256: 4c4e8476d0e2020585b69c6e2fc9e7d0cb12cbb36aa7b83c3a2e48ed4a9a424c


### PR DESCRIPTION
## Describe your changes
Add flatpak manifest for building flatpaks on Linux

Refer: #698 

# TODOs:
- [x] Create flatpak manifests
- [ ] Add circleci tests
- [ ] submit to flathub

Testers and reviews welcome! You will need  org.kde.Sdk 6.5 and org.freedesktop.Sdk.Extension.node14 for it to build. Please do install it before running flatpak-builder.
