### PR TITLE
llamamodel: fix macOS build

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -791,14 +791,16 @@ void LLamaModel::embedInternal(
     }
 
     // split into max_len-sized chunks
-    struct split_batch { int idx; TokenString batch; };
+    struct split_batch { unsigned idx; TokenString batch; };
     std::vector<split_batch> batches;
     for (unsigned i = 0; i < inputs.size(); i++) {
         auto &input = inputs[i];
         for (auto it = input.begin(); it < input.end(); it += max_len) {
             if (it > input.begin()) { it -= chunkOverlap; }
             auto end = std::min(it + max_len, input.end());
-            auto &batch = batches.emplace_back(i, prefixTokens).batch;
+            batches.push_back({ i, {} });
+            auto &batch = batches.back().batch;
+            batch = prefixTokens;
             batch.insert(batch.end(), it, end);
             batch.push_back(eos_token);
             if (!doMean) { break; /* limit text to one chunk */ }


### PR DESCRIPTION
I tried to use a C++20 feature that apparently even the latest Apple clang does [not yet support](https://en.cppreference.com/w/cpp/compiler_support/20#:~:text=Parenthesized%20initialization%20of%20aggregates).

Fixes this build failure on macOS:
```
[ 67%] Building CXX object llmodel/CMakeFiles/llamamodel-mainline-default.dir/llamamodel.cpp.o
In file included from /Users/jared/src/forks/gpt4all/gpt4all-backend/llamamodel.cpp:2:
In file included from /Users/jared/src/forks/gpt4all/gpt4all-backend/llamamodel_impl.h:7:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/functional:526:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__functional/boyer_moore_searcher.h:22:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/shared_ptr.h:22:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/allocation_guard.h:15:
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/allocator_traits.h:304:9: error: no matching function for call to 'construct_at'
        _VSTD::construct_at(__p, _VSTD::forward<_Args>(__args)...);
        ^~~~~~~~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__config:897:17: note: expanded from macro '_VSTD'
#  define _VSTD std
                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/vector:919:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<split_batch>>::construct<split_batch, unsigned int &, std::vector<int> &, void, void>' requested here
    __alloc_traits::construct(this->__alloc(), std::__to_address(__tx.__pos_),
                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/vector:1678:9: note: in instantiation of function template specialization 'std::vector<split_batch>::__construct_one_at_end<unsigned int &, std::vector<int> &>' requested here
        __construct_one_at_end(std::forward<_Args>(__args)...);
        ^
/Users/jared/src/forks/gpt4all/gpt4all-backend/llamamodel.cpp:801:35: note: in instantiation of function template specialization 'std::vector<split_batch>::emplace_back<unsigned int &, std::vector<int> &>' requested here
            auto &batch = batches.emplace_back(i, prefixTokens).batch;
                                  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__memory/construct_at.h:39:38: note: candidate template ignored: substitution failure [with _Tp = split_batch, _Args = <unsigned int &, std::vector<int> &>]: no matching constructor for initialization of 'split_batch'
_LIBCPP_HIDE_FROM_ABI constexpr _Tp* construct_at(_Tp* __location, _Args&&... __args) {
                                     ^
1 error generated.
```