### PR TITLE
llamamodel: add gemma model support

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -519,8 +519,8 @@ DLL_EXPORT bool magic_match(const char *fname) {
     bool valid = true;
 
     static const std::vector<const char *> known_arches {
-        "baichuan", "bloom", "codeshell", "falcon", "gpt2", "llama", "mpt", "orion", "persimmon", "phi2", "plamo",
-        "qwen", "qwen2", "refact", "stablelm", "starcoder"
+        "baichuan", "bloom", "codeshell", "falcon", "gemma", "gpt2", "llama", "mpt", "orion", "persimmon", "phi2",
+        "plamo", "qwen", "qwen2", "refact", "stablelm", "starcoder"
     };
 
     if (std::find(known_arches.begin(), known_arches.end(), arch) == known_arches.end()) {

--- a/gpt4all-chat/metadata/models2.json
+++ b/gpt4all-chat/metadata/models2.json
@@ -12,7 +12,7 @@
     "type": "Gemma",
     "description": "<strong>A state-of-the-art open model from Google</strong><br><ul><li>Fast responses</li><li>Chat based model</li><li>Trained by Google</li><li>Licensed for commercial use</li><li>Gemma is provided under and subject to the Gemma Terms of Use found at <a href=\"https://ai.google.dev/gemma/terms\">ai.google.dev/gemma/terms</a></li></ul>",
     "url": "https://gpt4all.io/models/gguf/gemma-7b-it.Q4_0.gguf",
-    "promptTemplate": "<start_of_turn>user\n%1<end_of_turn>\n<start_of_turn>model\n\n",
+    "promptTemplate": "<start_of_turn>user\n%1<end_of_turn>\n<start_of_turn>model\n",
     "systemPrompt": ""
   },
   {

--- a/gpt4all-chat/metadata/models2.json
+++ b/gpt4all-chat/metadata/models2.json
@@ -1,6 +1,22 @@
 [
   {
     "order": "a",
+    "md5sum": "6d1ca6e9533d177361fe2612a2c87474",
+    "name": "Gemma Instruct",
+    "filename": "gemma-7b-it.Q4_0.gguf",
+    "filesize": "4809316512",
+    "requires": "2.5.0",
+    "ramrequired": "8",
+    "parameters": "7 billion",
+    "quant": "q4_0",
+    "type": "Gemma",
+    "description": "<strong>A state-of-the-art open model from Google</strong><br><ul><li>Fast responses</li><li>Chat based model</li><li>Trained by Google</li><li>Licensed for commercial use</li><li>Gemma is provided under and subject to the Gemma Terms of Use found at <a href=\"https://ai.google.dev/gemma/terms\">ai.google.dev/gemma/terms</a></li></ul>",
+    "url": "https://gpt4all.io/models/gguf/gemma-7b-it.Q4_0.gguf",
+    "promptTemplate": "<start_of_turn>user\n%1<end_of_turn>\n<start_of_turn>model\n\n",
+    "systemPrompt": ""
+  },
+  {
+    "order": "b",
     "md5sum": "48de9538c774188eb25a7e9ee024bbd3",
     "name": "Mistral OpenOrca",
     "filename": "mistral-7b-openorca.Q4_0.gguf",
@@ -14,22 +30,6 @@
     "url": "https://gpt4all.io/models/gguf/mistral-7b-openorca.Q4_0.gguf",
     "promptTemplate": "<|im_start|>user\n%1<|im_end|><|im_start|>assistant\n",
     "systemPrompt": "<|im_start|>system\nYou are MistralOrca, a large language model trained by Alignment Lab AI. For multi-step problems, write out your reasoning for each step.\n<|im_end|>"
-  },
-  {
-    "order": "b",
-    "md5sum": "97463be739b50525df56d33b26b00852",
-    "name": "Mistral Instruct",
-    "filename": "mistral-7b-instruct-v0.1.Q4_0.gguf",
-    "filesize": "4108916384",
-    "requires": "2.5.0",
-    "ramrequired": "8",
-    "parameters": "7 billion",
-    "quant": "q4_0",
-    "type": "Mistral",
-    "systemPrompt": " ",
-    "description": "<strong>Best overall fast instruction following model</strong><br><ul><li>Fast responses</li><li>Trained by Mistral AI<li>Uncensored</li><li>Licensed for commercial use</li></ul>",
-    "url": "https://gpt4all.io/models/gguf/mistral-7b-instruct-v0.1.Q4_0.gguf",
-    "promptTemplate": "[INST] %1 [/INST]"
   },
   {
     "order": "c",
@@ -46,6 +46,22 @@
     "description": "<strong>Very fast model with good quality</strong><br><ul><li>Fastest responses</li><li>Instruction based</li><li>Trained by TII<li>Finetuned by Nomic AI<li>Licensed for commercial use</ul>",
     "url": "https://gpt4all.io/models/gguf/gpt4all-falcon-newbpe-q4_0.gguf",
     "promptTemplate": "### Instruction:\n%1\n### Response:\n"
+  },
+  {
+    "order": "d",
+    "md5sum": "97463be739b50525df56d33b26b00852",
+    "name": "Mistral Instruct",
+    "filename": "mistral-7b-instruct-v0.1.Q4_0.gguf",
+    "filesize": "4108916384",
+    "requires": "2.5.0",
+    "ramrequired": "8",
+    "parameters": "7 billion",
+    "quant": "q4_0",
+    "type": "Mistral",
+    "systemPrompt": " ",
+    "description": "<strong>Best overall fast instruction following model</strong><br><ul><li>Fast responses</li><li>Trained by Mistral AI<li>Uncensored</li><li>Licensed for commercial use</li></ul>",
+    "url": "https://gpt4all.io/models/gguf/mistral-7b-instruct-v0.1.Q4_0.gguf",
+    "promptTemplate": "[INST] %1 [/INST]"
   },
   {
     "order": "e",


### PR DESCRIPTION
Add Gemma support. Using a Q4_0 quant of this model: https://huggingface.co/google/gemma-7b-it

Also whitelist Kompute for Gemma, Phi and Phi-2, Qwen2, and StableLM, as I have tested Q4_0 quants of all of them without issue.