### PR TITLE
modellist: rename "deprecated" to "removedIn", disable if equal

### DIFF
--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -6,6 +6,7 @@
 #include <QFile>
 #include <QStandardPaths>
 #include <algorithm>
+#include <compare>
 
 //#define USE_LOCAL_MODELSJSON
 
@@ -549,8 +550,8 @@ QVariant ModelList::dataInternal(const ModelInfo *info, int role) const
             return info->description;
         case RequiresVersionRole:
             return info->requiresVersion;
-        case DeprecatedVersionRole:
-            return info->deprecatedVersion;
+        case VersionRemovedRole:
+            return info->versionRemoved;
         case UrlRole:
             return info->url;
         case BytesReceivedRole:
@@ -680,8 +681,8 @@ void ModelList::updateData(const QString &id, int role, const QVariant &value)
             info->description = value.toString(); break;
         case RequiresVersionRole:
             info->requiresVersion = value.toString(); break;
-        case DeprecatedVersionRole:
-            info->deprecatedVersion = value.toString(); break;
+        case VersionRemovedRole:
+            info->versionRemoved = value.toString(); break;
         case UrlRole:
             info->url = value.toString(); break;
         case BytesReceivedRole:
@@ -1074,22 +1075,19 @@ void ModelList::updateDataForSettings()
     emit dataChanged(index(0, 0), index(m_models.size() - 1, 0));
 }
 
-static bool compareVersions(const QString &a, const QString &b) {
+static std::strong_ordering compareVersions(const QString &a, const QString &b) {
     QStringList aParts = a.split('.');
     QStringList bParts = b.split('.');
 
     for (int i = 0; i < std::min(aParts.size(), bParts.size()); ++i) {
         int aInt = aParts[i].toInt();
         int bInt = bParts[i].toInt();
-
-        if (aInt > bInt) {
-            return true;
-        } else if (aInt < bInt) {
-            return false;
+        if (auto diff = aInt <=> bInt; diff != 0) {
+            return diff;
         }
     }
 
-    return aParts.size() > bParts.size();
+    return aParts.size() <=> bParts.size();
 }
 
 void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
@@ -1125,7 +1123,7 @@ void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
         QString modelFilename = obj["filename"].toString();
         QString modelFilesize = obj["filesize"].toString();
         QString requiresVersion = obj["requires"].toString();
-        QString deprecatedVersion = obj["deprecated"].toString();
+        QString versionRemoved = obj["removedIn"].toString();
         QString url = obj["url"].toString();
         QByteArray modelMd5sum = obj["md5sum"].toString().toLatin1().constData();
         bool isDefault = obj.contains("isDefault") && obj["isDefault"] == QString("true");
@@ -1137,16 +1135,13 @@ void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
         QString quant = obj["quant"].toString();
         QString type = obj["type"].toString();
 
-        // If the currentVersion version is strictly less than required version, then continue
-        if (!requiresVersion.isEmpty()
-            && requiresVersion != currentVersion
-            && compareVersions(requiresVersion, currentVersion)) {
+        // If the current version is strictly less than required version, then skip
+        if (!requiresVersion.isEmpty() && compareVersions(currentVersion, requiresVersion) < 0) {
             continue;
         }
 
-        // If the current version is strictly greater than the deprecated version, then continue
-        if (!deprecatedVersion.isEmpty()
-            && compareVersions(currentVersion, deprecatedVersion)) {
+        // If the version removed is less than or equal to the current version, then skip
+        if (!versionRemoved.isEmpty() && compareVersions(versionRemoved, currentVersion) <= 0) {
             continue;
         }
 
@@ -1168,7 +1163,7 @@ void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
         updateData(id, ModelList::DefaultRole, isDefault);
         updateData(id, ModelList::DescriptionRole, description);
         updateData(id, ModelList::RequiresVersionRole, requiresVersion);
-        updateData(id, ModelList::DeprecatedVersionRole, deprecatedVersion);
+        updateData(id, ModelList::VersionRemovedRole, versionRemoved);
         updateData(id, ModelList::UrlRole, url);
         updateData(id, ModelList::DisableGUIRole, disableGUI);
         updateData(id, ModelList::OrderRole, order);

--- a/gpt4all-chat/modellist.h
+++ b/gpt4all-chat/modellist.h
@@ -19,7 +19,7 @@ struct ModelInfo {
     Q_PROPERTY(bool isOnline MEMBER isOnline)
     Q_PROPERTY(QString description MEMBER description)
     Q_PROPERTY(QString requiresVersion MEMBER requiresVersion)
-    Q_PROPERTY(QString deprecatedVersion MEMBER deprecatedVersion)
+    Q_PROPERTY(QString versionRemoved MEMBER versionRemoved)
     Q_PROPERTY(QString url MEMBER url)
     Q_PROPERTY(qint64 bytesReceived MEMBER bytesReceived)
     Q_PROPERTY(qint64 bytesTotal MEMBER bytesTotal)
@@ -69,7 +69,7 @@ public:
     bool disableGUI = false;
     QString description;
     QString requiresVersion;
-    QString deprecatedVersion;
+    QString versionRemoved;
     QString url;
     qint64 bytesReceived = 0;
     qint64 bytesTotal = 0;
@@ -225,7 +225,7 @@ public:
         DisableGUIRole,
         DescriptionRole,
         RequiresVersionRole,
-        DeprecatedVersionRole,
+        VersionRemovedRole,
         UrlRole,
         BytesReceivedRole,
         BytesTotalRole,
@@ -270,7 +270,7 @@ public:
         roles[DisableGUIRole] = "disableGUI";
         roles[DescriptionRole] = "description";
         roles[RequiresVersionRole] = "requiresVersion";
-        roles[DeprecatedVersionRole] = "deprecatedVersion";
+        roles[VersionRemovedRole] = "versionRemoved";
         roles[UrlRole] = "url";
         roles[BytesReceivedRole] = "bytesReceived";
         roles[BytesTotalRole] = "bytesTotal";


### PR DESCRIPTION
A simple change that will be useful when we remove support for the SBert model that we are currently hosting. I've already made sure that the model will not be shown in the chat model list, or used for localdocs.

I think the name "removedIn" is more clear as it explicitly indicates that the model will not be listed, and if it was removed in version 2.8.0 and we are on version 2.8.0, we obviously shouldn't show the model.