### PR TITLE
chat: fix ChatGPT after #1970

### DIFF
--- a/gpt4all-chat/chatgpt.h
+++ b/gpt4all-chat/chatgpt.h
@@ -3,11 +3,14 @@
 
 #include <stdexcept>
 
-#include <QObject>
+#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QNetworkAccessManager>
+#include <QObject>
+#include <QString>
+#include <QStringList>
 #include <QThread>
+
 #include "../gpt4all-backend/llmodel.h"
 
 class ChatGPT;
@@ -126,6 +129,7 @@ private:
     QString m_modelName;
     QString m_apiKey;
     QList<QString> m_context;
+    QStringList m_queuedPrompts;
 };
 
 #endif // CHATGPT_H


### PR DESCRIPTION
I'm actually not sure how certain parts of this were working before #1970, namely:
- processRestoreStateFromText() - My understanding is that the LLModel would generate a new reply to both the original prompt and the original reply, because we called LLModel::prompt with the default n_predict (not zero). We were simply not *displaying* the reply (empty callback), even though it ended up in the LLModel's conversation history (m_context in the case of ChatGPT). I added fakeReply in PR 1970 because the prompt and response now need to happen within the same LLModel::prompt invocation, but as a bonus it fixes this apparent issue.
- For ChatGPT, decrementing n_past to regenerate the reply meant the *initial* new reply would be based on only the previous context, but we never actually removed anything from m_context, so any *further* replies would see old messages. Now we resize m_context as needed.