### PR TITLE
fix non-AVX CPU detection

### DIFF
--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -65,10 +65,10 @@ LLModel::Implementation::Implementation(Implementation &&o)
 }
 
 LLModel::Implementation::~Implementation() {
-    if (m_dlhandle) delete m_dlhandle;
+    delete m_dlhandle;
 }
 
-bool LLModel::Implementation::isImplementation(const Dlhandle &dl) {
+static bool isImplementation(const Dlhandle &dl) {
     return dl.get<bool(uint32_t)>("is_g4a_backend_model_implementation");
 }
 
@@ -105,9 +105,8 @@ const std::vector<LLModel::Implementation> &LLModel::Implementation::implementat
                     // Add to list if model implementation
                     try {
                         Dlhandle dl(p.string());
-                        if (!Implementation::isImplementation(dl)) {
+                        if (!isImplementation(dl))
                             continue;
-                        }
                         fres.emplace_back(Implementation(std::move(dl)));
                     } catch (...) {}
                 }

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -78,7 +78,7 @@ const std::vector<LLModel::Implementation> &LLModel::Implementation::implementat
     static auto* libs = new std::vector<Implementation>([] () {
         std::vector<Implementation> fres;
 
-        std::string impl_name_re = "(bert|gptj|llamamodel-mainline)";
+        std::string impl_name_re = "(gptj|llamamodel-mainline)";
         if (cpu_supports_avx2() == 0) {
             impl_name_re += "-avxonly";
         } else {

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -30,7 +30,6 @@ public:
 
     class Implementation {
     public:
-        Implementation(Dlhandle &&);
         Implementation(const Implementation &) = delete;
         Implementation(Implementation &&);
         ~Implementation();
@@ -38,9 +37,6 @@ public:
         std::string_view modelType() const { return m_modelType; }
         std::string_view buildVariant() const { return m_buildVariant; }
 
-        static bool isImplementation(const Dlhandle &dl);
-        static const std::vector<Implementation> &implementationList();
-        static const Implementation *implementation(const char *fname, const std::string &buildVariant);
         static LLModel *construct(const std::string &modelPath, std::string buildVariant = "auto", int n_ctx = 2048);
         static std::vector<GPUDevice> availableGPUDevices();
         static int32_t maxContextLength(const std::string &modelPath);
@@ -51,6 +47,10 @@ public:
         static bool hasSupportedCPU();
 
     private:
+        Implementation(Dlhandle &&);
+
+        static const std::vector<Implementation> &implementationList();
+        static const Implementation *implementation(const char *fname, const std::string &buildVariant);
         static LLModel *constructDefaultLlama();
 
         bool (*m_magicMatch)(const char *fname);

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -48,7 +48,7 @@ public:
         static bool isEmbeddingModel(const std::string &modelPath);
         static void setImplementationsSearchPath(const std::string &path);
         static const std::string &implementationsSearchPath();
-        static bool cpuSupportsAVX();
+        static bool hasSupportedCPU();
 
     private:
         static LLModel *constructDefaultLlama();

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -48,6 +48,7 @@ public:
         static bool isEmbeddingModel(const std::string &modelPath);
         static void setImplementationsSearchPath(const std::string &path);
         static const std::string &implementationsSearchPath();
+        static bool cpuSupportsAVX();
 
     private:
         static LLModel *constructDefaultLlama();

--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -185,7 +185,7 @@ class LLModel:
         model = llmodel.llmodel_model_create2(self.model_path, b"auto", ctypes.byref(err))
         if model is None:
             s = err.value
-            raise ValueError(f"Unable to instantiate model: {'null' if s is None else s.decode()}")
+            raise RuntimeError(f"Unable to instantiate model: {'null' if s is None else s.decode()}")
         self.model = model
 
     def __del__(self):

--- a/gpt4all-chat/llm.cpp
+++ b/gpt4all-chat/llm.cpp
@@ -27,7 +27,7 @@ LLM::LLM()
     : QObject{nullptr}
     , m_compatHardware(true)
 {
-#if defined(__x86_64__)
+#if defined(__x86_64__) || defined(_M_X64)
     #ifndef _MSC_VER
         const bool minimal(__builtin_cpu_supports("avx"));
     #else

--- a/gpt4all-chat/llm.cpp
+++ b/gpt4all-chat/llm.cpp
@@ -1,4 +1,5 @@
 #include "llm.h"
+#include "../gpt4all-backend/llmodel.h"
 #include "../gpt4all-backend/sysinfo.h"
 
 #include <QCoreApplication>
@@ -25,22 +26,8 @@ LLM *LLM::globalInstance()
 
 LLM::LLM()
     : QObject{nullptr}
-    , m_compatHardware(true)
+    , m_compatHardware(LLModel::Implementation::cpuSupportsAVX())
 {
-#if defined(__x86_64__) || defined(_M_X64)
-    #ifndef _MSC_VER
-        const bool minimal(__builtin_cpu_supports("avx"));
-    #else
-        int cpuInfo[4];
-        __cpuid(cpuInfo, 1);
-        const bool minimal(cpuInfo[2] & (1 << 28));
-    #endif
-#else
-    const bool minimal = true; // Don't know how to handle non-x86_64
-#endif
-
-    m_compatHardware = minimal;
-
     QNetworkInformation::loadDefaultBackend();
     auto * netinfo = QNetworkInformation::instance();
     if (netinfo) {

--- a/gpt4all-chat/llm.cpp
+++ b/gpt4all-chat/llm.cpp
@@ -26,7 +26,7 @@ LLM *LLM::globalInstance()
 
 LLM::LLM()
     : QObject{nullptr}
-    , m_compatHardware(LLModel::Implementation::cpuSupportsAVX())
+    , m_compatHardware(LLModel::Implementation::hasSupportedCPU())
 {
     QNetworkInformation::loadDefaultBackend();
     auto * netinfo = QNetworkInformation::instance();

--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -228,11 +228,11 @@ int ModelInfo::maxContextLength() const
     if (!installed || isOnline) return -1;
     if (m_maxContextLength != -1) return m_maxContextLength;
     auto path = (dirpath + filename()).toStdString();
-    int layers = LLModel::Implementation::maxContextLength(path);
-    if (layers < 0) {
-        layers = 4096; // fallback value
+    int n_ctx = LLModel::Implementation::maxContextLength(path);
+    if (n_ctx < 0) {
+        n_ctx = 4096; // fallback value
     }
-    m_maxContextLength = layers;
+    m_maxContextLength = n_ctx;
     return m_maxContextLength;
 }
 


### PR DESCRIPTION
## Key Changes
- Fix a missing `defined(_M_X64)` that caused the "you don't have AVX" screen to not appear on Windows
- Refactor CPU feature detection so that can't happen anymore
- Improve the way we report this to the bindings.

## Chat

This message can now be shown on Windows. This screenshot is only an example, I haven't actually tested this on a Windows machine without AVX:

<img width="1563" alt="Screenshot 2024-03-18 at 18 43 00" src="https://github.com/nomic-ai/gpt4all/assets/14168726/d8eec5fc-aade-44dc-9136-8089ede3bf6a">

## Bindings

Before (exception is generic and misleading, actual error is hidden above the traceback):
```
LLModel ERROR: CPU does not support AVX
Traceback (most recent call last):
  File "/home/jared/src/own/gpt4all-scripts/test_any.py", line 18, in <module>
    main()
  File "/home/jared/src/own/gpt4all-scripts/test_any.py", line 10, in main
    x = GPT4All(model_name=path.name, model_path=path.parent, allow_download=False, device="Tesla P40")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jared/src/forks/gpt4all/gpt4all-bindings/python/gpt4all/gpt4all.py", line 132, in __init__
    self.model = _pyllmodel.LLModel(self.config["path"], n_ctx, ngl)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jared/src/forks/gpt4all/gpt4all-bindings/python/gpt4all/_pyllmodel.py", line 188, in __init__
    raise ValueError(f"Unable to instantiate model: {'null' if s is None else s.decode()}")
ValueError: Unable to instantiate model: Model format not supported (no matching implementation found)
```

After:
```
Traceback (most recent call last):
  File "/home/jared/src/own/gpt4all-scripts/test_any.py", line 18, in <module>
    main()
  File "/home/jared/src/own/gpt4all-scripts/test_any.py", line 10, in main
    x = GPT4All(model_name=path.name, model_path=path.parent, allow_download=False, device="Tesla P40")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jared/src/forks/gpt4all/gpt4all-bindings/python/gpt4all/gpt4all.py", line 132, in __init__
    self.model = _pyllmodel.LLModel(self.config["path"], n_ctx, ngl)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jared/src/forks/gpt4all/gpt4all-bindings/python/gpt4all/_pyllmodel.py", line 188, in __init__
    raise RuntimeError(f"Unable to instantiate model: {'null' if s is None else s.decode()}")
RuntimeError: Unable to instantiate model: CPU does not support AVX
```