### PR TITLE
Fix colors for server chat in all themes.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -891,7 +891,13 @@ Rectangle {
                         text: value + references
                         anchors.horizontalCenter: listView.contentItem.horizontalCenter
                         width: Math.min(1280, listView.contentItem.width)
-                        color: theme.textColor
+                        color: {
+                            if (!currentChat.isServer)
+                                return theme.textColor
+                            if (name === qsTr("Response: "))
+                                return theme.white
+                            return theme.black
+                        }
                         wrapMode: Text.WordWrap
                         textFormat: TextEdit.PlainText
                         focus: false


### PR DESCRIPTION
The server colors are messed up right now for some themes. This hardcodes the background and text colors for server that distinguishes it from all other chats and works for all themes.
