### PR TITLE
mixpanel: fix opt-out events after #2238

### DIFF
--- a/gpt4all-chat/network.cpp
+++ b/gpt4all-chat/network.cpp
@@ -228,7 +228,7 @@ void Network::sendOptOut()
 
     QJsonDocument doc;
     doc.setArray(array);
-    emit requestMixpanel(doc.toJson(QJsonDocument::Compact), true /*isOptOut*/);
+    emit requestMixpanel(doc.toJson(QJsonDocument::Compact));
 
 #if defined(DEBUG)
     printf("%s %s\n", qPrintable("opt_out"), qPrintable(doc.toJson(QJsonDocument::Indented)));
@@ -339,11 +339,8 @@ void Network::sendIpify()
     connect(reply, &QNetworkReply::finished, this, &Network::handleIpifyFinished);
 }
 
-void Network::sendMixpanel(const QByteArray &json, bool isOptOut)
+void Network::sendMixpanel(const QByteArray &json)
 {
-    if (!m_sendUsageStats)
-        return;
-
     QUrl trackUrl("https://api.mixpanel.com/track");
     QNetworkRequest request(trackUrl);
     QSslConfiguration conf = request.sslConfiguration();

--- a/gpt4all-chat/network.h
+++ b/gpt4all-chat/network.h
@@ -37,7 +37,7 @@ private Q_SLOTS:
     void handleMixpanelFinished();
     void handleIsActiveChanged();
     void handleUsageStatsActiveChanged();
-    void sendMixpanel(const QByteArray &json, bool isOptOut);
+    void sendMixpanel(const QByteArray &json);
 
 private:
     void sendOptOut();


### PR DESCRIPTION
It turns out that we have not been sending any opt-out events since v2.7.4. I relied too much on the #ifdef-ed out debug prints while testing this code, so I didn't notice this.