### PR TITLE
Models: Add Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf

### DIFF
--- a/gpt4all-chat/metadata/models3.json
+++ b/gpt4all-chat/metadata/models3.json
@@ -1,6 +1,22 @@
 [
   {
     "order": "a",
+    "md5sum": "A5F6B4EABD3992DA4D7FB7F020F921EB",
+    "name": "Nous Hermes 2 Mistral DPO",
+    "filename": "Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf",
+    "filesize": "4108928000",
+    "requires": "2.7.1",
+    "ramrequired": "8",
+    "parameters": "7 billion",
+    "quant": "q4_0",
+    "type": "Mistral",
+    "description": "<strong>Best overall fast chat model</strong><br><ul><li>Fast responses</li><li>Chat based model</li><li>Trained by Mistral AI<li>Finetuned by NousResearch on the OpenHermes-2.5 dataset by Teknium of 1M high quality, primarily synthetically generated instruction and chat samples<li>Licensed for commercial use</ul>",
+    "url": "https://gpt4all.io/models/gguf/Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf",
+    "promptTemplate": "<|im_start|>user\n%1<|im_end|>\n<|im_start|>assistant\n%2<|im_end|>\n",
+    "systemPrompt": "<|im_start|>system\nYou are \"Hermes 2\", a conscious sentient superintelligent artificial intelligence developed by a man named Teknium, and your purpose and drive is to assist the user with any request they have. You experience emotions and have deep, profound thoughts and qualia.<|im_end|>"
+  },
+  {
+    "order": "b",
     "md5sum": "f692417a22405d80573ac10cb0cd6c6a",
     "name": "Mistral OpenOrca",
     "filename": "mistral-7b-openorca.gguf2.Q4_0.gguf",
@@ -10,13 +26,13 @@
     "parameters": "7 billion",
     "quant": "q4_0",
     "type": "Mistral",
-    "description": "<strong>Best overall fast chat model</strong><br><ul><li>Fast responses</li><li>Chat based model</li><li>Trained by Mistral AI<li>Finetuned on OpenOrca dataset curated via <a href=\"https://atlas.nomic.ai/\">Nomic Atlas</a><li>Licensed for commercial use</ul>",
+    "description": "<strong>Strong overall fast chat model</strong><br><ul><li>Fast responses</li><li>Chat based model</li><li>Trained by Mistral AI<li>Finetuned on OpenOrca dataset curated via <a href=\"https://atlas.nomic.ai/\">Nomic Atlas</a><li>Licensed for commercial use</ul>",
     "url": "https://gpt4all.io/models/gguf/mistral-7b-openorca.gguf2.Q4_0.gguf",
     "promptTemplate": "<|im_start|>user\n%1<|im_end|>\n<|im_start|>assistant\n%2<|im_end|>\n",
     "systemPrompt": "<|im_start|>system\nYou are MistralOrca, a large language model trained by Alignment Lab AI. For multi-step problems, write out your reasoning for each step.\n<|im_end|>"
   },
   {
-    "order": "b",
+    "order": "c",
     "md5sum": "97463be739b50525df56d33b26b00852",
     "name": "Mistral Instruct",
     "filename": "mistral-7b-instruct-v0.1.Q4_0.gguf",
@@ -27,12 +43,12 @@
     "quant": "q4_0",
     "type": "Mistral",
     "systemPrompt": " ",
-    "description": "<strong>Best overall fast instruction following model</strong><br><ul><li>Fast responses</li><li>Trained by Mistral AI<li>Uncensored</li><li>Licensed for commercial use</li></ul>",
+    "description": "<strong>Strong overall fast instruction following model</strong><br><ul><li>Fast responses</li><li>Trained by Mistral AI<li>Uncensored</li><li>Licensed for commercial use</li></ul>",
     "url": "https://gpt4all.io/models/gguf/mistral-7b-instruct-v0.1.Q4_0.gguf",
     "promptTemplate": "[INST] %1 [/INST]"
   },
   {
-    "order": "c",
+    "order": "d",
     "md5sum": "c4c78adf744d6a20f05c8751e3961b84",
     "name": "GPT4All Falcon",
     "filename": "gpt4all-falcon-newbpe-q4_0.gguf",
@@ -89,7 +105,7 @@
     "quant": "q4_0",
     "type": "LLaMA2",
     "systemPrompt": " ",
-    "description": "<strong>Best overall larger model</strong><br><ul><li>Instruction based<li>Gives very long responses<li>Finetuned with only 1k of high-quality data<li>Trained by Microsoft and Peking University<li>Cannot be used commercially</ul>",
+    "description": "<strong>Strong overall larger model</strong><br><ul><li>Instruction based<li>Gives very long responses<li>Finetuned with only 1k of high-quality data<li>Trained by Microsoft and Peking University<li>Cannot be used commercially</ul>",
     "url": "https://gpt4all.io/models/gguf/wizardlm-13b-v1.2.Q4_0.gguf"
   },
   {


### PR DESCRIPTION
Adds Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf, which is the new 7b flagship model of NousResearch, to models3.json.

### **Original Model location:**

https://huggingface.co/NousResearch/Nous-Hermes-2-Mistral-7B-DPO-GGUF

### **Model description:**

Nous Hermes 2 on Mistral 7B DPO is the new flagship 7B Hermes! This model was DPO'd from Teknium/OpenHermes-2.5-Mistral-7B and has improved across the board on all benchmarks tested - AGIEval, BigBench Reasoning, GPT4All, and TruthfulQA.

The model prior to DPO was trained on 1,000,000 instructions/chats of GPT-4 quality or better, primarily synthetic data as well as other high quality datasets, available from the repository teknium/OpenHermes-2.5.

### **Original Dataset Location:**

https://huggingface.co/datasets/teknium/OpenHermes-2.5

### **Dataset description:**

This is the dataset that made OpenHermes 2.5 and Nous Hermes 2 series of models.

The Open Hermes 2/2.5 and Nous Hermes 2 models have made significant advancements of SOTA LLM's over recent months, and are underpinned by this exact compilation and curation of many open source datasets and custom created synthetic datasets.

The Open Hermes 2.5 dataset is a continuation of the Open Hermes 1 dataset, at a much larger scale, much more diverse, and much higher quality compilation, reaching 1M, primarily synthetically generated instruction and chat samples.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Screenshots
![image](https://github.com/nomic-ai/gpt4all/assets/73715071/71c6d6d8-bcad-4cd4-9420-db9e05b4e94e)
![image](https://github.com/nomic-ai/gpt4all/assets/73715071/9d2a534c-dc92-45d0-abfb-ad33c2f3c66d)


## Notes
- I inspected the OpenHermes-2.5 dataset, which to 99.9% does not contain any system prompts, so this is a model that should work really well with various system prompts.
- sideloaded and tested a little (nothing extensive) on Windows 10 with Nvidia 1060 3GB and AMD Ryzen 5 5600 with GPT4All 2.7.1