### PR TITLE
chat: set version to 2.7.0

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -17,8 +17,8 @@ if(APPLE)
 endif()
 
 set(APP_VERSION_MAJOR 2)
-set(APP_VERSION_MINOR 6)
-set(APP_VERSION_PATCH 3)
+set(APP_VERSION_MINOR 7)
+set(APP_VERSION_PATCH 0)
 set(APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}")
 
 # Include the binary directory for the generated header file


### PR DESCRIPTION
Especially because of #1914, I don't want us to stay on the 2.6.x minor version for much longer.