### PR TITLE
chatllm: do not write uninitialized data to stream

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -742,7 +742,7 @@ bool ChatLLM::serialize(QDataStream &stream, int version)
     stream << generatedName();
     stream << m_promptResponseTokens;
     if (version <= 3) {
-        int responseLogits;
+        int responseLogits = 0;
         stream << responseLogits;
     }
     stream << m_ctx.n_past;


### PR DESCRIPTION
I saw this while building with Visual Studio. It seems like a good idea to initialize responseLogits before serializing it, even if its value isn't used anywhere.