### PR TITLE
installer script: fix detection of macOS on newer QtIFW

### DIFF
--- a/gpt4all-chat/cmake/installerscript.qs
+++ b/gpt4all-chat/cmake/installerscript.qs
@@ -30,7 +30,7 @@ Component.prototype.createOperations = function()
                 "workingDirectory=" + targetDirectory + "/bin",
                 "iconPath=" + targetDirectory + "/gpt4all.ico",
                 "iconId=0", "description=Open GPT4All");
-        } else if (systemInfo.productType === "osx") {
+        } else if (systemInfo.productType === "macos" || systemInfo.productType === "osx") {
             var gpt4allAppPath = targetDirectory + "/bin/gpt4all.app";
             var symlinkPath = targetDirectory + "/../GPT4All.app";
             // Remove the symlink if it already exists
@@ -56,7 +56,7 @@ Component.prototype.createOperationsForArchive = function(archive)
 {
     component.createOperationsForArchive(archive);
 
-    if (systemInfo.productType === "osx") {
+    if (systemInfo.productType === "macos" || systemInfo.productType === "osx") {
         var uninstallTargetDirectory = installer.value("TargetDir");
         var symlinkPath = uninstallTargetDirectory + "/../GPT4All.app";
 


### PR DESCRIPTION
I noticed that the offline installer for GPT4All v2.8.0-pre1 created `GPT4All.desktop` instead of the symlink in the applications folder. 

According to the [QtIFW docs](https://doc.qt.io/qtinstallerframework/scripting-systeminfo.html#productType-prop), systemInfo is always "macos" on macOS, not "osx".

This PR updates the installer script to also recognize "macos". This bug has presumably existed since at least #2015, when QtIFW was updated in CI. I have no idea which version of QtIFW is used to make the online installers, so I am keeping the "osx" check for backwards compatibility.