### PR TITLE
llmodel: print an error if the CPU does not support AVX

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -121,9 +121,10 @@ const LLModel::Implementation* LLModel::Implementation::implementation(const cha
 }
 
 LLModel *LLModel::Implementation::construct(const std::string &modelPath, std::string buildVariant) {
-
-    if (!has_at_least_minimal_hardware())
+    if (!has_at_least_minimal_hardware()) {
+        std::cerr << "LLModel ERROR: CPU does not support AVX\n";
         return nullptr;
+    }
 
     // Get correct implementation
     const Implementation* impl = nullptr;


### PR DESCRIPTION
This makes it clearer to users of the bindings when they are trying to run them on an unsupported CPU:
```
Found model file at ./orca-mini-3b.q4_0.gguf
LLModel ERROR: CPU does not support AVX
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/gpt4all/gpt4all.py", line 96, in __init__
    self.model.load_model(self.config["path"])
  File "/usr/local/lib/python3.11/site-packages/gpt4all/pyllmodel.py", line 266, in load_model
    raise ValueError(f"Unable to instantiate model: code={err.code}, {err.message.decode()}")
ValueError: Unable to instantiate model: code=45, Model format not supported (no matching implementation found)
```
(The ERROR line is the new one.)