### PR TITLE
fix regressions in system prompt handling

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -503,7 +503,8 @@ class GPT4All:
             if fct_func is GPT4All._format_chat_prompt_template:
                 if reset:
                     # ingest system prompt
-                    self.model.prompt_model(self._history[0]["content"], "%1",
+                    # use "%1%2" and not "%1" to avoid implicit whitespace
+                    self.model.prompt_model(self._history[0]["content"], "%1%2",
                                             empty_response_callback,
                                             n_batch=n_batch, n_predict=0, reset_context=True, special=True)
                 prompt_template = self._current_prompt_template.format("%1", "%2")

--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -497,7 +497,6 @@ class GPT4All:
         if self._history is not None:
             # check if there is only one message, i.e. system prompt:
             reset = len(self._history) == 1
-            generate_kwargs["reset_context"] = reset
             self._history.append({"role": "user", "content": prompt})
 
             fct_func = self._format_chat_prompt_template.__func__  # type: ignore[attr-defined]
@@ -506,7 +505,7 @@ class GPT4All:
                     # ingest system prompt
                     self.model.prompt_model(self._history[0]["content"], "%1",
                                             empty_response_callback,
-                                            n_batch=n_batch, n_predict=0, special=True)
+                                            n_batch=n_batch, n_predict=0, reset_context=True, special=True)
                 prompt_template = self._current_prompt_template.format("%1", "%2")
             else:
                 warnings.warn(
@@ -519,6 +518,7 @@ class GPT4All:
                     self._history[0]["content"] if reset else "",
                 )
                 prompt_template = "%1"
+                generate_kwargs["reset_context"] = reset
         else:
             prompt_template = "%1"
             generate_kwargs["reset_context"] = True

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="2.5.1",
+    version="2.5.2",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The main issue is specific to the python bindings and is a regression since #1970 - reset_context was passed at the wrong time, causing context to be reset *after* ingesting the system prompt instead of immediately before. This meant that the system prompt had no effect.

The other fix in this PR makes sure we use `%1%2` with the system prompt so we don't add implicit whitespace that we assume templates without a `%2` should use. This was a minor regression in #1996, although I doubt it really hurt anything.

Fixes #2208