### PR TITLE
backend: allow disabling debug messages

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -237,7 +237,7 @@ jobs:
             cd gpt4all-backend
             mkdir build
             cd build
-            cmake ..
+            cmake .. -DGPT4ALL_QUIET=ON -DLLAMA_QUIET=ON
             cmake --build . --parallel
       - run:
           name: Build wheel
@@ -268,7 +268,7 @@ jobs:
             cd gpt4all-backend
             mkdir build
             cd build
-            cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+            cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DGPT4ALL_QUIET=ON -DLLAMA_QUIET=ON
             cmake --build . --parallel
       - run:
           name: Build wheel
@@ -312,7 +312,7 @@ jobs:
             mkdir build
             cd build
             $env:Path += ";C:\VulkanSDK\1.3.261.1\bin"
-            cmake -G "MinGW Makefiles" .. -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF
+            cmake -G "MinGW Makefiles" .. -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF -DGPT4ALL_QUIET=ON -DLLAMA_QUIET=ON
             cmake --build . --parallel
       - run:
           name: Build wheel

--- a/gpt4all-backend/CMakeLists.txt
+++ b/gpt4all-backend/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+option(GPT4ALL_QUIET "Disable debugging output" ON)
+
+if(GPT4ALL_QUIET)
+  add_compile_definitions(GPT4ALL_QUIET)
+endif()
+
 if(APPLE)
   option(BUILD_UNIVERSAL "Build a Universal binary on macOS" ON)
   if(BUILD_UNIVERSAL)

--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -74,6 +74,7 @@ option(LLAMA_SANITIZE_UNDEFINED     "llama: enable undefined sanitizer"         
 # 3rd party libs
 option(LLAMA_ACCELERATE             "llama: enable Accelerate framework"                    ON)
 option(LLAMA_OPENBLAS               "llama: use OpenBLAS"                                   OFF)
+option(LLAMA_QUIET                  "llama: disable debugging output"                       OFF)
 #option(LLAMA_CUBLAS                 "llama: use cuBLAS"                                     OFF)
 #option(LLAMA_CLBLAST                "llama: use CLBlast"                                    OFF)
 #option(LLAMA_METAL                  "llama: use Metal"                                      OFF)
@@ -90,6 +91,10 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED true)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+
+if (LLAMA_QUIET)
+  add_compile_definitions(LLAMA_QUIET)
+endif()
 
 if (NOT MSVC)
     if (LLAMA_SANITIZE_THREAD)

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -153,7 +153,9 @@ bool LLamaModel::loadModel(const std::string &modelPath)
     d_ptr->params.n_parts  = params.n_parts;
 #endif
 #ifdef GGML_USE_METAL
+    #ifndef GPT4ALL_QUIET
     std::cerr << "llama.cpp: using Metal" << std::endl;
+    #endif
     // metal always runs the whole model if n_gpu_layers is not 0, at least
     // currently
     d_ptr->params.n_gpu_layers = 1;

--- a/gpt4all-backend/llmodel_shared.cpp
+++ b/gpt4all-backend/llmodel_shared.cpp
@@ -16,7 +16,9 @@ void LLModel::recalculateContext(PromptContext &promptCtx, std::function<bool(bo
         std::vector<int32_t> batch(promptCtx.tokens.begin() + i, promptCtx.tokens.begin() + batch_end);
         assert(promptCtx.n_past + int32_t(batch.size()) <= promptCtx.n_ctx);
         if (!evalTokens(promptCtx, batch)) {
+            #ifndef GPT4ALL_QUIET
             std::cerr << "LLModel ERROR: Failed to process prompt\n";
+            #endif
             goto stop_generating;
         }
         promptCtx.n_past += batch.size();
@@ -37,14 +39,18 @@ void LLModel::prompt(const std::string &prompt,
                      PromptContext &promptCtx)
 {
     if (!isModelLoaded()) {
+        #ifndef GPT4ALL_QUIET
         std::cerr << implementation().modelType() << " ERROR: prompt won't work with an unloaded model!\n";
+        #endif
         return;
     }
 
     if (!supportsCompletion()) {
         std::string errorMessage = "ERROR: this model does not support text completion or chat!\n";
         responseCallback(-1, errorMessage);
+        #ifndef GPT4ALL_QUIET
         std::cerr << implementation().modelType() << errorMessage;
+        #endif
         return;
     }
 
@@ -56,8 +62,10 @@ void LLModel::prompt(const std::string &prompt,
 
     if ((int) embd_inp.size() > promptCtx.n_ctx - 4) {
         responseCallback(-1, "ERROR: The prompt size exceeds the context window size and cannot be processed.");
+        #ifndef GPT4ALL_QUIET
         std::cerr << implementation().modelType() << " ERROR: The prompt is " << embd_inp.size() <<
             " tokens and the context window is " << promptCtx.n_ctx << "!\n";
+        #endif
         return;
     }
 
@@ -75,7 +83,9 @@ void LLModel::prompt(const std::string &prompt,
         if (promptCtx.n_past + int32_t(batch.size()) > promptCtx.n_ctx) {
             const int32_t erasePoint = promptCtx.n_ctx * promptCtx.contextErase;
             // Erase the first percentage of context from the tokens...
+            #ifndef GPT4ALL_QUIET
             std::cerr << implementation().modelType() << ": reached the end of the context window so resizing\n";
+            #endif
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
             recalculateContext(promptCtx, recalculateCallback);
@@ -83,7 +93,9 @@ void LLModel::prompt(const std::string &prompt,
         }
 
         if (!evalTokens(promptCtx, batch)) {
+            #ifndef GPT4ALL_QUIET
             std::cerr << implementation().modelType() << " ERROR: Failed to process prompt\n";
+            #endif
             return;
         }
 
@@ -114,7 +126,9 @@ void LLModel::prompt(const std::string &prompt,
         if (promptCtx.n_past + 1 > promptCtx.n_ctx) {
             const int32_t erasePoint = promptCtx.n_ctx * promptCtx.contextErase;
             // Erase the first percentage of context from the tokens...
+            #ifndef GPT4ALL_QUIET
             std::cerr << implementation().modelType() << ": reached the end of the context window so resizing\n";
+            #endif
             promptCtx.tokens.erase(promptCtx.tokens.begin(), promptCtx.tokens.begin() + erasePoint);
             promptCtx.n_past = promptCtx.tokens.size();
             recalculateContext(promptCtx, recalculateCallback);
@@ -122,7 +136,9 @@ void LLModel::prompt(const std::string &prompt,
         }
 
         if (!evalTokens(promptCtx, { id })) {
+            #ifndef GPT4ALL_QUIET
             std::cerr << implementation().modelType() << " ERROR: Failed to predict next token\n";
+            #endif
             return;
         }
 

--- a/gpt4all-backend/mpt.cpp
+++ b/gpt4all-backend/mpt.cpp
@@ -771,7 +771,9 @@ bool MPT::loadModel(const std::string &modelPath) {
 
     // load the model
     if (!mpt_model_load(modelPath, fin, *d_ptr->model, d_ptr->vocab, nullptr)) {
+        #ifndef GPT4ALL_QUIET
         std::cerr << "MPT ERROR: failed to load model from " <<  modelPath;
+        #endif
         return false;
     }
 

--- a/gpt4all-backend/starcoder.cpp
+++ b/gpt4all-backend/starcoder.cpp
@@ -888,7 +888,9 @@ bool Starcoder::loadModel(const std::string &modelPath)
 
     // load the model
     if (!starcoder_model_load(modelPath, *d_ptr->model, d_ptr->vocab, nullptr)) {
+        #ifndef GPT4ALL_QUIET
         std::cerr << "STARCODER ERROR: failed to load model from " <<  modelPath;
+        #endif
         return false;
     }
 


### PR DESCRIPTION
Allows disabling (most) logging in the backend - unless it is enabled by another option explicitly requesting it, or is fatal - and turns this option on for the Python binding builds in CircleCI

Mostly ifdefs around logging statements, except in `llama.cpp` (the file) (see submodule change and PR https://github.com/nomic-ai/llama.cpp/pull/6 to update master) where I instead ifdef away `fprintf` to avoid introducing more merge conflicts than absolutely necessary.

This notably does not prevent the 

```
objc[66083]: Class GGMLMetalClass is implemented in both /Users/aaron/proj/gpt4all/gpt4all-bindings/python/gpt4all/llmodel_DO_NOT_MODIFY/build/libreplit-mainline-metal.dylib (0x110744210) and /Users/aaron/proj/gpt4all/gpt4all-bindings/python/gpt4all/llmodel_DO_NOT_MODIFY/build/libllamamodel-mainline-metal.dylib (0x111e6c210). One of the two will be used. Which one is undefined.
```

message that occurs on MacOS - this comes from the Objective-C runtime and is printed because more than one library that is statically linked against llama.cpp has a `GGMLMetalClass` defined in it. This is difficult to prevent because Obj-C classes are not namespaced and cannot be hidden like other symbols in statically linked libraries, and we currently load multiple model backend libraries that may link this code into the same app simultaneously.

This is at least *harmless*, as the class [contains no code](https://github.com/ggerganov/llama.cpp/blob/8781013ef654270cbead3e0011e33a6d690fb168/ggml-metal.m#L118-L121) and is only used to leverage Objective-C functionality on MacOS to [find the library path](https://github.com/ggerganov/llama.cpp/blob/8781013ef654270cbead3e0011e33a6d690fb168/ggml-metal.m#L158-L159) - all of our backend files live in the same directory, so it does not matter which implementation is actually used here. In order to *prevent* this message from being output we would need to either prevent multiple backend libraries from being resident at once (which would mean making them able to be *unloaded* and *reloaded* safely, likely not currently the case), *OR* somehow generate different classnames for each library that links llama.cpp (a change not likely to be upstreamable as its only needed accommodate loading multiple distinct instances of the llama.cpp library into the same application)
