### PR TITLE
ci: use `aws s3 sync` to upload docs

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -370,13 +370,13 @@ jobs:
       - run:
           name: Make Documentation
           command: |
-            cd gpt4all-bindings/python/
+            cd gpt4all-bindings/python
             mkdocs build
       - run:
           name: Deploy Documentation
           command: |
-            cd gpt4all-bindings/python/
-            aws s3 cp ./site s3://docs.gpt4all.io/ --recursive | cat
+            cd gpt4all-bindings/python
+            aws s3 sync --delete site/ s3://docs.gpt4all.io/
       - run:
           name: Invalidate docs.gpt4all.io cloudfront
           command: aws cloudfront create-invalidation --distribution-id E1STQOW63QL2OH --paths "/*"


### PR DESCRIPTION
This change is necessary to allow documentation pages to be renamed or deleted - otherwise, they still show up under the old name.

I have no easy way of testing this (e.g. locally with --dryrun) because my AWS account does not have permission to access the `s3://docs.gpt4all.io/` bucket, so we'll just have to hope this doesn't break anything.