### PR TITLE
llmodel: add CUDA to the DLL search path if CUDA_PATH is set

### DIFF
--- a/gpt4all-backend/dlhandle.h
+++ b/gpt4all-backend/dlhandle.h
@@ -58,12 +58,13 @@ public:
 #include <string>
 #include <exception>
 #include <stdexcept>
+
+#define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
-    #define NOMINMAX
+#   define NOMINMAX
 #endif
 #include <windows.h>
 #include <libloaderapi.h>
-
 
 
 class Dlhandle {


### PR DESCRIPTION
I tested this change with Qt Creator on Windows. Without it, the CUDA runtime libraries are only found if they are copied into the build directory. With this change, the CUDA runtime libraries are found as long as CUDA_PATH is set correctly, which is done automatically by the CUDA Toolkit installer.

As far as the chat UI is concerned, this change only matters for users that build GPT4All from source themselves, which already requires the CUDA Toolkit. Once GPT4All is installed, the CUDA libraries are copied into the install directory.

This change should also benefit the bindings, by allowing the system CUDA libraries to be used automatically if they are installed.