### PR TITLE
python: connection resume and MSVC support

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -233,7 +233,7 @@ class GPT4All:
             except Exception:
                 if os.path.exists(download_path):
                     if verbose:
-                        print("Cleaning up the interrupted download...")
+                        print("Cleaning up the interrupted download...", file=sys.stderr)
                     os.remove(download_path)
                 raise
 
@@ -245,7 +245,7 @@ class GPT4All:
         time.sleep(2)
 
         if verbose:
-            print("Model downloaded at: ", download_path)
+            print("Model downloaded at:", download_path, file=sys.stderr)
         return download_path
 
     def generate(


### PR DESCRIPTION
The smaller fixes:
- print verbose messages to stderr instead of stdout
- support finding llmodel.dll for MSVC builds, which is not called libllmodel.dll

The larger change here is that we will now attempt to resume interrupted downloads. @apage43 and I have both run into flaky connections with the server the models are hosted on, and this should improve the situation.

Tested by using psutil to suspend/resume the process, causing the sever to close the connection due to a timeout. It is now able to resume where it left off, and the sha256sum checks out:
```
>>> x = GPT4All('orca-mini-3b-gguf2-q4_0.gguf')
 13%|███████████████▊                                                                                                           | 254M/1.98G [12:10<1:12:32, 397kiB/s]
Download interrupted, resuming from byte position 257949696
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.98G/1.98G [13:01<00:00, 2.53MiB/s]
>>>
```