### PR TITLE
llamamodel: re-enable error messages by default

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -36,16 +36,16 @@ namespace {
 const char *modelType_ = "LLaMA";
 }
 
-static void llama_log_callback(enum ggml_log_level level, const char *text, void *userdata) {
-    (void)userdata;
-    if (level <= GGML_LOG_LEVEL_ERROR) {
-        fputs(text, stderr);
-    }
-}
-
 static bool llama_verbose() {
     const char* var = getenv("GPT4ALL_VERBOSE_LLAMACPP");
     return var && *var;
+}
+
+static void llama_log_callback(enum ggml_log_level level, const char *text, void *userdata) {
+    (void)userdata;
+    if (llama_verbose() || level <= GGML_LOG_LEVEL_ERROR) {
+        fputs(text, stderr);
+    }
 }
 
 struct gpt_params {
@@ -404,9 +404,7 @@ DLL_EXPORT bool magic_match(const char * fname) {
 }
 
 DLL_EXPORT LLModel *construct() {
-    if (!llama_verbose()) {
-        llama_log_set(llama_log_callback, nullptr);
-    }
+    llama_log_set(llama_log_callback, nullptr);
     return new LLamaModel;
 }
 }

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -36,10 +36,11 @@ namespace {
 const char *modelType_ = "LLaMA";
 }
 
-static void null_log_callback(enum ggml_log_level level, const char* text, void* userdata) {
-    (void)level;
-    (void)text;
+static void llama_log_callback(enum ggml_log_level level, const char *text, void *userdata) {
     (void)userdata;
+    if (level <= GGML_LOG_LEVEL_ERROR) {
+        fputs(text, stderr);
+    }
 }
 
 static bool llama_verbose() {
@@ -404,7 +405,7 @@ DLL_EXPORT bool magic_match(const char * fname) {
 
 DLL_EXPORT LLModel *construct() {
     if (!llama_verbose()) {
-        llama_log_set(null_log_callback, nullptr);
+        llama_log_set(llama_log_callback, nullptr);
     }
     return new LLamaModel;
 }

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -61,7 +61,7 @@ copy_prebuilt_C_lib(SRC_CLIB_DIRECtORY,
 
 setup(
     name=package_name,
-    version="2.0.0rc1",
+    version="2.0.0rc2",
     description="Python bindings for GPT4All",
     author="Nomic and the Open Source Community",
     author_email="support@nomic.ai",


### PR DESCRIPTION
This will be important once #1515 is merged:
```
>>> from gpt4all import GPT4All
>>> x = GPT4All('mpt-7b.Q4_0.oldbpe.nodup.nomerges.gguf', model_path='.', allow_download=False)
error loading model: cannot find tokenizer merges in model file

llama_load_model_from_file: failed to load model
LLAMA ERROR: failed to load model from ./mpt-7b.Q4_0.oldbpe.nodup.nomerges.gguf
>>>
```

Without this change, only the LLAMA ERROR line would be printed by default.