### PR TITLE
python: use TypedDict from typing_extensions on python 3.9 and 3.10

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -9,12 +9,18 @@ import sys
 import threading
 from enum import Enum
 from queue import Queue
-from typing import Any, Callable, Generic, Iterable, TypedDict, TypeVar, overload
+from typing import Any, Callable, Generic, Iterable, TypeVar, overload
 
 if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
 else:
     import importlib_resources
+
+if (3, 9) <= sys.version_info < (3, 11):
+    # python 3.9 broke generic TypedDict, python 3.11 fixed it
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 EmbeddingsType = TypeVar('EmbeddingsType', bound='list[Any]')
 

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -90,6 +90,7 @@ setup(
         'requests',
         'tqdm',
         'importlib_resources; python_version < "3.9"',
+        'typing-extensions>=4.3.0; python_version >= "3.9" and python_version < "3.11"',
     ],
     extras_require={
         'dev': [

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="2.3.0",
+    version="2.3.1",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Fixes #2159