### PR TITLE
python: implement close() and context manager interface

### DIFF
--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="2.3.2",
+    version="2.3.3",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This allows you to do this:
```python
from gpt4all import GPT4All
model = GPT4All('orca-mini-3b-gguf2-q4_0.gguf')
model.generate(...)
model.close()
```
or even this:
```python
from gpt4all import GPT4All
with GPT4All('orca-mini-3b-gguf2-q4_0.gguf') as model:
    model.generate(...)
```

In order to free resources after using a GPT4All or Embed4All instance. This will be important for the nomic client integration, which is expected to automatically (re-)create Embed4All instances as needed, and ideally it would explicitly avoid using up all system RAM or VRAM in the process.