### PR TITLE
chat: join ChatLLM threads without calling destructors

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -35,6 +35,7 @@ Chat::Chat(bool isServer, QObject *parent)
 Chat::~Chat()
 {
     delete m_llmodel;
+    m_llmodel = nullptr;
 }
 
 void Chat::connectLLM()

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -35,7 +35,6 @@ Chat::Chat(bool isServer, QObject *parent)
 Chat::~Chat()
 {
     delete m_llmodel;
-    m_llmodel = nullptr;
 }
 
 void Chat::connectLLM()

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -46,6 +46,7 @@ public:
     explicit Chat(QObject *parent = nullptr);
     explicit Chat(bool isServer, QObject *parent = nullptr);
     virtual ~Chat();
+    void destroy() { m_llmodel->destroy(); }
     void connectLLM();
 
     QString id() const { return m_id; }

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -192,13 +192,8 @@ public:
 
     int count() const { return m_chats.size(); }
 
-    void clearChats() {
-        m_newChat = nullptr;
-        m_serverChat = nullptr;
-        m_currentChat = nullptr;
-        for (auto * chat: m_chats) { delete chat; }
-        m_chats.clear();
-    }
+    // stop ChatLLM threads for clean shutdown
+    void destroyChats() { for (auto *chat: m_chats) { chat->destroy(); } }
 
     void removeChatFile(Chat *chat) const;
     Q_INVOKABLE void saveChats();

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -95,6 +95,10 @@ ChatLLM::ChatLLM(Chat *parent, bool isServer)
 
 ChatLLM::~ChatLLM()
 {
+    destroy();
+}
+
+void ChatLLM::destroy() {
     m_stopGenerating = true;
     m_llmThread.quit();
     m_llmThread.wait();

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -72,6 +72,7 @@ public:
     ChatLLM(Chat *parent, bool isServer = false);
     virtual ~ChatLLM();
 
+    void destroy();
     bool isModelLoaded() const;
     void regenerateResponse();
     void resetResponse();

--- a/gpt4all-chat/main.cpp
+++ b/gpt4all-chat/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 
     // Make sure ChatLLM threads are joined before global destructors run.
     // Otherwise, we can get a heap-use-after-free inside of llama.cpp.
-    ChatListModel::globalInstance()->clearChats();
+    ChatListModel::globalInstance()->destroyChats();
 
     return res;
 }


### PR DESCRIPTION
There were some harmless warnings at shutdown with the previous code. This version of the thread joining does things a little more cleanly so the warnings don't appear.

Fixes #1921