### PR TITLE
llamamodel: fix embedding crash for >512 tokens after #2310

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -386,7 +386,8 @@ bool LLamaModel::loadModel(const std::string &modelPath, int n_ctx, int ngl)
     bool isEmbedding = is_embedding_arch(llama_model_arch(d_ptr->model));
     const int n_ctx_train = llama_n_ctx_train(d_ptr->model);
     if (isEmbedding) {
-        d_ptr->ctx_params.n_batch = n_ctx;
+        d_ptr->ctx_params.n_batch  = n_ctx;
+        d_ptr->ctx_params.n_ubatch = n_ctx;
     } else {
         if (n_ctx > n_ctx_train) {
             std::cerr << "warning: model was trained on only " << n_ctx_train << " context tokens ("


### PR DESCRIPTION
n_ubatch defaults to 512, but as of the latest llama.cpp you cannot pass more than n_ubatch tokens to BERT without hitting an assertion failure.

Tested with this python code:
```python
from gpt4all import Embed4All
m = Embed4All('nomic-embed-text-v1.f16.gguf')
e = m.embed('a ' * 513)
```
Without this PR, it crashes with an assertion failure (including in release builds, since it's a GGML_ASSERT). With this PR, it succeeds.

Broken by #2310 because of https://github.com/ggerganov/llama.cpp/pull/6017
Fix based on https://github.com/ggerganov/llama.cpp/pull/6296
Fixes #2375