### PR TITLE
chatllm: fix undefined behavior in resetContext

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -480,7 +480,7 @@ void ChatLLM::resetResponse()
 
 void ChatLLM::resetContext()
 {
-    regenerateResponse();
+    resetResponse();
     m_processedSystemPrompt = false;
     m_ctx = LLModel::PromptContext();
 }


### PR DESCRIPTION
Chat::reset -> ChatLLM::resetContext is called when we change models. This will happen even if no model has been previously loaded.

In that case, m_llModelType is unset (contains a garbage value). regenerateResponse will attempt to read m_llModelType, causing undefined behavior (found by UBSAN) - but it seems like resetResponse was intended here anyway.