### PR TITLE
Maxwell GPU support and crash fix

### DIFF
--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -196,6 +196,7 @@ public:
         m_newChat = nullptr;
         m_serverChat = nullptr;
         m_currentChat = nullptr;
+        for (auto * chat: m_chats) { delete chat; }
         m_chats.clear();
     }
 

--- a/gpt4all-chat/main.cpp
+++ b/gpt4all-chat/main.cpp
@@ -63,9 +63,11 @@ int main(int argc, char *argv[])
     }
 #endif
 
+    int res = app.exec();
+
     // Make sure ChatLLM threads are joined before global destructors run.
     // Otherwise, we can get a heap-use-after-free inside of llama.cpp.
     ChatListModel::globalInstance()->clearChats();
 
-    return app.exec();
+    return res;
 }


### PR DESCRIPTION
Supporting Pascal GPUs is apparently as simple as relaxing the device requirements - no shader modifications necessary.

Also, fix a mistake from #1890 where clearChats is called *before* app.exec() - I obviously meant to call it after, but didn't read the code carefully enough.

Tested working on my Tesla P40 with Falcon and Mini Orca (Small) - getting about 22 tokens per second on the former and 31 tokens per second on the latter.

**edit:** Also working on my GTX 970.