### PR TITLE
chat: fix issues with quickly switching between multiple chats

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -313,7 +313,7 @@ void Chat::forceReloadModel()
 
 void Chat::trySwitchContextOfLoadedModel()
 {
-    m_trySwitchContextInProgress = true;
+    m_trySwitchContextInProgress = 1;
     emit trySwitchContextInProgressChanged();
     m_llmodel->setShouldTrySwitchContext(true);
 }
@@ -376,8 +376,8 @@ void Chat::handleModelInfoChanged(const ModelInfo &modelInfo)
     emit modelInfoChanged();
 }
 
-void Chat::handleTrySwitchContextOfLoadedModelCompleted() {
-    m_trySwitchContextInProgress = false;
+void Chat::handleTrySwitchContextOfLoadedModelCompleted(int value) {
+    m_trySwitchContextInProgress = value;
     emit trySwitchContextInProgressChanged();
 }
 

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -54,7 +54,7 @@ void Chat::connectLLM()
     connect(m_llmodel, &ChatLLM::reportFallbackReason, this, &Chat::handleFallbackReasonChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::databaseResultsChanged, this, &Chat::handleDatabaseResultsChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::modelInfoChanged, this, &Chat::handleModelInfoChanged, Qt::QueuedConnection);
-    connect(m_llmodel, &ChatLLM::trySwitchContextOfLoadedModelCompleted, this, &Chat::trySwitchContextOfLoadedModelCompleted, Qt::QueuedConnection);
+    connect(m_llmodel, &ChatLLM::trySwitchContextOfLoadedModelCompleted, this, &Chat::handleTrySwitchContextOfLoadedModelCompleted, Qt::QueuedConnection);
 
     connect(this, &Chat::promptRequested, m_llmodel, &ChatLLM::prompt, Qt::QueuedConnection);
     connect(this, &Chat::modelChangeRequested, m_llmodel, &ChatLLM::modelChangeRequested, Qt::QueuedConnection);
@@ -320,7 +320,8 @@ void Chat::forceReloadModel()
 
 void Chat::trySwitchContextOfLoadedModel()
 {
-    emit trySwitchContextOfLoadedModelAttempted();
+    m_trySwitchContextInProgress = true;
+    emit trySwitchContextInProgressChanged();
     m_llmodel->setShouldTrySwitchContext(true);
 }
 
@@ -378,6 +379,11 @@ void Chat::handleModelInfoChanged(const ModelInfo &modelInfo)
 
     m_modelInfo = modelInfo;
     emit modelInfoChanged();
+}
+
+void Chat::handleTrySwitchContextOfLoadedModelCompleted() {
+    m_trySwitchContextInProgress = false;
+    emit trySwitchContextInProgressChanged();
 }
 
 bool Chat::serialize(QDataStream &stream, int version) const

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -95,16 +95,6 @@ void Chat::processSystemPrompt()
     emit processSystemPromptRequested();
 }
 
-bool Chat::isModelLoaded() const
-{
-    return m_modelLoadingPercentage == 1.0f;
-}
-
-float Chat::modelLoadingPercentage() const
-{
-    return m_modelLoadingPercentage;
-}
-
 void Chat::resetResponseState()
 {
     if (m_responseInProgress && m_responseState == Chat::LocalDocsRetrieval)
@@ -167,9 +157,16 @@ void Chat::handleModelLoadingPercentageChanged(float loadingPercentage)
     if (loadingPercentage == m_modelLoadingPercentage)
         return;
 
+    bool wasLoading = isCurrentlyLoading();
+    bool wasLoaded = isModelLoaded();
+
     m_modelLoadingPercentage = loadingPercentage;
     emit modelLoadingPercentageChanged();
-    if (m_modelLoadingPercentage == 1.0f || m_modelLoadingPercentage == 0.0f)
+
+    if (isCurrentlyLoading() != wasLoading)
+        emit isCurrentlyLoadingChanged();
+
+    if (isModelLoaded() != wasLoaded)
         emit isModelLoadedChanged();
 }
 
@@ -248,11 +245,15 @@ void Chat::setModelInfo(const ModelInfo &modelInfo)
         return;
 
     m_modelLoadingPercentage = std::numeric_limits<float>::min(); // small non-zero positive value
+    emit modelLoadingPercentageChanged();
     emit isModelLoadedChanged();
+
     m_modelLoadingError = QString();
     emit modelLoadingErrorChanged();
+
     m_modelInfo = modelInfo;
     emit modelInfoChanged();
+
     emit modelChangeRequested(modelInfo);
 }
 

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -315,7 +315,7 @@ void Chat::trySwitchContextOfLoadedModel()
 {
     m_trySwitchContextInProgress = 1;
     emit trySwitchContextInProgressChanged();
-    m_llmodel->setShouldTrySwitchContext(true);
+    m_llmodel->requestTrySwitchContext();
 }
 
 void Chat::generatedNameChanged(const QString &name)

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -244,16 +244,8 @@ void Chat::setModelInfo(const ModelInfo &modelInfo)
     if (m_modelInfo == modelInfo && isModelLoaded())
         return;
 
-    m_modelLoadingPercentage = std::numeric_limits<float>::min(); // small non-zero positive value
-    emit modelLoadingPercentageChanged();
-    emit isModelLoadedChanged();
-
-    m_modelLoadingError = QString();
-    emit modelLoadingErrorChanged();
-
     m_modelInfo = modelInfo;
     emit modelInfoChanged();
-
     emit modelChangeRequested(modelInfo);
 }
 
@@ -344,8 +336,10 @@ void Chat::handleRecalculating()
 
 void Chat::handleModelLoadingError(const QString &error)
 {
-    auto stream = qWarning().noquote() << "ERROR:" << error << "id";
-    stream.quote() << id();
+    if (!error.isEmpty()) {
+        auto stream = qWarning().noquote() << "ERROR:" << error << "id";
+        stream.quote() << id();
+    }
     m_modelLoadingError = error;
     emit modelLoadingErrorChanged();
 }

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -31,7 +31,8 @@ class Chat : public QObject
     Q_PROPERTY(QString device READ device NOTIFY deviceChanged);
     Q_PROPERTY(QString fallbackReason READ fallbackReason NOTIFY fallbackReasonChanged);
     Q_PROPERTY(LocalDocsCollectionsModel *collectionModel READ collectionModel NOTIFY collectionModelChanged)
-    Q_PROPERTY(bool trySwitchContextInProgress READ trySwitchContextInProgress NOTIFY trySwitchContextInProgressChanged)
+    // 0=no, 1=waiting, 2=working
+    Q_PROPERTY(int trySwitchContextInProgress READ trySwitchContextInProgress NOTIFY trySwitchContextInProgressChanged)
     QML_ELEMENT
     QML_UNCREATABLE("Only creatable from c++!")
 
@@ -108,7 +109,7 @@ public:
     QString device() const { return m_device; }
     QString fallbackReason() const { return m_fallbackReason; }
 
-    bool trySwitchContextInProgress() const { return m_trySwitchContextInProgress; }
+    int trySwitchContextInProgress() const { return m_trySwitchContextInProgress; }
 
 public Q_SLOTS:
     void serverNewPromptResponsePair(const QString &prompt);
@@ -142,7 +143,6 @@ Q_SIGNALS:
     void deviceChanged();
     void fallbackReasonChanged();
     void collectionModelChanged();
-    void trySwitchContextOfLoadedModelCompleted(bool);
     void trySwitchContextInProgressChanged();
 
 private Q_SLOTS:
@@ -158,7 +158,7 @@ private Q_SLOTS:
     void handleFallbackReasonChanged(const QString &device);
     void handleDatabaseResultsChanged(const QList<ResultInfo> &results);
     void handleModelInfoChanged(const ModelInfo &modelInfo);
-    void handleTrySwitchContextOfLoadedModelCompleted();
+    void handleTrySwitchContextOfLoadedModelCompleted(int value);
 
 private:
     QString m_id;
@@ -183,7 +183,7 @@ private:
     float m_modelLoadingPercentage = 0.0f;
     LocalDocsCollectionsModel *m_collectionModel;
     bool m_firstResponse = true;
-    bool m_trySwitchContextInProgress = false;
+    int m_trySwitchContextInProgress = 0;
     bool m_isCurrentlyLoading = false;
 };
 

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -17,6 +17,7 @@ class Chat : public QObject
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
     Q_PROPERTY(ChatModel *chatModel READ chatModel NOTIFY chatModelChanged)
     Q_PROPERTY(bool isModelLoaded READ isModelLoaded NOTIFY isModelLoadedChanged)
+    Q_PROPERTY(bool isCurrentlyLoading READ isCurrentlyLoading NOTIFY isCurrentlyLoadingChanged)
     Q_PROPERTY(float modelLoadingPercentage READ modelLoadingPercentage NOTIFY modelLoadingPercentageChanged)
     Q_PROPERTY(QString response READ response NOTIFY responseChanged)
     Q_PROPERTY(ModelInfo modelInfo READ modelInfo WRITE setModelInfo NOTIFY modelInfoChanged)
@@ -63,8 +64,9 @@ public:
 
     Q_INVOKABLE void reset();
     Q_INVOKABLE void processSystemPrompt();
-    Q_INVOKABLE bool isModelLoaded() const;
-    Q_INVOKABLE float modelLoadingPercentage() const;
+    bool  isModelLoaded()          const { return m_modelLoadingPercentage == 1.0f; }
+    bool  isCurrentlyLoading()     const { return m_modelLoadingPercentage > 0.0f && m_modelLoadingPercentage < 1.0f; }
+    float modelLoadingPercentage() const { return m_modelLoadingPercentage; }
     Q_INVOKABLE void prompt(const QString &prompt);
     Q_INVOKABLE void regenerateResponse();
     Q_INVOKABLE void stopGenerating();
@@ -116,6 +118,7 @@ Q_SIGNALS:
     void nameChanged();
     void chatModelChanged();
     void isModelLoadedChanged();
+    void isCurrentlyLoadingChanged();
     void modelLoadingPercentageChanged();
     void modelLoadingWarning(const QString &warning);
     void responseChanged();
@@ -181,6 +184,7 @@ private:
     LocalDocsCollectionsModel *m_collectionModel;
     bool m_firstResponse = true;
     bool m_trySwitchContextInProgress = false;
+    bool m_isCurrentlyLoading = false;
 };
 
 #endif // CHAT_H

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -30,6 +30,7 @@ class Chat : public QObject
     Q_PROPERTY(QString device READ device NOTIFY deviceChanged);
     Q_PROPERTY(QString fallbackReason READ fallbackReason NOTIFY fallbackReasonChanged);
     Q_PROPERTY(LocalDocsCollectionsModel *collectionModel READ collectionModel NOTIFY collectionModelChanged)
+    Q_PROPERTY(bool trySwitchContextInProgress READ trySwitchContextInProgress NOTIFY trySwitchContextInProgressChanged)
     QML_ELEMENT
     QML_UNCREATABLE("Only creatable from c++!")
 
@@ -105,6 +106,8 @@ public:
     QString device() const { return m_device; }
     QString fallbackReason() const { return m_fallbackReason; }
 
+    bool trySwitchContextInProgress() const { return m_trySwitchContextInProgress; }
+
 public Q_SLOTS:
     void serverNewPromptResponsePair(const QString &prompt);
 
@@ -136,8 +139,8 @@ Q_SIGNALS:
     void deviceChanged();
     void fallbackReasonChanged();
     void collectionModelChanged();
-    void trySwitchContextOfLoadedModelAttempted();
     void trySwitchContextOfLoadedModelCompleted(bool);
+    void trySwitchContextInProgressChanged();
 
 private Q_SLOTS:
     void handleResponseChanged(const QString &response);
@@ -152,6 +155,7 @@ private Q_SLOTS:
     void handleFallbackReasonChanged(const QString &device);
     void handleDatabaseResultsChanged(const QList<ResultInfo> &results);
     void handleModelInfoChanged(const ModelInfo &modelInfo);
+    void handleTrySwitchContextOfLoadedModelCompleted();
 
 private:
     QString m_id;
@@ -176,6 +180,7 @@ private:
     float m_modelLoadingPercentage = 0.0f;
     LocalDocsCollectionsModel *m_collectionModel;
     bool m_firstResponse = true;
+    bool m_trySwitchContextInProgress = false;
 };
 
 #endif // CHAT_H

--- a/gpt4all-chat/chatlistmodel.h
+++ b/gpt4all-chat/chatlistmodel.h
@@ -195,7 +195,11 @@ public:
     int count() const { return m_chats.size(); }
 
     // stop ChatLLM threads for clean shutdown
-    void destroyChats() { for (auto *chat: m_chats) { chat->destroy(); } }
+    void destroyChats()
+    {
+        for (auto *chat: m_chats) { chat->destroy(); }
+        ChatLLM::destroyStore();
+    }
 
     void removeChatFile(Chat *chat) const;
     Q_INVOKABLE void saveChats();

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -223,6 +223,12 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
     if (isModelLoaded() && this->modelInfo() == modelInfo)
         return true;
 
+    // reset status
+    emit modelLoadingPercentageChanged(std::numeric_limits<float>::min()); // small non-zero positive value
+    emit modelLoadingError("");
+    emit reportFallbackReason("");
+    emit reportDevice("");
+
     QString filePath = modelInfo.dirpath + modelInfo.filename();
     QFileInfo fileInfo(filePath);
 
@@ -235,7 +241,6 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
 #endif
         delete m_llModelInfo.model;
         m_llModelInfo.model = nullptr;
-        emit modelLoadingPercentageChanged(std::numeric_limits<float>::min()); // small non-zero positive value
     } else if (!m_isServer) {
         // This is a blocking call that tries to retrieve the model we need from the model store.
         // If it succeeds, then we just have to restore state. If the store has never had a model
@@ -353,8 +358,6 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     emit modelLoadingPercentageChanged(progress);
                     return m_shouldBeLoaded;
                 });
-
-                emit reportFallbackReason(""); // no fallback yet
 
                 auto approxDeviceMemGB = [](const LLModel::GPUDevice *dev) {
                     float memGB = dev->heapSize / float(1024 * 1024 * 1024);

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -185,7 +185,7 @@ bool ChatLLM::trySwitchContextOfLoadedModel(const ModelInfo &modelInfo)
     // modelInfo is empty, then this should fail
     if (isModelLoaded() || m_isServer || m_reloadingToChangeVariant || modelInfo.name().isEmpty()) {
         m_shouldTrySwitchContext = false;
-        emit trySwitchContextOfLoadedModelCompleted(false);
+        emit trySwitchContextOfLoadedModelCompleted(0);
         return false;
     }
 
@@ -202,7 +202,7 @@ bool ChatLLM::trySwitchContextOfLoadedModel(const ModelInfo &modelInfo)
     if (!m_llModelInfo.model || m_llModelInfo.fileInfo != fileInfo) {
         LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
         m_shouldTrySwitchContext = false;
-        emit trySwitchContextOfLoadedModelCompleted(false);
+        emit trySwitchContextOfLoadedModelCompleted(0);
         return false;
     }
 
@@ -214,10 +214,12 @@ bool ChatLLM::trySwitchContextOfLoadedModel(const ModelInfo &modelInfo)
     m_shouldBeLoaded = true;
     m_shouldTrySwitchContext = false;
 
+    emit trySwitchContextOfLoadedModelCompleted(2);
+
     // Restore, signal and process
     restoreState();
     emit modelLoadingPercentageChanged(1.0f);
-    emit trySwitchContextOfLoadedModelCompleted(true);
+    emit trySwitchContextOfLoadedModelCompleted(0);
     processSystemPrompt();
     return true;
 }

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -182,6 +182,10 @@ private:
     bool m_reloadingToChangeVariant;
     bool m_processedSystemPrompt;
     bool m_restoreStateFromText;
+    // m_pristineLoadedState is set if saveSate is unnecessary, either because:
+    // - an unload was queued during LLModel::restoreState()
+    // - the chat will be restored from text and hasn't been interacted with yet
+    bool m_pristineLoadedState = false;
     QVector<QPair<QString, QString>> m_stateFromText;
 };
 

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -84,7 +84,7 @@ public:
 
     bool shouldBeLoaded() const { return m_shouldBeLoaded; }
     void setShouldBeLoaded(bool b);
-    void setShouldTrySwitchContext(bool b);
+    void requestTrySwitchContext();
     void setForceUnloadModel(bool b) { m_forceUnloadModel = b; }
     void setMarkedForDeletion(bool b) { m_markedForDeletion = b; }
 
@@ -104,7 +104,7 @@ public:
 public Q_SLOTS:
     bool prompt(const QList<QString> &collectionList, const QString &prompt);
     bool loadDefaultModel();
-    bool trySwitchContextOfLoadedModel(const ModelInfo &modelInfo);
+    void trySwitchContextOfLoadedModel(const ModelInfo &modelInfo);
     bool loadModel(const ModelInfo &modelInfo);
     void modelChangeRequested(const ModelInfo &modelInfo);
     void unloadModel();
@@ -112,7 +112,6 @@ public Q_SLOTS:
     void generateName();
     void handleChatIdChanged(const QString &id);
     void handleShouldBeLoadedChanged();
-    void handleShouldTrySwitchContextChanged();
     void handleThreadStarted();
     void handleForceMetalChanged(bool forceMetal);
     void handleDeviceChanged();
@@ -131,7 +130,7 @@ Q_SIGNALS:
     void stateChanged();
     void threadStarted();
     void shouldBeLoadedChanged();
-    void shouldTrySwitchContextChanged();
+    void trySwitchContextRequested(const ModelInfo &modelInfo);
     void trySwitchContextOfLoadedModelCompleted(int value);
     void requestRetrieveFromDB(const QList<QString> &collections, const QString &text, int retrievalSize, QList<ResultInfo> *results);
     void reportSpeed(const QString &speed);
@@ -175,7 +174,6 @@ private:
     QThread m_llmThread;
     std::atomic<bool> m_stopGenerating;
     std::atomic<bool> m_shouldBeLoaded;
-    std::atomic<bool> m_shouldTrySwitchContext;
     std::atomic<bool> m_isRecalc;
     std::atomic<bool> m_forceUnloadModel;
     std::atomic<bool> m_markedForDeletion;

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -5,6 +5,8 @@
 #include <QThread>
 #include <QFileInfo>
 
+#include <memory>
+
 #include "database.h"
 #include "modellist.h"
 #include "../gpt4all-backend/llmodel.h"
@@ -16,7 +18,7 @@ enum LLModelType {
 };
 
 struct LLModelInfo {
-    LLModel *model = nullptr;
+    std::unique_ptr<LLModel> model;
     QFileInfo fileInfo;
     // NOTE: This does not store the model type or name on purpose as this is left for ChatLLM which
     // must be able to serialize the information even if it is in the unloaded state
@@ -72,6 +74,7 @@ public:
     virtual ~ChatLLM();
 
     void destroy();
+    static void destroyStore();
     bool isModelLoaded() const;
     void regenerateResponse();
     void resetResponse();

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -132,7 +132,7 @@ Q_SIGNALS:
     void threadStarted();
     void shouldBeLoadedChanged();
     void shouldTrySwitchContextChanged();
-    void trySwitchContextOfLoadedModelCompleted(bool);
+    void trySwitchContextOfLoadedModelCompleted(int value);
     void requestRetrieveFromDB(const QList<QString> &collections, const QString &text, int retrievalSize, QList<ResultInfo> *results);
     void reportSpeed(const QString &speed);
     void reportDevice(const QString &device);

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -122,8 +122,6 @@ Rectangle {
         return ModelList.modelInfo(currentChat.modelInfo.id).name;
     }
 
-    property bool isCurrentlyLoading: false
-
     PopupDialog {
         id: errorCompatHardware
         anchors.centerIn: parent
@@ -339,25 +337,17 @@ Rectangle {
                     width: window.width >= 750 ? implicitWidth : implicitWidth - (750 - window.width)
                     enabled: !currentChat.isServer
                         && !currentChat.trySwitchContextInProgress
-                        && !window.isCurrentlyLoading
+                        && !currentChat.isCurrentlyLoading
                     model: ModelList.installedModels
                     valueRole: "id"
                     textRole: "name"
 
                     function changeModel(index) {
-                        window.isCurrentlyLoading = true;
                         currentChat.stopGenerating()
                         currentChat.reset();
                         currentChat.modelInfo = ModelList.modelInfo(comboBox.valueAt(index))
                     }
 
-                    Connections {
-                        target: currentChat
-                        function onModelLoadingPercentageChanged() {
-                            window.isCurrentlyLoading = currentChat.modelLoadingPercentage !== 0.0
-                                && currentChat.modelLoadingPercentage !== 1.0;
-                        }
-                    }
                     Connections {
                         target: switchModelDialog
                         function onAccepted() {
@@ -374,7 +364,7 @@ Rectangle {
                         }
                         contentItem: Item {
                             Rectangle {
-                                visible: window.isCurrentlyLoading
+                                visible: currentChat.isCurrentlyLoading
                                 anchors.bottom: parent.bottom
                                 width: modelProgress.visualPosition * parent.width
                                 height: 10
@@ -402,7 +392,7 @@ Rectangle {
                                 return qsTr("Choose a model...")
                             if (currentChat.modelLoadingPercentage === 0.0)
                                 return qsTr("Reload \u00B7 ") + currentModelName()
-                            if (window.isCurrentlyLoading)
+                            if (currentChat.isCurrentlyLoading)
                                 return qsTr("Loading \u00B7 ") + currentModelName()
                             return currentModelName()
                         }
@@ -446,7 +436,7 @@ Rectangle {
 
                     MyMiniButton {
                         id: ejectButton
-                        visible: currentChat.isModelLoaded && !window.isCurrentlyLoading
+                        visible: currentChat.isModelLoaded && !currentChat.isCurrentlyLoading
                         z: 500
                         anchors.right: parent.right
                         anchors.rightMargin: 50
@@ -465,7 +455,7 @@ Rectangle {
                         id: reloadButton
                         visible: currentChat.modelLoadingError === ""
                             && !currentChat.trySwitchContextInProgress
-                            && !window.isCurrentlyLoading
+                            && !currentChat.isCurrentlyLoading
                             && (currentChat.isModelLoaded || currentModelName() !== "")
                         z: 500
                         anchors.right: ejectButton.visible ? ejectButton.left : parent.right
@@ -1335,7 +1325,7 @@ Rectangle {
                 visible: !currentChat.isServer
                     && !currentChat.isModelLoaded
                     && !currentChat.trySwitchContextInProgress
-                    && !window.isCurrentlyLoading
+                    && !currentChat.isCurrentlyLoading
                     && currentModelName() !== ""
 
                 Image {

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -386,7 +386,9 @@ Rectangle {
                         text: {
                             if (currentChat.modelLoadingError !== "")
                                 return qsTr("Model loading error...")
-                            if (currentChat.trySwitchContextInProgress)
+                            if (currentChat.trySwitchContextInProgress == 1)
+                                return qsTr("Waiting for model...")
+                            if (currentChat.trySwitchContextInProgress == 2)
                                 return qsTr("Switching context...")
                             if (currentModelName() === "")
                                 return qsTr("Choose a model...")

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -123,7 +123,6 @@ Rectangle {
     }
 
     property bool isCurrentlyLoading: false
-    property real modelLoadingPercentage: 0.0
 
     PopupDialog {
         id: errorCompatHardware
@@ -346,7 +345,6 @@ Rectangle {
                     textRole: "name"
 
                     function changeModel(index) {
-                        window.modelLoadingPercentage = 0.0;
                         window.isCurrentlyLoading = true;
                         currentChat.stopGenerating()
                         currentChat.reset();
@@ -356,7 +354,6 @@ Rectangle {
                     Connections {
                         target: currentChat
                         function onModelLoadingPercentageChanged() {
-                            window.modelLoadingPercentage = currentChat.modelLoadingPercentage;
                             window.isCurrentlyLoading = currentChat.modelLoadingPercentage !== 0.0
                                 && currentChat.modelLoadingPercentage !== 1.0;
                         }
@@ -370,7 +367,7 @@ Rectangle {
 
                     background: ProgressBar {
                         id: modelProgress
-                        value: window.modelLoadingPercentage
+                        value: currentChat.modelLoadingPercentage
                         background: Rectangle {
                             color: theme.mainComboBackground
                             radius: 10

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1326,6 +1326,7 @@ Rectangle {
                 textColor: theme.textColor
                 visible: !currentChat.isServer
                     && !currentChat.isModelLoaded
+                    && currentChat.modelLoadingError === ""
                     && !currentChat.trySwitchContextInProgress
                     && !currentChat.isCurrentlyLoading
                     && currentModelName() !== ""

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -124,7 +124,6 @@ Rectangle {
 
     property bool isCurrentlyLoading: false
     property real modelLoadingPercentage: 0.0
-    property bool trySwitchContextInProgress: false
 
     PopupDialog {
         id: errorCompatHardware
@@ -340,7 +339,7 @@ Rectangle {
                     implicitWidth: 575
                     width: window.width >= 750 ? implicitWidth : implicitWidth - (750 - window.width)
                     enabled: !currentChat.isServer
-                        && !window.trySwitchContextInProgress
+                        && !currentChat.trySwitchContextInProgress
                         && !window.isCurrentlyLoading
                     model: ModelList.installedModels
                     valueRole: "id"
@@ -360,12 +359,6 @@ Rectangle {
                             window.modelLoadingPercentage = currentChat.modelLoadingPercentage;
                             window.isCurrentlyLoading = currentChat.modelLoadingPercentage !== 0.0
                                 && currentChat.modelLoadingPercentage !== 1.0;
-                        }
-                        function onTrySwitchContextOfLoadedModelAttempted() {
-                            window.trySwitchContextInProgress = true;
-                        }
-                        function onTrySwitchContextOfLoadedModelCompleted() {
-                            window.trySwitchContextInProgress = false;
                         }
                     }
                     Connections {
@@ -406,7 +399,7 @@ Rectangle {
                         text: {
                             if (currentChat.modelLoadingError !== "")
                                 return qsTr("Model loading error...")
-                            if (window.trySwitchContextInProgress)
+                            if (currentChat.trySwitchContextInProgress)
                                 return qsTr("Switching context...")
                             if (currentModelName() === "")
                                 return qsTr("Choose a model...")
@@ -474,7 +467,7 @@ Rectangle {
                     MyMiniButton {
                         id: reloadButton
                         visible: currentChat.modelLoadingError === ""
-                            && !window.trySwitchContextInProgress
+                            && !currentChat.trySwitchContextInProgress
                             && !window.isCurrentlyLoading
                             && (currentChat.isModelLoaded || currentModelName() !== "")
                         z: 500
@@ -1344,7 +1337,7 @@ Rectangle {
                 textColor: theme.textColor
                 visible: !currentChat.isServer
                     && !currentChat.isModelLoaded
-                    && !window.trySwitchContextInProgress
+                    && !currentChat.trySwitchContextInProgress
                     && !window.isCurrentlyLoading
                     && currentModelName() !== ""
 


### PR DESCRIPTION
If you switch between chats too quickly, it can result in the UI getting into inconsistent states (e.g. a progress bar stuck at 60%) and sometimes seemingly deadlocking (which happens during the new "Waiting for model" status).

To fix UI inconsistencies:
- Move trySwitchContextInProgress, modelLoadingPercentage, and isCurrentlyLoading properties from the window to the chat so the load status always reflects the current chat
- Initialize load status at the beginning of loadModel instead of only in setModelInfo - reloadModel calls this too
- If loadModel is cancelled, quickly return instead of trying to fall back and reporting an "invalid model" error
- On load failure, instead of showing only the bottom "reload" button, show neither

To prevent quickly switching chats from queueing many slow operations:
- Skip context switch if an unload is pending
- Skip unnecessary calls to LLModel::saveState

UI enhancement:
- Show "waiting for model" as a separate state when switching context, so it's clearer what is taking so long

Other bugfix:
- Use std::unique_ptr in the LLModelStore and fix a related memory leak - not absolutely necessary for this PR, but it makes some other changes slightly simpler

Non-functional changes:
- Use std::optional to store zero or one items in the LLModelStore
- Remove m_shouldTrySwitchContext, which didn't do anything useful, and simplify the related code