### PR TITLE
python: init_gpu fixes

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -274,11 +274,12 @@ class LLModel:
 
         all_gpus = self.list_gpus()
         available_gpus = self.list_gpus(mem_required)
-        unavailable_gpus = set(all_gpus).difference(available_gpus)
+        unavailable_gpus = [g for g in all_gpus if g not in available_gpus]
 
-        error_msg = "Unable to initialize model on GPU: {!r}".format(device)
-        error_msg += "\nAvailable GPUs: {}".format(available_gpus)
-        error_msg += "\nUnavailable GPUs due to insufficient memory or features: {}".format(unavailable_gpus)
+        error_msg = (f"Unable to initialize model on GPU: {device!r}" +
+                     f"\nAvailable GPUs: {available_gpus}")
+        if unavailable_gpus:
+            error_msg += f"\nUnavailable GPUs due to insufficient memory: {unavailable_gpus}"
         raise ValueError(error_msg)
 
     def load_model(self) -> bool:


### PR DESCRIPTION
This PR fixes two problems with `LLModel.init_gpu`.

The major one is a use-after-free that was uncovered by [`8dbe93d` (#2310)](https://github.com/nomic-ai/gpt4all/pull/2310/commits/8dbe93db22ccc24af25b8a3560787ae67d7579b2), which started using the `name` field of the result of `ggml_vk_get_device`. You will hit this if you try to use kompute via the python bindings after the CUDA PR.

The other one is that the error message when a GPU is not found is 1) misleading ("insufficient features" isn't implemented as those devices have *never* been listed AFAIK, and "insufficient memory" doesn't work since GGUF), and 2) formatted oddly (shows `set()` when there are no unavailable GPUs).

Message before:
```
ValueError: Unable to initialize model on GPU: 'foo'
Available GPUs: ['NVIDIA GeForce GTX 970', 'Tesla P40']
Unavailable GPUs: set()
```

Message after:
```
ValueError: Unable to initialize model on GPU: 'foo'
Available GPUs: ['NVIDIA GeForce GTX 970', 'Tesla P40']
```

Currently there will never be any unavailable GPUs, but if the memory size calculation is implemented again, they will be listed like this (with square brackets, not curly brackets, and with order preserved):
```
ValueError: Unable to initialize model on GPU: 'foo'
Available GPUs: ['Tesla P40']
Unavailable GPUs: ['NVIDIA GeForce GTX 970']
```