### PR TITLE
python: depend on offical NVIDIA CUDA packages

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -28,6 +28,25 @@ if TYPE_CHECKING:
 EmbeddingsType = TypeVar('EmbeddingsType', bound='list[Any]')
 
 
+# Find CUDA libraries from the official packages
+if platform.system() in ('Linux', 'Windows'):
+    try:
+        from nvidia import cuda_runtime, cublas
+    except ImportError:
+        pass  # CUDA is optional
+    else:
+        if platform.system() == 'Linux':
+            cudalib   = 'lib/libcudart.so.12'
+            cublaslib = 'lib/libcublas.so.12'
+        else:  # Windows
+            cudalib   = r'bin\cudart64_12.dll'
+            cublaslib = r'bin\cublas64_12.dll'
+
+        # preload the CUDA libs so the backend can find them
+        ctypes.CDLL(os.path.join(cuda_runtime.__path__[0], cudalib), mode=ctypes.RTLD_GLOBAL)
+        ctypes.CDLL(os.path.join(cublas.__path__[0], cublaslib), mode=ctypes.RTLD_GLOBAL)
+
+
 # TODO: provide a config file to make this more robust
 MODEL_LIB_PATH = importlib_resources.files("gpt4all") / "llmodel_DO_NOT_MODIFY" / "build"
 

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -91,6 +91,8 @@ setup(
         'tqdm',
         'importlib_resources; python_version < "3.9"',
         'typing-extensions>=4.3.0; python_version >= "3.9" and python_version < "3.11"',
+        'nvidia-cuda-runtime-cu12; platform_system == "Windows" or platform_system == "Linux"',
+        'nvidia-cublas-cu12; platform_system == "Windows" or platform_system == "Linux"',
     ],
     extras_require={
         'dev': [

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -91,11 +91,17 @@ setup(
         'tqdm',
         'importlib_resources; python_version < "3.9"',
         'typing-extensions>=4.3.0; python_version >= "3.9" and python_version < "3.11"',
-        'nvidia-cuda-runtime-cu12; platform_system == "Windows" or platform_system == "Linux"',
-        'nvidia-cublas-cu12; platform_system == "Windows" or platform_system == "Linux"',
     ],
     extras_require={
+        'cuda': [
+            'nvidia-cuda-runtime-cu12',
+            'nvidia-cublas-cu12',
+        ],
+        'all': [
+            'gpt4all[cuda]; platform_system == "Windows" or platform_system == "Linux"',
+        ],
         'dev': [
+            'gpt4all[all]',
             'pytest',
             'twine',
             'wheel',


### PR DESCRIPTION
Use the official nvidia-cuda-runtime-cu12 and nvidia-cublas-cu12 pypi packages to provide the CUDA runtime.

This way, the python bindings will always be able to find CUDA on Windows and Linux, even without the CUDA Toolkit installed.