### PR TITLE
Fix bugs with the context link text for localdocs

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -184,45 +184,43 @@ void Chat::responseStopped()
     m_tokenSpeed = QString();
     emit tokenSpeedChanged();
 
-    if (MySettings::globalInstance()->localDocsShowReferences()) {
-        const QString chatResponse = response();
-        QList<QString> references;
-        QList<QString> referencesContext;
-        int validReferenceNumber = 1;
-        for (const ResultInfo &info : databaseResults()) {
-            if (info.file.isEmpty())
-                continue;
-            if (validReferenceNumber == 1)
-                references.append((!chatResponse.endsWith("\n") ? "\n" : QString()) + QStringLiteral("\n---"));
-            QString reference;
-            {
-                QTextStream stream(&reference);
-                stream << (validReferenceNumber++) << ". ";
-                if (!info.title.isEmpty())
-                    stream << "\"" << info.title << "\". ";
-                if (!info.author.isEmpty())
-                    stream << "By " << info.author << ". ";
-                if (!info.date.isEmpty())
-                    stream << "Date: " << info.date << ". ";
-                stream << "In " << info.file << ". ";
-                if (info.page != -1)
-                    stream << "Page " << info.page << ". ";
-                if (info.from != -1) {
-                    stream << "Lines " << info.from;
-                    if (info.to != -1)
-                        stream << "-" << info.to;
-                    stream << ". ";
-                }
-                stream << "[Context](context://" << validReferenceNumber - 1 << ")";
+    const QString chatResponse = response();
+    QList<QString> references;
+    QList<QString> referencesContext;
+    int validReferenceNumber = 1;
+    for (const ResultInfo &info : databaseResults()) {
+        if (info.file.isEmpty())
+            continue;
+        if (validReferenceNumber == 1)
+            references.append((!chatResponse.endsWith("\n") ? "\n" : QString()) + QStringLiteral("\n---"));
+        QString reference;
+        {
+            QTextStream stream(&reference);
+            stream << (validReferenceNumber++) << ". ";
+            if (!info.title.isEmpty())
+                stream << "\"" << info.title << "\". ";
+            if (!info.author.isEmpty())
+                stream << "By " << info.author << ". ";
+            if (!info.date.isEmpty())
+                stream << "Date: " << info.date << ". ";
+            stream << "In " << info.file << ". ";
+            if (info.page != -1)
+                stream << "Page " << info.page << ". ";
+            if (info.from != -1) {
+                stream << "Lines " << info.from;
+                if (info.to != -1)
+                    stream << "-" << info.to;
+                stream << ". ";
             }
-            references.append(reference);
-            referencesContext.append(info.text);
+            stream << "[Context](context://" << validReferenceNumber - 1 << ")";
         }
-
-        const int index = m_chatModel->count() - 1;
-        m_chatModel->updateReferences(index, references.join("\n"), referencesContext);
-        emit responseChanged();
+        references.append(reference);
+        referencesContext.append(info.text);
     }
+
+    const int index = m_chatModel->count() - 1;
+    m_chatModel->updateReferences(index, references.join("\n"), referencesContext);
+    emit responseChanged();
 
     m_responseInProgress = false;
     m_responseState = Chat::ResponseStopped;

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -885,7 +885,7 @@ Rectangle {
 
                     delegate: TextArea {
                         id: myTextArea
-                        text: value + references
+                        text: value + (MySettings.localDocsShowReferences ? references : "")
                         anchors.horizontalCenter: listView.contentItem.horizontalCenter
                         width: Math.min(1280, listView.contentItem.width)
                         color: {

--- a/gpt4all-chat/responsetext.h
+++ b/gpt4all-chat/responsetext.h
@@ -6,6 +6,7 @@
 #include <QQuickTextDocument>
 #include <QSyntaxHighlighter>
 #include <QRegularExpression>
+#include <QTextObjectInterface>
 
 class SyntaxHighlighter : public QSyntaxHighlighter {
     Q_OBJECT
@@ -27,6 +28,20 @@ struct CodeCopy {
     int endPos = -1;
     QString text;
 };
+
+class ContextLinkInterface : public QObject, public QTextObjectInterface
+{
+    Q_OBJECT
+    Q_INTERFACES(QTextObjectInterface)
+
+public:
+    explicit ContextLinkInterface(QObject *parent) : QObject(parent) {}
+    void drawObject(QPainter *painter, const QRectF &rect, QTextDocument *doc, int posInDocument,
+                    const QTextFormat &format) override;
+
+    QSizeF intrinsicSize(QTextDocument *doc, int posInDocument, const QTextFormat &format) override;
+};
+
 
 class ResponseText : public QObject
 {
@@ -61,6 +76,7 @@ private:
     QColor m_linkColor;
     QColor m_headerColor;
     bool m_isProcessingText = false;
+    ContextLinkInterface *m_contextLink;
 };
 
 #endif // RESPONSETEXT_H


### PR DESCRIPTION
This fixes two problems with current context links:

1) When you have a long conversation and each response has context links, scrolling to the bottom of the conversation can cause the context links to no longer work for the responses at the top.

2) The context links do not work across application loads.

This patch fixes both these issues by implementing the QTextObjectInterface which allows for insertion of custom objects in the QTextDocument.

...

The second patch makes the setting for 'showReferences' simply a cosmetic toggle for the view. This way we always capture the references across restarts.
