### PR TITLE
chatllm: fix model loading progress showing "Reload" sometimes

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -350,6 +350,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                 }
 
                 m_llModelInfo.model->setProgressCallback([this](float progress) -> bool {
+                    progress = std::max(progress, std::numeric_limits<float>::min()); // keep progress above zero
                     emit modelLoadingPercentageChanged(progress);
                     return m_shouldBeLoaded;
                 });


### PR DESCRIPTION
This is mostly only visible on macOS, where the Metal backend has a stuttery progress report, typically reporting 0%, then some small percentage, and then quickly jumping to 100% (although not skipping the steps in between).

This change prevents a visible "Reload" prompt from showing when llama.cpp reports 0% progress.