### PR TITLE
chat: do not allow sending a message while the LLM is responding

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1408,11 +1408,11 @@ Rectangle {
                 Accessible.role: Accessible.EditableText
                 Accessible.name: placeholderText
                 Accessible.description: qsTr("Send messages/prompts to the model")
-                Keys.onReturnPressed: (event)=> {
-                    if (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.ShiftModifier)
-                        event.accepted = false;
-                    else {
-                        editingFinished();
+                Keys.onReturnPressed: (event) => {
+                    if (event.modifiers & Qt.ControlModifier || event.modifiers & Qt.ShiftModifier) {
+                        event.accepted = false
+                    } else if (!currentChat.responseInProgress) {
+                        editingFinished()
                         sendMessage()
                     }
                 }
@@ -1482,6 +1482,7 @@ Rectangle {
             width: 30
             height: 30
             visible: !currentChat.isServer
+            enabled: !currentChat.responseInProgress
             source: "qrc:/gpt4all/icons/send_message.svg"
             Accessible.name: qsTr("Send message")
             Accessible.description: qsTr("Sends the message/prompt contained in textfield to the model")


### PR DESCRIPTION
In the current release of GPT4All, it is possible to send a message while the LLM is generating a response, with strange results. Don't allow the user to do this.