### PR TITLE
ci: fix missing Kompute support in python bindings

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -235,10 +235,8 @@ jobs:
           name: Build
           command: |
             export CMAKE_PREFIX_PATH=~/Qt/6.5.1/gcc_64/lib/cmake
-            mkdir build
-            cd build
-            ~/Qt/Tools/CMake/bin/cmake -DCMAKE_BUILD_TYPE=Release -S ../gpt4all-chat -B .
-            ~/Qt/Tools/CMake/bin/cmake --build . --target all
+            ~/Qt/Tools/CMake/bin/cmake -DCMAKE_BUILD_TYPE=Release -S gpt4all-chat -B build
+            ~/Qt/Tools/CMake/bin/cmake --build build --target all
 
   build-gpt4all-chat-windows:
     machine:
@@ -291,17 +289,15 @@ jobs:
             $Env:INCLUDE = "${Env:INCLUDE};C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include"
             $Env:INCLUDE = "${Env:INCLUDE};C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\ATLMFC\include"
             $Env:VULKAN_SDK = "C:\VulkanSDK\1.3.261.1"
-            mkdir build
-            cd build
             & "C:\Qt\Tools\CMake_64\bin\cmake.exe" `
               "-DCMAKE_GENERATOR:STRING=Ninja" `
               "-DCMAKE_BUILD_TYPE=Release" `
               "-DCMAKE_PREFIX_PATH:PATH=C:\Qt\6.5.1\msvc2019_64" `
               "-DCMAKE_MAKE_PROGRAM:FILEPATH=C:\Qt\Tools\Ninja\ninja.exe" `
               "-DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON" `
-              "-S ..\gpt4all-chat" `
-              "-B ."
-            & "C:\Qt\Tools\Ninja\ninja.exe"
+              "-S gpt4all-chat" `
+              "-B build"
+            & "C:\Qt\Tools\Ninja\ninja.exe" -C build
 
   build-gpt4all-chat-macos:
     macos:
@@ -332,17 +328,15 @@ jobs:
       - run:
           name: Build
           command: |
-            mkdir build
-            cd build
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake \
               -DCMAKE_GENERATOR:STRING=Ninja \
               -DBUILD_UNIVERSAL=ON \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH:PATH=~/Qt/6.5.1/macos/lib/cmake/Qt6 \
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
-              -S ../gpt4all-chat \
-              -B .
-            ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target all
+              -S gpt4all-chat \
+              -B build
+            ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build build --target all
   build-ts-docs: 
     docker: 
       - image: cimg/base:stable
@@ -410,10 +404,8 @@ jobs:
             git submodule init
             git submodule update
             cd gpt4all-backend
-            mkdir build
-            cd build
-            cmake ..
-            cmake --build . --parallel
+            cmake -B build
+            cmake --build build --parallel
       - run:
           name: Build wheel
           command: |
@@ -443,10 +435,8 @@ jobs:
             git submodule init
             git submodule update
             cd gpt4all-backend
-            mkdir build
-            cd build
-            cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
-            cmake --build . --parallel
+            cmake -B build -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+            cmake --build build --parallel
       - run:
           name: Build wheel
           command: |
@@ -485,13 +475,11 @@ jobs:
             git submodule init
             git submodule update
             cd gpt4all-backend
-            mkdir build
-            cd build
             $Env:Path += ";C:\ProgramData\mingw64\mingw64\bin"
             $Env:Path += ";C:\VulkanSDK\1.3.261.1\bin"
             $Env:VULKAN_SDK = "C:\VulkanSDK\1.3.261.1"
-            cmake -G "MinGW Makefiles" .. -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF
-            cmake --build . --parallel
+            cmake -G "MinGW Makefiles" -B build -DKOMPUTE_OPT_DISABLE_VULKAN_VERSION_CHECK=ON -DKOMPUTE_OPT_USE_BUILT_IN_VULKAN_HEADER=OFF
+            cmake --build build --parallel
       - run:
           name: Build wheel
           # TODO: As part of this task, we need to move mingw64 binaries into package.

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -401,8 +401,7 @@ jobs:
       - run:
           name: Build C library
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init --recursive
             cd gpt4all-backend
             cmake -B build
             cmake --build build --parallel
@@ -432,8 +431,7 @@ jobs:
       - run:
           name: Build C library
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init  # don't use --recursive because macOS doesn't use Kompute
             cd gpt4all-backend
             cmake -B build -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
             cmake --build build --parallel
@@ -472,8 +470,7 @@ jobs:
       - run:
           name: Build C library
           command: |
-            git submodule init
-            git submodule update
+            git submodule update --init --recursive
             cd gpt4all-backend
             $Env:Path += ";C:\ProgramData\mingw64\mingw64\bin"
             $Env:Path += ";C:\VulkanSDK\1.3.261.1\bin"

--- a/gpt4all-backend/CMakeLists.txt
+++ b/gpt4all-backend/CMakeLists.txt
@@ -39,10 +39,6 @@ else()
     message(STATUS "Interprocedural optimization support detected")
 endif()
 
-if(NOT APPLE)
-  set(LLAMA_KOMPUTE YES)
-endif()
-
 include(llama.cpp.cmake)
 
 set(BUILD_VARIANTS default avxonly)

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -432,6 +432,8 @@ std::vector<LLModel::GPUDevice> LLamaModel::availableGPUDevices(size_t memoryReq
         free(vkDevices);
         return devices;
     }
+#else
+    std::cerr << __func__ << ": built without Kompute\n";
 #endif
 
     return {};

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -61,7 +61,7 @@ copy_prebuilt_C_lib(SRC_CLIB_DIRECTORY,
 
 setup(
     name=package_name,
-    version="2.2.0",
+    version="2.2.1",
     description="Python bindings for GPT4All",
     author="Nomic and the Open Source Community",
     author_email="support@nomic.ai",


### PR DESCRIPTION
The CI built version 2.2.0 of the python bindings without Kompute because it was not using `--recursive` on `git submodule update`, and Kompute is now a submodule of llama.cpp.

To make GPT4All more robust to this problem:
* Fail the build if Kompute is missing instead of warning
  * Allow users to pass `-DLLAMA_KOMPUTE=OFF` to explicitly build without Kompute
* Print a message on stderr if the bindings attempt to enumerate GPU devices without Kompute being built in