### PR TITLE
python: do not print GPU name with verbose=False, expose this info via properties

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -560,7 +560,7 @@ bool LLamaModel::initializeGPUDevice(int device, std::string *unavail_reason) co
 #endif
 }
 
-bool LLamaModel::hasGPUDevice()
+bool LLamaModel::hasGPUDevice() const
 {
 #if defined(GGML_USE_KOMPUTE)
     return d_ptr->device != -1;
@@ -569,7 +569,7 @@ bool LLamaModel::hasGPUDevice()
 #endif
 }
 
-bool LLamaModel::usingGPUDevice()
+bool LLamaModel::usingGPUDevice() const
 {
 #if defined(GGML_USE_KOMPUTE)
     bool hasDevice = hasGPUDevice() && d_ptr->model_params.n_gpu_layers > 0;
@@ -582,11 +582,11 @@ bool LLamaModel::usingGPUDevice()
 #endif
 }
 
-const char *LLamaModel::backendName() {
+const char *LLamaModel::backendName() const {
     return d_ptr->backend_name;
 }
 
-const char *LLamaModel::gpuDeviceName() {
+const char *LLamaModel::gpuDeviceName() const {
 #if defined(GGML_USE_KOMPUTE)
     if (usingGPUDevice()) {
         return ggml_vk_current_device().name;

--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -365,7 +365,9 @@ bool LLamaModel::loadModel(const std::string &modelPath, int n_ctx, int ngl)
 
 #ifdef GGML_USE_KOMPUTE
     if (usingGPUDevice() && ggml_vk_has_device()) {
-        std::cerr << "llama.cpp: using Vulkan on " << ggml_vk_current_device().name << std::endl;
+        if (llama_verbose()) {
+            std::cerr << "llama.cpp: using Vulkan on " << ggml_vk_current_device().name << std::endl;
+        }
         d_ptr->backend_name = "kompute";
     }
 #endif

--- a/gpt4all-backend/llamamodel_impl.h
+++ b/gpt4all-backend/llamamodel_impl.h
@@ -35,6 +35,8 @@ public:
     bool initializeGPUDevice(int device, std::string *unavail_reason = nullptr) const override;
     bool hasGPUDevice() override;
     bool usingGPUDevice() override;
+    const char *backendName() override;
+    const char *gpuDeviceName() override;
 
     size_t embeddingSize() const override;
     // user-specified prefix

--- a/gpt4all-backend/llamamodel_impl.h
+++ b/gpt4all-backend/llamamodel_impl.h
@@ -33,10 +33,10 @@ public:
     std::vector<GPUDevice> availableGPUDevices(size_t memoryRequired) const override;
     bool initializeGPUDevice(size_t memoryRequired, const std::string &name) const override;
     bool initializeGPUDevice(int device, std::string *unavail_reason = nullptr) const override;
-    bool hasGPUDevice() override;
-    bool usingGPUDevice() override;
-    const char *backendName() override;
-    const char *gpuDeviceName() override;
+    bool hasGPUDevice() const override;
+    bool usingGPUDevice() const override;
+    const char *backendName() const override;
+    const char *gpuDeviceName() const override;
 
     size_t embeddingSize() const override;
     // user-specified prefix

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -146,6 +146,8 @@ public:
 
     virtual bool hasGPUDevice() { return false; }
     virtual bool usingGPUDevice() { return false; }
+    virtual const char *backendName() { return "cpu"; }
+    virtual const char *gpuDeviceName() { return nullptr; }
 
     void setProgressCallback(ProgressCallback callback) { m_progressCallback = callback; }
 

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -144,10 +144,10 @@ public:
         return false;
     }
 
-    virtual bool hasGPUDevice() { return false; }
-    virtual bool usingGPUDevice() { return false; }
-    virtual const char *backendName() { return "cpu"; }
-    virtual const char *gpuDeviceName() { return nullptr; }
+    virtual bool hasGPUDevice() const { return false; }
+    virtual bool usingGPUDevice() const { return false; }
+    virtual const char *backendName() const { return "cpu"; }
+    virtual const char *gpuDeviceName() const { return nullptr; }
 
     void setProgressCallback(ProgressCallback callback) { m_progressCallback = callback; }
 

--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -283,18 +283,18 @@ bool llmodel_gpu_init_gpu_device_by_int(llmodel_model model, int device)
 
 bool llmodel_has_gpu_device(llmodel_model model)
 {
-    auto *wrapper = static_cast<LLModelWrapper *>(model);
+    const auto *wrapper = static_cast<LLModelWrapper *>(model);
     return wrapper->llModel->hasGPUDevice();
 }
 
 const char *llmodel_model_backend_name(llmodel_model model)
 {
-    auto *wrapper = static_cast<LLModelWrapper *>(model);
+    const auto *wrapper = static_cast<LLModelWrapper *>(model);
     return wrapper->llModel->backendName();
 }
 
 const char *llmodel_model_gpu_device_name(llmodel_model model)
 {
-    auto *wrapper = static_cast<LLModelWrapper *>(model);
+    const auto *wrapper = static_cast<LLModelWrapper *>(model);
     return wrapper->llModel->gpuDeviceName();
 }

--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -286,3 +286,15 @@ bool llmodel_has_gpu_device(llmodel_model model)
     auto *wrapper = static_cast<LLModelWrapper *>(model);
     return wrapper->llModel->hasGPUDevice();
 }
+
+const char *llmodel_model_backend_name(llmodel_model model)
+{
+    auto *wrapper = static_cast<LLModelWrapper *>(model);
+    return wrapper->llModel->backendName();
+}
+
+const char *llmodel_model_gpu_device_name(llmodel_model model)
+{
+    auto *wrapper = static_cast<LLModelWrapper *>(model);
+    return wrapper->llModel->gpuDeviceName();
+}

--- a/gpt4all-backend/llmodel_c.h
+++ b/gpt4all-backend/llmodel_c.h
@@ -295,6 +295,16 @@ bool llmodel_gpu_init_gpu_device_by_int(llmodel_model model, int device);
  */
 bool llmodel_has_gpu_device(llmodel_model model);
 
+/**
+ * @return The name of the llama.cpp backend currently in use. One of "cpu", "kompute", or "metal".
+ */
+const char *llmodel_model_backend_name(llmodel_model model);
+
+/**
+ * @return The name of the GPU device currently in use, or NULL for backends other than Kompute.
+ */
+const char *llmodel_model_gpu_device_name(llmodel_model model);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -232,10 +232,14 @@ class LLModel:
 
     @property
     def backend(self) -> Literal["cpu", "kompute", "metal"]:
+        if self.model is None:
+            self._raise_closed()
         return llmodel.llmodel_model_backend_name(self.model).decode()
 
     @property
     def device(self) -> str | None:
+        if self.model is None:
+            self._raise_closed()
         dev = llmodel.llmodel_model_gpu_device_name(self.model)
         return None if dev is None else dev.decode()
 

--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -227,6 +227,16 @@ class GPT4All:
         self.model.close()
 
     @property
+    def backend(self) -> Literal["cpu", "kompute", "metal"]:
+        """The name of the llama.cpp backend currently in use. One of "cpu", "kompute", or "metal"."""
+        return self.model.backend
+
+    @property
+    def device(self) -> str | None:
+        """The name of the GPU device currently in use, or None for backends other than Kompute."""
+        return self.model.device
+
+    @property
     def current_chat_session(self) -> list[MessageType] | None:
         return None if self._history is None else list(self._history)
 

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="2.5.2",
+    version="2.6.0",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Before:
```
>>> model = GPT4All('orca-mini-3b-gguf2-q4_0.gguf', device='gpu')
llama.cpp: using Vulkan on NVIDIA GeForce GTX 970
```

After:
```
>>> model = GPT4All('orca-mini-3b-gguf2-q4_0.gguf', device='gpu')
>>> model.backend
'kompute'
>>> model.device
'NVIDIA GeForce GTX 970'
```

The message can still be enabled with `GPT4ALL_VERBOSE_LLAMACPP=1`, which is how the Metal print worked already.