### PR TITLE
python: bump version to 2.3.2 to include *all* of the bugfixes

### DIFF
--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="2.3.1",
+    version="2.3.2",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The 2.3.1 release of the bindings [failed](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/2130/workflows/e022c8b3-dc62-430f-8727-bdd865be7476) to upload, because it was already [built and uploaded](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/2126/workflows/51aec527-ac7b-4181-a009-50b38fdeeb47) from PR #2164.

Release version 2.3.2 of the python bindings to include all three of the intended changes (#2162, #2163, #2164).