### PR TITLE
chat: fix issues with the initial "New Chat"

### DIFF
--- a/gpt4all-chat/chatlistmodel.cpp
+++ b/gpt4all-chat/chatlistmodel.cpp
@@ -15,7 +15,9 @@ ChatListModel *ChatListModel::globalInstance()
 }
 
 ChatListModel::ChatListModel()
-    : QAbstractListModel(nullptr)
+    : QAbstractListModel(nullptr) {}
+
+void ChatListModel::loadChats()
 {
     addChat();
 
@@ -26,7 +28,6 @@ ChatListModel::ChatListModel()
     thread->start();
 
     connect(MySettings::globalInstance(), &MySettings::serverChatChanged, this, &ChatListModel::handleServerEnabledChanged);
-
 }
 
 void ChatListModel::removeChatFile(Chat *chat) const

--- a/gpt4all-chat/chatlistmodel.cpp
+++ b/gpt4all-chat/chatlistmodel.cpp
@@ -22,8 +22,8 @@ void ChatListModel::loadChats()
     addChat();
 
     ChatsRestoreThread *thread = new ChatsRestoreThread;
-    connect(thread, &ChatsRestoreThread::chatRestored, this, &ChatListModel::restoreChat);
-    connect(thread, &ChatsRestoreThread::finished, this, &ChatListModel::chatsRestoredFinished);
+    connect(thread, &ChatsRestoreThread::chatRestored, this, &ChatListModel::restoreChat, Qt::QueuedConnection);
+    connect(thread, &ChatsRestoreThread::finished, this, &ChatListModel::chatsRestoredFinished, Qt::QueuedConnection);
     connect(thread, &ChatsRestoreThread::finished, thread, &QObject::deleteLater);
     thread->start();
 

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -83,9 +83,11 @@ public:
 
     Q_INVOKABLE void addChat()
     {
-        // Don't add a new chat if we already have one
-        if (m_newChat)
+        // Select the existing new chat if we already have one
+        if (m_newChat) {
+            setCurrentChat(m_newChat);
             return;
+        }
 
         // Create a new chat pointer and connect it to determine when it is populated
         m_newChat = new Chat(this);

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -81,6 +81,8 @@ public:
     bool shouldSaveChatGPTChats() const;
     void setShouldSaveChatGPTChats(bool b);
 
+    Q_INVOKABLE void loadChats();
+
     Q_INVOKABLE void addChat()
     {
         // Select the existing new chat if we already have one

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -114,20 +114,6 @@ public:
         emit countChanged();
     }
 
-    void setNewChat(Chat* chat)
-    {
-        // Don't add a new chat if we already have one
-        if (m_newChat)
-            return;
-
-        m_newChat = chat;
-        connect(m_newChat->chatModel(), &ChatModel::countChanged,
-            this, &ChatListModel::newChatCountChanged);
-        connect(m_newChat, &Chat::nameChanged,
-            this, &ChatListModel::nameChanged);
-        setCurrentChat(m_newChat);
-    }
-
     Q_INVOKABLE void removeChat(Chat* chat)
     {
         Q_ASSERT(chat != m_serverChat);

--- a/gpt4all-chat/qml/ChatDrawer.qml
+++ b/gpt4all-chat/qml/ChatDrawer.qml
@@ -61,6 +61,9 @@ Rectangle {
                 anchors.fill: parent
                 anchors.rightMargin: 10
                 model: ChatListModel
+
+                Component.onCompleted: ChatListModel.loadChats()
+
                 ScrollBar.vertical: ScrollBar {
                     parent: conversationList.parent
                     anchors.top: conversationList.top

--- a/gpt4all-chat/qml/ChatDrawer.qml
+++ b/gpt4all-chat/qml/ChatDrawer.qml
@@ -39,7 +39,8 @@ Rectangle {
             text: qsTr("\uFF0B New chat")
             Accessible.description: qsTr("Create a new chat")
             onClicked: {
-                ChatListModel.addChat();
+                ChatListModel.addChat()
+                conversationList.positionViewAtIndex(0, ListView.Beginning)
                 Network.trackEvent("new_chat", {"number_of_chats": ChatListModel.count})
             }
         }


### PR DESCRIPTION
At startup:
- Wait until the conversationList view has been connected to the ChatListModel before adding any chats to the list. Otherwise, the initial "New Chat" tends to be scrolled just above the top of the view if the user has enough chats.

When the "New chat" button is clicked:
- If there is already a new chat, select the existing new chat instead of doing nothing. Buttons that do nothing are frustrating.
- When the new chat button is clicked, always scroll to the top of the list, so the chat is visible.

Also, make the connections to ChatRestoreThread explicitly queued. I'm pretty sure m_chats was being modified from more than one thread without this change.