### PR TITLE
Fix to set proper app icon on MacOS.

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -68,6 +68,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
   set(METAL_SHADER_FILE ../gpt4all-backend/llama.cpp-mainline/ggml-metal.metal)
 endif()
 
+set(APP_ICON_FILE "${CMAKE_CURRENT_SOURCE_DIR}/icons/favicon.icns")
+set_source_files_properties(${APP_ICON_FILE} PROPERTIES
+    MACOSX_PACKAGE_LOCATION "Resources")
+
 qt_add_executable(chat
     main.cpp
     chat.h chat.cpp
@@ -87,6 +91,7 @@ qt_add_executable(chat
     logger.h logger.cpp
     responsetext.h responsetext.cpp
     ${METAL_SHADER_FILE}
+    ${APP_ICON_FILE}
 )
 
 qt_add_qml_module(chat


### PR DESCRIPTION
## Describe your changes

This sets the app icon properly so that when built on MacOS, the app icon shows as intended. While the favicon.icns file appears to be specified in some places, it's necessary to include it in the Resources folder and the appropriate executable manifest for it to actually be used on MacOS.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
  - I am unable to apply any labels myself. It would probably be an _Enhancement_
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo

|              | Before fix  | With fix in place |
| ------------ | ----------- | ----------------- |
| Dock    | ![Screenshot 2024-03-29 at 1 06 32 PM](https://github.com/nomic-ai/gpt4all/assets/4975196/9f4405ad-027b-4930-bb99-0b16c1cbc0e5) | ![Screenshot 2024-03-29 at 1 00 18 PM](https://github.com/nomic-ai/gpt4all/assets/4975196/c2342063-7d6e-4515-ac72-c3e6116f6223) |
| Icon | ![Screenshot 2024-03-29 at 1 07 11 PM](https://github.com/nomic-ai/gpt4all/assets/4975196/a1051ca8-6fd6-4511-b45c-9dbd9d6e2551) | ![Screenshot 2024-03-29 at 1 10 27 PM](https://github.com/nomic-ai/gpt4all/assets/4975196/f46b5b0e-58f7-4083-a135-47af43d41f22) |

### Steps to Reproduce

Build the app and check the build output folder (e.g. build-gpt4all-chat-Desktop_arm_darwin_generic_mach_o_64bit-Release/bin) to view the app icon. It should be the GPT4All icon from favicon.icns. After applying the fix, it may be necessary to manually remove the build output dir and run Clean on the project to handle caching around the app icon.

## Notes
<!-- Any other relevant information to include about PR !-->
