### PR TITLE
bert: fix layer norm epsilon value

### DIFF
--- a/gpt4all-backend/bert.cpp
+++ b/gpt4all-backend/bert.cpp
@@ -343,7 +343,7 @@ void bert_eval(
 
     // embd norm
     {
-        inpL = ggml_norm(ctx0, inpL, 1e-5f);
+        inpL = ggml_norm(ctx0, inpL, 1e-12f);
 
         inpL = ggml_add(ctx0,
                         ggml_mul(ctx0,
@@ -403,7 +403,7 @@ void bert_eval(
 
         // attention norm
         {
-            cur = ggml_norm(ctx0, cur, 1e-5f);
+            cur = ggml_norm(ctx0, cur, 1e-12f);
 
             cur = ggml_add(ctx0,
                            ggml_mul(ctx0,
@@ -429,7 +429,7 @@ void bert_eval(
 
         // output norm
         {
-            cur = ggml_norm(ctx0, cur, 1e-5f);
+            cur = ggml_norm(ctx0, cur, 1e-12f);
 
             cur = ggml_add(ctx0,
                            ggml_mul(ctx0,


### PR DESCRIPTION
ref https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/blob/7dbbc90392e2f80f3d3c277d6e90027e55de9125/config.json#L13

This is a quick-and-dirty fix since this code is going to be replaced anyway. It would be more correct to read layer_norm_eps when we convert to GGUF, and load that hyperparameter from the GGUF at inference time.

The difference between an epsilon of 1e-6 in LLaMA 1 and 1e-5 in LLaMA-2 created a [significant difference](https://github.com/ggerganov/llama.cpp/pull/2384) in perplexity, so they implemented this parameter to ggml_norm and ggml_rms_norm soon after LLaMA-2 came out, and until the switch to GGUF they defaulted to 5e-6, which was a suitable middleground, and allowed the user to customize the parameter at inference time via a command-line option.

The difference between 1e-5 and 1e-12 is certainly more significant... if only we had benchmarks for this code.