### PR TITLE
#2024 Use the currently selected chat model as the default displayed when opening settings to update parameters

### DIFF
--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Basic
 import QtQuick.Layouts
 import modellist
 import mysettings
+import chatlistmodel
 
 MySettingsTab {
     onRestoreDefaultsClicked: {
@@ -42,7 +43,7 @@ MySettingsTab {
                 model: ModelList.installedModels
                 valueRole: "id"
                 textRole: "name"
-                currentIndex: 0
+                currentIndex: comboBox.indexOfValue(ChatListModel.currentChat.modelInfo.id)
                 contentItem: Text {
                     leftPadding: 10
                     rightPadding: 20


### PR DESCRIPTION
…x to the currently selected chat model

## Describe your changes
As described in issue #2024 the model/character settings does not default to the currently selected chat model when opened. This commit addresses that.

## Issue ticket number and link
#2024 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

### Steps to Reproduce
Described in #2024 

