### PR TITLE
backend: support GGUFv3

### DIFF
--- a/gpt4all-backend/bert.cpp
+++ b/gpt4all-backend/bert.cpp
@@ -884,7 +884,7 @@ DLL_EXPORT bool magic_match(const char * fname) {
     if (!ctx_gguf)
         return false;
 
-    bool isValid = gguf_get_version(ctx_gguf) <= 2;
+    bool isValid = gguf_get_version(ctx_gguf) <= 3;
     isValid = isValid && get_arch_name(ctx_gguf) == "bert";
 
     gguf_free(ctx_gguf);

--- a/gpt4all-backend/gptj.cpp
+++ b/gpt4all-backend/gptj.cpp
@@ -806,7 +806,7 @@ DLL_EXPORT bool magic_match(const char * fname) {
     if (!ctx_gguf)
         return false;
 
-    bool isValid = gguf_get_version(ctx_gguf) <= 2;
+    bool isValid = gguf_get_version(ctx_gguf) <= 3;
     isValid = isValid && get_arch_name(ctx_gguf) == "gptj";
 
     gguf_free(ctx_gguf);

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -395,7 +395,7 @@ DLL_EXPORT bool magic_match(const char * fname) {
     if (!ctx_gguf)
         return false;
 
-    bool isValid = gguf_get_version(ctx_gguf) <= 2;
+    bool isValid = gguf_get_version(ctx_gguf) <= 3;
     auto arch = get_arch_name(ctx_gguf);
     isValid = isValid && (arch == "llama" || arch == "starcoder" || arch == "falcon" || arch == "mpt");
 


### PR DESCRIPTION
I don't think GGUFv3 is actually a different format on little-endian CPUs, but because of the version bump we have to update the version numbers accordingly.

I cherry-picked the [GGUFv3 PR](https://github.com/ggerganov/llama.cpp/pull/3552) into the llama.cpp submodule anyway, so we will have to merge [this branch](https://github.com/nomic-ai/llama.cpp/tree/ggufv3) into our llama.cpp fork as well.