### PR TITLE
ChatView: make context menus more intuitive

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1069,7 +1069,7 @@ Rectangle {
                             anchors.fill: parent
                             acceptedButtons: Qt.RightButton
 
-                            onClicked: {
+                            onClicked: (mouse) => {
                                 if (mouse.button === Qt.RightButton) {
                                     conversationContextMenu.x = conversationMouseArea.mouseX
                                     conversationContextMenu.y = conversationMouseArea.mouseY
@@ -1441,7 +1441,7 @@ Rectangle {
                     anchors.fill: parent
                     acceptedButtons: Qt.RightButton
 
-                    onClicked: {
+                    onClicked: (mouse) => {
                         if (mouse.button === Qt.RightButton) {
                             textInputContextMenu.x = textInputMouseArea.mouseX
                             textInputContextMenu.y = textInputMouseArea.mouseY

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1082,11 +1082,19 @@ Rectangle {
                             id: conversationContextMenu
                             MenuItem {
                                 text: qsTr("Copy")
+                                enabled: myTextArea.selectedText !== ""
+                                height: enabled ? implicitHeight : 0
                                 onTriggered: myTextArea.copy()
                             }
                             MenuItem {
-                                text: qsTr("Select All")
-                                onTriggered: myTextArea.selectAll()
+                                text: qsTr("Copy Message")
+                                enabled: myTextArea.selectedText === ""
+                                height: enabled ? implicitHeight : 0
+                                onTriggered: {
+                                    myTextArea.selectAll()
+                                    myTextArea.copy()
+                                    myTextArea.deselect()
+                                }
                             }
                         }
 
@@ -1454,10 +1462,14 @@ Rectangle {
                     id: textInputContextMenu
                     MenuItem {
                         text: qsTr("Cut")
+                        enabled: textInput.selectedText !== ""
+                        height: enabled ? implicitHeight : 0
                         onTriggered: textInput.cut()
                     }
                     MenuItem {
                         text: qsTr("Copy")
+                        enabled: textInput.selectedText !== ""
+                        height: enabled ? implicitHeight : 0
                         onTriggered: textInput.copy()
                     }
                     MenuItem {


### PR DESCRIPTION
I had some trouble understanding the context menus in the chat initially. I saw a "Copy" button and was confused when it did nothing.

What this button actually does is copy the current selection. Buttons like Copy and Cut in the context menus are now hidden when nothing is selected in order to make this more obvious.

Additionally, "Select All" on a chat message has been replaced with "Copy Message", which reduces the number of clicks required to copy an entire message from four to two.