### PR TITLE
Add new model type to use custom OpenAI api compatible servers

### DIFF
--- a/gpt4all-chat/chatgpt.cpp
+++ b/gpt4all-chat/chatgpt.cpp
@@ -154,7 +154,7 @@ void ChatGPTWorker::request(const QString &apiKey,
 {
     m_ctx = promptCtx;
 
-    QUrl openaiUrl("https://api.openai.com/v1/chat/completions");
+    QUrl openaiUrl(m_chat->APIBase() + "/chat/completions");
     const QString authorization = QString("Bearer %1").arg(apiKey).trimmed();
     QNetworkRequest request(openaiUrl);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");

--- a/gpt4all-chat/chatgpt.h
+++ b/gpt4all-chat/chatgpt.h
@@ -63,8 +63,11 @@ public:
     void setThreadCount(int32_t n_threads) override;
     int32_t threadCount() const override;
 
+    const QString& APIBase() const { return m_apiBase; }
+
     void setModelName(const QString &modelName) { m_modelName = modelName; }
     void setAPIKey(const QString &apiKey) { m_apiKey = apiKey; }
+    void setAPIBase(const QString &apiBase) { m_apiBase = apiBase; }
 
     QList<QString> context() const { return m_context; }
     void setContext(const QList<QString> &context) { m_context = context; }
@@ -91,6 +94,7 @@ private:
     std::function<bool(int32_t, const std::string&)> m_responseCallback;
     QString m_modelName;
     QString m_apiKey;
+    QString m_apiBase;
     QList<QString> m_context;
 };
 

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -784,9 +784,7 @@ bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
         case GPTJ_: stream << GPTJ_INTERNAL_STATE_VERSION; break;
         case LLAMA_: stream << LLAMA_INTERNAL_STATE_VERSION; break;
         case BERT_: stream << BERT_INTERNAL_STATE_VERSION; break;
-#ifndef DEBUG
         default: Q_UNREACHABLE();
-#endif
         }
     }
     stream << response();

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -239,25 +239,24 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                 QFile file(filePath);
                 file.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text);
                 QTextStream stream(&file);
-                QStringList char_gpt_params = stream.readAll().split('\n');
-                if (!char_gpt_params.size()) {
+                QStringList chatGPTParams = stream.readAll().split('\n');
+                if (chatGPTParams.isEmpty()) {
 
                     emit modelLoadingError(QString("Could not load model due to invalid settings for %1").arg(modelInfo.filename()));
-                }
-                else {
-                    apiKey = char_gpt_params[0];
-                    if (char_gpt_params.size() >= 2) {
-                        apiBase = char_gpt_params[1];
+                } else {
+                    apiKey = chatGPTParams[0];
+                    if (chatGPTParams.size() >= 2) {
+                        apiBase = chatGPTParams[1];
                     }
-                    if (char_gpt_params.size() >= 3) {
-                        chatGPTModel = char_gpt_params[2];
+                    if (chatGPTParams.size() >= 3) {
+i                       chatGPTModel = chatGPTParams[2];
                     }
                 }
                 file.close();
             }
             m_llModelType = LLModelType::CHATGPT_;
             ChatGPT *model = new ChatGPT();
-            model->setModelName(chatGPTModel.size() ? chatGPTModel : (fileInfo.completeBaseName().remove(0, 8))); // remove the chatgpt- prefix
+            model->setModelName(chatGPTModel.size() ? chatGPTModel : fileInfo.completeBaseName().remove(0, 8)); // remove the chatgpt- prefix
             model->setAPIKey(apiKey);
             model->setAPIBase(apiBase.size() ? apiBase : "https://api.openai.com/v1/");
             m_llModelInfo.model = model;

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -249,7 +249,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                         apiBase = chatGPTParams[1];
                     }
                     if (chatGPTParams.size() >= 3) {
-i                       chatGPTModel = chatGPTParams[2];
+                       chatGPTModel = chatGPTParams[2];
                     }
                 }
                 file.close();

--- a/gpt4all-chat/download.cpp
+++ b/gpt4all-chat/download.cpp
@@ -172,10 +172,10 @@ void Download::cancelDownload(const QString &modelFile)
     }
 }
 
-void Download::installModel(const QString &modelFile, const QString &apiKey)
+void Download::installModel(const QString &modelFile, const QString &apiBase, const QString &apiKey, const QString &modelName)
 {
-    Q_ASSERT(!apiKey.isEmpty());
-    if (apiKey.isEmpty())
+    Q_ASSERT(!(apiKey.isEmpty() && apiBase.isEmpty()));
+    if (apiKey.isEmpty() && apiBase.isEmpty())
         return;
 
     Network::globalInstance()->sendInstallModel(modelFile);
@@ -183,7 +183,10 @@ void Download::installModel(const QString &modelFile, const QString &apiKey)
     QFile file(filePath);
     if (file.open(QIODeviceBase::WriteOnly | QIODeviceBase::Text)) {
         QTextStream stream(&file);
-        stream << apiKey;
+        stream << apiKey + "\n" + apiBase;
+        if (modelName.size()) {
+            stream << "\n" + modelName;
+        }
         file.close();
     }
 }

--- a/gpt4all-chat/download.h
+++ b/gpt4all-chat/download.h
@@ -52,7 +52,7 @@ public:
     bool hasNewerRelease() const;
     Q_INVOKABLE void downloadModel(const QString &modelFile);
     Q_INVOKABLE void cancelDownload(const QString &modelFile);
-    Q_INVOKABLE void installModel(const QString &modelFile, const QString &apiKey);
+    Q_INVOKABLE void installModel(const QString &modelFile, const QString& apiBase, const QString &apiKey, const QString& modelName="");
     Q_INVOKABLE void removeModel(const QString &modelFile);
     Q_INVOKABLE bool isFirstStart() const;
 

--- a/gpt4all-chat/download.h
+++ b/gpt4all-chat/download.h
@@ -52,7 +52,7 @@ public:
     bool hasNewerRelease() const;
     Q_INVOKABLE void downloadModel(const QString &modelFile);
     Q_INVOKABLE void cancelDownload(const QString &modelFile);
-    Q_INVOKABLE void installModel(const QString &modelFile, const QString& apiBase, const QString &apiKey, const QString& modelName="");
+    Q_INVOKABLE void installModel(const QString &modelFile, const QString &apiBase, const QString &apiKey, const QString &modelName = "");
     Q_INVOKABLE void removeModel(const QString &modelFile);
     Q_INVOKABLE bool isFirstStart() const;
 

--- a/gpt4all-chat/main.qml
+++ b/gpt4all-chat/main.qml
@@ -967,7 +967,7 @@ Window {
                 }
 
                 Image {
-                    visible: currentChat.isServer || (currentChat.modelInfo.isChatGPT || currentChat.modelInfo.isOpenAICompatible)
+                    visible: currentChat.isServer || currentChat.modelInfo.isChatGPT || currentChat.modelInfo.isOpenAICompatible
                     anchors.fill: parent
                     sourceSize.width: 1024
                     sourceSize.height: 1024

--- a/gpt4all-chat/main.qml
+++ b/gpt4all-chat/main.qml
@@ -967,7 +967,7 @@ Window {
                 }
 
                 Image {
-                    visible: currentChat.isServer || currentChat.modelInfo.isChatGPT
+                    visible: currentChat.isServer || (currentChat.modelInfo.isChatGPT || currentChat.modelInfo.isOpenAICompatible)
                     anchors.fill: parent
                     sourceSize.width: 1024
                     sourceSize.height: 1024

--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -880,8 +880,9 @@ void ModelList::updateModelsFromDirectory()
 
                     for (const QString &id : modelsById) {
                         updateData(id, FilenameRole, filename);
-                        updateData(id, ChatGPTRole, filename.startsWith("chatgpt-"));
-                        updateData(id, OpenAICompatibleRole, filename.startsWith("chatgpt-custom"));
+                        const bool is_chatgpt_custom = filename.startsWith("chatgpt-custom");
+                        updateData(id, OpenAICompatibleRole, is_chatgpt_custom);
+                        updateData(id, ChatGPTRole, (!is_chatgpt_custom && filename.startsWith("chatgpt-")));
                         updateData(id, DirpathRole, info.dir().absolutePath() + "/");
                         updateData(id, FilesizeRole, toFileSize(info.size()));
                     }

--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -1123,7 +1123,7 @@ void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
             updateData(id, ModelList::SystemPromptRole, obj["systemPrompt"].toString());
     }
 
-    const QString CustomOpenAIDesc = tr("<ul><li>Requires acces to OpenAI compatible server</li>"
+    const QString CustomOpenAIDesc = tr("<ul><li>Requires access to OpenAI compatible server</li>"
                                         "<li>Any OpenAI compatible server that support chat/completions method</li></li></li>"
                                         "<br />"
                                         "<p>For OpenAI, the base path is \"https://api.openai.com/v1/\"</p>"

--- a/gpt4all-chat/modellist.h
+++ b/gpt4all-chat/modellist.h
@@ -17,6 +17,7 @@ struct ModelInfo {
     Q_PROPERTY(bool isDefault MEMBER isDefault)
     Q_PROPERTY(bool disableGUI MEMBER disableGUI)
     Q_PROPERTY(bool isChatGPT MEMBER isChatGPT)
+    Q_PROPERTY(bool isOpenAICompatible MEMBER isOpenAICompatible)
     Q_PROPERTY(QString description MEMBER description)
     Q_PROPERTY(QString requiresVersion MEMBER requiresVersion)
     Q_PROPERTY(QString deprecatedVersion MEMBER deprecatedVersion)
@@ -61,6 +62,7 @@ public:
     bool installed = false;
     bool isDefault = false;
     bool isChatGPT = false;
+    bool isOpenAICompatible = false;
     bool disableGUI = false;
     QString description;
     QString requiresVersion;
@@ -204,6 +206,7 @@ public:
         InstalledRole,
         DefaultRole,
         ChatGPTRole,
+        OpenAICompatibleRole,
         DisableGUIRole,
         DescriptionRole,
         RequiresVersionRole,
@@ -246,6 +249,7 @@ public:
         roles[InstalledRole] = "installed";
         roles[DefaultRole] = "isDefault";
         roles[ChatGPTRole] = "isChatGPT";
+        roles[OpenAICompatibleRole] = "isOpenAICompatible";
         roles[DisableGUIRole] = "disableGUI";
         roles[DescriptionRole] = "description";
         roles[RequiresVersionRole] = "requiresVersion";

--- a/gpt4all-chat/qml/ModelDownloaderDialog.qml
+++ b/gpt4all-chat/qml/ModelDownloaderDialog.qml
@@ -190,8 +190,6 @@ MyDialog {
                                         if (isOpenAICompatible) {
                                             if (openaiBase.text === "")
                                                 openaiBase.showError();
-//                                            else if (openaiModel.text === "")
-//                                                openaiBase.showError();
                                             else
                                                 Download.installModel(filename, openaiBase.text, openaiKey.text, openaiModel.text);
                                         } else if (isChatGPT) {

--- a/gpt4all-chat/qml/ModelDownloaderDialog.qml
+++ b/gpt4all-chat/qml/ModelDownloaderDialog.qml
@@ -187,15 +187,14 @@ MyDialog {
                                         color: installButton.hovered ? theme.backgroundDark : theme.backgroundDarkest
                                     }
                                     onClicked: {
-                                    if (isOpenAICompatible) {
-                                        if (openaiBase.text === "")
-                                            openaiBase.showError();
-//                                        else if (openaiModel.text === "")
-//                                            openaiBase.showError();
-                                        else
-                                            Download.installModel(filename, openaiBase.text, openaiKey.text, openaiModel.text);
-                                        }
-                                        else if (isChatGPT) {
+                                        if (isOpenAICompatible) {
+                                            if (openaiBase.text === "")
+                                                openaiBase.showError();
+//                                            else if (openaiModel.text === "")
+//                                                openaiBase.showError();
+                                            else
+                                                Download.installModel(filename, openaiBase.text, openaiKey.text, openaiModel.text);
+                                        } else if (isChatGPT) {
                                             if (openaiKey.text === "")
                                                 openaiKey.showError();
                                             else

--- a/gpt4all-chat/qml/ModelDownloaderDialog.qml
+++ b/gpt4all-chat/qml/ModelDownloaderDialog.qml
@@ -424,7 +424,7 @@ MyDialog {
                                     Layout.topMargin: 10
                                     Layout.leftMargin: 20
                                     Layout.minimumWidth: 150
-                                    Layout.maximumWidth: textMetrics.width + 25
+                                    Layout.maximumWidth: textMetricsOAIKey.width + 25
                                     Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
                                     color: theme.textColor
                                     background: Rectangle {

--- a/gpt4all-chat/qml/ModelDownloaderDialog.qml
+++ b/gpt4all-chat/qml/ModelDownloaderDialog.qml
@@ -131,7 +131,7 @@ MyDialog {
                                     Layout.minimumWidth: openaiKey.width
                                     Layout.fillWidth: true
                                     Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-                                    visible: !isChatGPT && !installed && !calcHash && downloadError === ""
+                                    visible: !(isChatGPT || isOpenAICompatible) && !installed && !calcHash && downloadError === ""
                                     Accessible.description: qsTr("Stop/restart/start the download")
                                     background: Rectangle {
                                         border.color: downloadButton.down ? theme.backgroundLightest : theme.buttonBorder
@@ -172,7 +172,7 @@ MyDialog {
 
                                 MyButton {
                                     id: installButton
-                                    visible: !installed && isChatGPT
+                                    visible: !installed && (isChatGPT || isOpenAICompatible)
                                     Layout.topMargin: 20
                                     Layout.leftMargin: 20
                                     Layout.minimumWidth: openaiKey.width
@@ -187,10 +187,20 @@ MyDialog {
                                         color: installButton.hovered ? theme.backgroundDark : theme.backgroundDarkest
                                     }
                                     onClicked: {
-                                        if (openaiKey.text === "")
-                                            openaiKey.showError();
+                                    if (isOpenAICompatible) {
+                                        if (openaiBase.text === "")
+                                            openaiBase.showError();
+//                                        else if (openaiModel.text === "")
+//                                            openaiBase.showError();
                                         else
-                                            Download.installModel(filename, openaiKey.text);
+                                            Download.installModel(filename, openaiBase.text, openaiKey.text, openaiModel.text);
+                                        }
+                                        else if (isChatGPT) {
+                                            if (openaiKey.text === "")
+                                                openaiKey.showError();
+                                            else
+                                                Download.installModel(filename, openaiBase.text, openaiKey.text, "");
+                                        }
                                     }
                                     Accessible.role: Accessible.Button
                                     Accessible.name: qsTr("Install")
@@ -343,9 +353,75 @@ MyDialog {
                                 }
 
                                 MyTextField {
+                                    id: openaiBase
+                                    visible: !installed && (isOpenAICompatible) // maybe (isChatGPT || isOpenAICompatible)
+                                    Layout.topMargin: 10
+                                    Layout.leftMargin: 20
+                                    Layout.minimumWidth: openaiKey.width
+                                    Layout.maximumWidth: openaiKey.width
+                                    Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+                                    color: theme.textColor
+                                    background: Rectangle {
+                                        color: theme.backgroundLighter
+                                        radius: 10
+                                    }
+                                    wrapMode: Text.WrapAnywhere
+                                    font.pixelSize: theme.fontSizeLarge
+                                    function showError() {
+                                        openaiBase.placeholderTextColor = theme.textErrorColor
+                                    }
+                                    onTextChanged: {
+                                        openaiBase.placeholderTextColor = theme.backgroundLightest
+                                    }
+                                    placeholderText: isOpenAICompatible ? qsTr("(required) $OPENAI_API_BASE") : qsTr("(optional) $OPENAI_API_BASE")
+                                    placeholderTextColor: theme.backgroundLightest
+                                    Accessible.role: Accessible.EditableText
+                                    Accessible.name: placeholderText
+                                    Accessible.description: qsTr("Base URL to access Open API")
+                                    TextMetrics {
+                                        id: textMetricsOAIBase
+                                        font: openaiBase.font
+                                        text: openaiBase.placeholderText
+                                    }
+                                }
+
+                                MyTextField {
+                                    id: openaiModel
+                                    visible: !installed && (isOpenAICompatible)
+                                    Layout.topMargin: 10
+                                    Layout.leftMargin: 20
+                                    Layout.minimumWidth: openaiKey.width
+                                    Layout.maximumWidth: openaiKey.width
+                                    Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+                                    color: theme.textColor
+                                        background: Rectangle {
+                                        color: theme.backgroundLighter
+                                        radius: 10
+                                    }
+                                    wrapMode: Text.WrapAnywhere
+                                    font.pixelSize: theme.fontSizeLarge
+                                    function showError() {
+                                    openaiModel.placeholderTextColor = theme.textErrorColor
+                                    }
+                                    onTextChanged: {
+                                        openaiModel.placeholderTextColor = theme.backgroundLightest
+                                    }
+                                    placeholderText: qsTr("(optional) Model name")
+                                    placeholderTextColor: theme.backgroundLightest
+                                    Accessible.role: Accessible.EditableText
+                                    Accessible.name: placeholderText
+                                    Accessible.description: qsTr("Remote model name")
+                                    TextMetrics {
+                                        id: textMetricsOAIModel
+                                        font: openaiModel.font
+                                        text: openaiModel.placeholderText
+                                    }
+                                }
+
+                                MyTextField {
                                     id: openaiKey
-                                    visible: !installed && isChatGPT
-                                    Layout.topMargin: 20
+                                    visible: !installed && (isChatGPT || isOpenAICompatible)
+                                    Layout.topMargin: 10
                                     Layout.leftMargin: 20
                                     Layout.minimumWidth: 150
                                     Layout.maximumWidth: textMetrics.width + 25
@@ -362,17 +438,18 @@ MyDialog {
                                     onTextChanged: {
                                         openaiKey.placeholderTextColor = theme.backgroundLightest
                                     }
-                                    placeholderText: qsTr("enter $OPENAI_API_KEY")
+                                    placeholderText: isOpenAICompatible ? qsTr("(optional) $OPENAI_API_KEY") : qsTr("(required) $OPENAI_API_KEY")
                                     font.pixelSize: theme.fontSizeLarge
                                     placeholderTextColor: theme.backgroundLightest
                                     Accessible.role: Accessible.EditableText
                                     Accessible.name: placeholderText
-                                    Accessible.description: qsTr("Whether the file hash is being calculated")
+                                    Accessible.description: qsTr("OpenAI API key")
                                     TextMetrics {
-                                        id: textMetrics
+                                        id: textMetricsOAIKey
                                         font: openaiKey.font
                                         text: openaiKey.placeholderText
                                     }
+
                                 }
                             }
                         }


### PR DESCRIPTION
## Describe your changes
I added a new model type similar to OpenAI, but with the possibility to define the API entry point and the model name in order to allow using custom OpenAI compatible servers like those of vllm or llama.cpp

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.

## Notes
Model settings are stored in chatgpt-custom.txt which contains 3 lines:
1. api key (backward compatiblity)
2. api base url
3. model name

A future release may use QSettings, Json library or any other to store these values in a dict for safety