### PR TITLE
CI: increase minimum macOS version of Python bindings to 10.15

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -444,7 +444,7 @@ jobs:
           name: Build wheel
           command: |
             cd gpt4all-bindings/python
-            python setup.py bdist_wheel --plat-name=macosx_10_9_universal2
+            python setup.py bdist_wheel --plat-name=macosx_10_15_universal2
       - persist_to_workspace:
           root: gpt4all-bindings/python/dist
           paths:


### PR DESCRIPTION
I tried to install from pip on OS X 10.13 High Sierra and got "load command 0x80000034 is unknown" while trying to load a .dylib. This corresponds to the LC_DYLD_CHAINED_FIXUPS command, which is only available as of OS X 10.15 (see [10.14 SDK](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.14.sdk/usr/include/mach-o/loader.h#L313), [10.15 SDK](https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.15.sdk/usr/include/mach-o/loader.h#L324)).

related to #70 (although that issue mainly refers to the chat client)