### PR TITLE
localdocs: small but important fixes to local docs

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -283,10 +283,10 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
             QString modelName;
             {
                 QFile file(filePath);
-                file.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text);
-                QTextStream stream(&file);
-                QString text = stream.readAll();
-                QJsonDocument doc = QJsonDocument::fromJson(text.toUtf8());
+                bool success = file.open(QIODeviceBase::ReadOnly);
+                (void)success;
+                Q_ASSERT(success);
+                QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
                 QJsonObject obj = doc.object();
                 apiKey = obj["apiKey"].toString();
                 modelName = obj["modelName"].toString();

--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -410,8 +410,8 @@ bool updateDocument(QSqlQuery &q, int id, qint64 document_time)
 {
     if (!q.prepare(UPDATE_DOCUMENT_TIME_SQL))
         return false;
-    q.addBindValue(id);
     q.addBindValue(document_time);
+    q.addBindValue(id);
     return q.exec();
 }
 

--- a/gpt4all-chat/embllm.cpp
+++ b/gpt4all-chat/embllm.cpp
@@ -42,12 +42,17 @@ bool EmbeddingLLMWorker::loadModel()
     }
 
     auto filename = fileInfo.fileName();
-    bool isNomic = filename.startsWith("nomic-") && filename.endsWith(".txt");
+    bool isNomic = filename.startsWith("gpt4all-nomic-") && filename.endsWith(".rmodel");
     if (isNomic) {
         QFile file(filePath);
-        file.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text);
-        QTextStream stream(&file);
-        m_nomicAPIKey = stream.readAll();
+        if (!file.open(QIODeviceBase::ReadOnly)) {
+            qWarning() << "failed to open" << filePath << ":" << file.errorString();
+            m_model = nullptr;
+            return false;
+        }
+        QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+        QJsonObject obj = doc.object();
+        m_nomicAPIKey = obj["apiKey"].toString();
         file.close();
         return true;
     }

--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -12,7 +12,7 @@
 
 const char * const KNOWN_EMBEDDING_MODELS[] {
     "all-MiniLM-L6-v2.gguf2.f16.gguf",
-    "nomic-embed-text-v1.txt",
+    "gpt4all-nomic-embed-text-v1.rmodel",
 };
 
 QString ModelInfo::id() const
@@ -1178,7 +1178,7 @@ void ModelList::updateModelsFromDirectory()
             it.next();
             if (!it.fileInfo().isDir()) {
                 QString filename = it.fileName();
-                if (filename.startsWith("chatgpt-") && filename.endsWith(".txt")) {
+                if (filename.endsWith(".txt") && (filename.startsWith("chatgpt-") || filename.startsWith("nomic-"))) {
                     QString apikey;
                     QString modelname(filename);
                     modelname.chop(4); // strip ".txt" extension
@@ -1648,7 +1648,7 @@ void ModelList::parseModelsJsonFile(const QByteArray &jsonData, bool save)
             "<li>You can apply for an API key <a href=\"https://atlas.nomic.ai/\">with Nomic Atlas.</a></li>");
         const QString modelName = "Nomic Embed";
         const QString id = modelName;
-        const QString modelFilename = "nomic-embed-text-v1.txt"; // FIXME: This should be made to use '.rmodel' as well
+        const QString modelFilename = "gpt4all-nomic-embed-text-v1.rmodel";
         if (contains(modelFilename))
             changeId(modelFilename, id);
         if (!contains(id))


### PR DESCRIPTION
- Use new `.rmodel` format for remote Nomic Embed so it can be used again.

- Fix swapped arguments in updateDocument so that documents are not reindexed on future starts if they have been updated once. On startup, this could result in excessive CPU usage and excessive token usage on the Atlas API in certain cases, e.g. when a document has been copied into the localdocs folder while GPT4All is running.