### PR TITLE
chat: better handle case where network reachability is unknown

### DIFF
--- a/gpt4all-chat/llm.cpp
+++ b/gpt4all-chat/llm.cpp
@@ -42,8 +42,11 @@ LLM::LLM()
     m_compatHardware = minimal;
 
     QNetworkInformation::loadDefaultBackend();
-    connect(QNetworkInformation::instance(), &QNetworkInformation::reachabilityChanged,
-        this, &LLM::isNetworkOnlineChanged);
+    auto * netinfo = QNetworkInformation::instance();
+    if (netinfo) {
+        connect(netinfo, &QNetworkInformation::reachabilityChanged,
+            this, &LLM::isNetworkOnlineChanged);
+    }
 }
 
 bool LLM::hasSettingsAccess() const
@@ -108,8 +111,6 @@ QString LLM::systemTotalRAMInGBString() const
 
 bool LLM::isNetworkOnline() const
 {
-    if (!QNetworkInformation::instance())
-        return false;
-
-    return QNetworkInformation::instance()->reachability() == QNetworkInformation::Reachability::Online;
+    auto * netinfo = QNetworkInformation::instance();
+    return !netinfo || netinfo->reachability() == QNetworkInformation::Reachability::Online;
 }


### PR DESCRIPTION
On Linux, QNetworkInformation uses NetworkManager by default. I don't have NetworkManager (I use systemd-networkd), so I get no download button, *and* I get this warning on console:
```
[Warning] (Tue Feb 27 12:41:53 2024): QObject::connect(QNetworkInformation, LLM): invalid nullptr parameter
```

Change this so that the download button appears and there is no warning.

Question: Is QNetworkInformation even the right thing here? It's clearly designed to report information about how the computer is connected to the local network, which on the plus side means that the download button immediately disappears when you disable your network adapter, but I don't think it would be accurate in the case where a computer is networked but not connected to the internet (e.g. the user's ISP is experiencing a service outage). And in cases like mine, it fails entirely, while e.g. an HTTP request to a known server would just work.