### PR TITLE
issue template: remove "Related Components" section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,21 +27,6 @@ body:
         - label: "The official example notebooks/scripts"
         - label: "My own modified scripts"
 
-  - type: checkboxes
-    id: related-components
-    attributes:
-      label: Related Components
-      description: "Select the components related to the issue (if applicable):"
-      options:
-        - label: "backend"
-        - label: "bindings"
-        - label: "python-bindings"
-        - label: "chat-ui"
-        - label: "models"
-        - label: "circleci"
-        - label: "docker"
-        - label: "api"
-
   - type: textarea
     id: reproduction
     validations:


### PR DESCRIPTION
This section is often not used correctly (left blank or wrong boxes checked), and it is redundant since maintainers can select the relevant labels anyway, which can be seen at a glance and used to filter issues.