### PR TITLE
More sensible main window sizing

### DIFF
--- a/gpt4all-chat/main.qml
+++ b/gpt4all-chat/main.qml
@@ -14,10 +14,10 @@ import mysettings
 
 Window {
     id: window
-    width: 1920
-    height: 1080
-    minimumWidth: 1280
-    minimumHeight: 720
+    width: 1280
+    height: 980
+    minimumWidth: 500
+    minimumHeight: 500
     visible: true
     title: qsTr("GPT4All v") + Qt.application.version
 


### PR DESCRIPTION
Smaller startup main window size.
Smaller main window minimum size limits.

Trying to make GPT4All work nicer with window tiling tools that typically use 1/3 or 1/4 screen slots.

I didn't go through and check other component sizing as I don't have Qt installed.

As a user, I would be fine expanding the window out further to deal with settings.
But most of the work is going to be done in the chat interface, which should just wrap the text for a narrower window.

Feel free to modify this. I just wanted to throw out a change to make an easy starting point.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
