### PR TITLE
mixpanel: improved GPU device statistics (plus GPU sort order fix)

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -346,6 +346,11 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
 
                 emit reportFallbackReason(""); // no fallback yet
 
+                auto approxDeviceMemGB = [](const LLModel::GPUDevice *dev) {
+                    float memGB = dev->heapSize / float(1024 * 1024 * 1024);
+                    return std::floor(memGB * 10.f) / 10.f; // truncate to 1 decimal place
+                };
+
                 std::vector<LLModel::GPUDevice> availableDevices;
                 const LLModel::GPUDevice *defaultDevice = nullptr;
                 {
@@ -356,7 +361,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                         float memGB = defaultDevice->heapSize / float(1024 * 1024 * 1024);
                         memGB = std::floor(memGB * 10.f) / 10.f; // truncate to 1 decimal place
                         modelLoadProps.insert("default_device", QString::fromStdString(defaultDevice->name));
-                        modelLoadProps.insert("default_device_mem", memGB);
+                        modelLoadProps.insert("default_device_mem", approxDeviceMemGB(defaultDevice));
                     }
                 }
 
@@ -383,6 +388,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                         emit reportFallbackReason(QString::fromStdString("<br>" + unavail_reason));
                     } else {
                         actualDevice = QString::fromStdString(device->name);
+                        modelLoadProps.insert("requested_device_mem", approxDeviceMemGB(device));
                     }
                 }
 

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -7,6 +7,16 @@
 #include "mysettings.h"
 #include "../gpt4all-backend/llmodel.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <QElapsedTimer>
 
 //#define DEBUG

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -344,20 +344,31 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     return m_shouldBeLoaded;
                 });
 
-                // Pick the best match for the device
-                QString actualDevice = m_llModelInfo.model->implementation().buildVariant() == "metal" ? "Metal" : "CPU";
-                const QString requestedDevice = MySettings::globalInstance()->device();
-                if (requestedDevice == "CPU") {
-                    emit reportFallbackReason(""); // fallback not applicable
-                } else {
-                    const size_t requiredMemory = m_llModelInfo.model->requiredMem(filePath.toStdString(), n_ctx, ngl);
-                    std::vector<LLModel::GPUDevice> availableDevices = m_llModelInfo.model->availableGPUDevices(requiredMemory);
-                    LLModel::GPUDevice *device = nullptr;
+                emit reportFallbackReason(""); // no fallback yet
 
-                    if (!availableDevices.empty() && requestedDevice == "Auto" && availableDevices.front().type == 2 /*a discrete gpu*/) {
-                        device = &availableDevices.front();
-                    } else {
-                        for (LLModel::GPUDevice &d : availableDevices) {
+                std::vector<LLModel::GPUDevice> availableDevices;
+                const LLModel::GPUDevice *defaultDevice = nullptr;
+                {
+                    const size_t requiredMemory = m_llModelInfo.model->requiredMem(filePath.toStdString(), n_ctx, ngl);
+                    availableDevices = m_llModelInfo.model->availableGPUDevices(requiredMemory);
+                    if (!availableDevices.empty() && availableDevices.front().type == 2 /*a discrete gpu*/) {
+                        defaultDevice = &availableDevices.front();
+                        float memGB = defaultDevice->heapSize / float(1024 * 1024 * 1024);
+                        memGB = std::floor(memGB * 10.f) / 10.f; // truncate to 1 decimal place
+                        modelLoadProps.insert("default_device", QString::fromStdString(defaultDevice->name));
+                        modelLoadProps.insert("default_device_mem", memGB);
+                    }
+                }
+
+                const QString requestedDevice = MySettings::globalInstance()->device();
+                bool isMetal = m_llModelInfo.model->implementation().buildVariant() == "metal";
+
+                // Pick the best match for the device
+                QString actualDevice = isMetal ? "Metal" : "CPU";
+                if (!isMetal && requestedDevice != "CPU") {
+                    const auto *device = defaultDevice;
+                    if (requestedDevice != "Auto") {
+                        for (const LLModel::GPUDevice &d : availableDevices) {
                             if (QString::fromStdString(d.name) == requestedDevice) {
                                 device = &d;
                                 break;
@@ -365,7 +376,6 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                         }
                     }
 
-                    emit reportFallbackReason(""); // no fallback yet
                     std::string unavail_reason;
                     if (!device) {
                         // GPU not available


### PR DESCRIPTION
Added properties to `model_load` event:
- `default_device`: what GPU would have been chosen if "Auto" were selected (unset if none available)
- `default_device_mem`: how much VRAM said GPU has in GiB, rounded down to the nearest 100MiB (e.g. `3.2`)
- `requested_device_mem`: how much VRAM the device the user has requested has in GiB

Other changes:
- Pick the GPU with the most VRAM by default, not the least (GPT4All has been wanting to use my GTX 970 instead of my P40 until now)
- Do not search for a device named "Metal" on macOS devices (there won't be any devices anyway)
- If somehow the requested GPU does not exist, use the default GPU instead of the CPU (shouldn't happen in practice but it makes the code simpler)