### PR TITLE
localdocs: load model before checking which model is loaded

### DIFF
--- a/gpt4all-chat/embllm.cpp
+++ b/gpt4all-chat/embllm.cpp
@@ -97,7 +97,7 @@ bool EmbeddingLLMWorker::isNomic() const
 // this function is always called for retrieval tasks
 std::vector<float> EmbeddingLLMWorker::generateSyncEmbedding(const QString &text)
 {
-    Q_ASSERT(isNomic());
+    Q_ASSERT(!isNomic());
     std::vector<float> embedding(m_model->embeddingSize());
     try {
         m_model->embed({text.toStdString()}, embedding.data(), true);


### PR DESCRIPTION
Fixes "WARNING: Request to generate sync embeddings for non-local model invalid" when using Nomic Embed.