### PR TITLE
kompute: fix library loading issues with kp_logger

### DIFF
--- a/gpt4all-backend/llama.cpp.cmake
+++ b/gpt4all-backend/llama.cpp.cmake
@@ -222,6 +222,7 @@ if (LLAMA_KOMPUTE)
 
     if (EXISTS "${LLAMA_DIR}/kompute/CMakeLists.txt")
         message(STATUS "Kompute found")
+        set(KOMPUTE_OPT_LOG_LEVEL Error CACHE STRING "Kompute log level")
         add_subdirectory(${LLAMA_DIR}/kompute)
 
         # Compile our shaders


### PR DESCRIPTION
Follow-up to https://github.com/nomic-ai/llama.cpp/pull/8.

Fixes this error from the python bindings:
```
OSError: libkp_logger.so: cannot open shared object file: No such file or directory
```