### PR TITLE
llamamodel: free the batch in embedInternal

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -940,6 +940,8 @@ void LLamaModel::embedInternal(
     }
 
     if (tokenCount) { *tokenCount = totalTokens; }
+
+    llama_batch_free(batch);
 }
 
 #if defined(_WIN32)


### PR DESCRIPTION
Looks like we inherited a minor bug from the llama.cpp embedding example that was fixed in https://github.com/ggerganov/llama.cpp/pull/7297.