### PR TITLE
mixpanel: fix doc_collections_total of localdocs_startup

### DIFF
--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -972,7 +972,7 @@ int Database::addCurrentFolders()
 
     updateIndexingStatus();
 
-    return nAdded;
+    return collections.count() + nAdded;
 }
 
 bool Database::addFolder(const QString &collection, const QString &path, bool fromDb)


### PR DESCRIPTION
doc_collections_total is almost always zero on this event without this fix. At least doc_collections_total on send_message is working correctly.