### PR TITLE
Fixes https://github.com/nomic-ai/gpt4all/issues/1760 LLModel ERROR: …

### DIFF
--- a/gpt4all-backend/dlhandle.h
+++ b/gpt4all-backend/dlhandle.h
@@ -54,6 +54,7 @@ public:
 };
 #else
 #include <string>
+#include <algorithm>
 #include <exception>
 #include <stdexcept>
 #ifndef NOMINMAX
@@ -75,7 +76,9 @@ public:
 
     Dlhandle() : chandle(nullptr) {}
     Dlhandle(const std::string& fpath) {
-        chandle = LoadLibraryExA(fpath.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+        std::string path = fpath;
+        std::replace(path.begin(), path.end(), '/', '\\');
+        chandle = LoadLibraryExA(path.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
         if (!chandle) {
             throw Exception("dlopen(\""+fpath+"\"): Error");
         }

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -104,7 +104,7 @@ const std::vector<LLModel::Implementation> &LLModel::Implementation::implementat
 
                     // Add to list if model implementation
                     try {
-                        Dlhandle dl(p.string());
+                        Dlhandle dl(std::filesystem::absolute(p).string());
                         if (!Implementation::isImplementation(dl)) {
                             continue;
                         }


### PR DESCRIPTION
Fix for "LLModel ERROR: Could not find CPU LLaMA implementation"

Solution provided by @NotArandomGUY


## Describe your changes

Inspired by Microsoft docs for LoadLibraryExA (https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa). When using LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR, the lpFileName parameter must specify a fully qualified path, also it needs to be backslashes (\), not forward slashes (/).

## Issue ticket number and link

Fixes https://github.com/nomic-ai/gpt4all/issues/1760

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.
