### PR TITLE
build_and_run: clarify which additional Qt libs are needed

### DIFF
--- a/gpt4all-chat/build_and_run.md
+++ b/gpt4all-chat/build_and_run.md
@@ -47,7 +47,9 @@ Under this release, select the following additional components:
 - Qt Quick 3D
 - Qt 5 Compatibility Module
 - Qt Shader Tools
-- Additional Libraries (clicking the checkbox to the left of this item enables all of them)
+- Additional Libraries:
+  - Qt HTTP Server
+  - Qt PDF
 - Qt Debug information Files
 - Qt Quick Timeline
 


### PR DESCRIPTION
Only the Qt HTTP Server and Qt PDF libraries (and their implied dependencies) are needed, as far as I know. This could save the user a significant amount of disk space.