### PR TITLE
dlhandle: suppress DLL errors on Windows

### DIFF
--- a/gpt4all-backend/dlhandle.cpp
+++ b/gpt4all-backend/dlhandle.cpp
@@ -3,6 +3,7 @@
 #ifndef _WIN32
 #   include <dlfcn.h>
 #else
+#   include <cassert>
 #   include <sstream>
 #   define WIN32_LEAN_AND_MEAN
 #   ifndef NOMINMAX
@@ -34,11 +35,20 @@ void *Dlhandle::get_internal(const char *symbol) const {
 #else // defined(_WIN32)
 
 Dlhandle::Dlhandle(const fs::path &fpath) {
-    auto afpath = fs::absolute(fpath);
+    fs::path afpath = fs::absolute(fpath);
+
+    // Suppress the "Entry Point Not Found" dialog, caused by outdated nvcuda.dll from the GPU driver
+    UINT lastErrorMode = GetErrorMode();
+    UINT success = SetErrorMode(lastErrorMode | SEM_FAILCRITICALERRORS);
+    assert(success);
+
     chandle = LoadLibraryExW(afpath.c_str(), NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
 
+    success = SetErrorMode(lastErrorMode);
+    assert(success);
+
     if (!chandle) {
-        auto err = GetLastError();
+        DWORD err = GetLastError();
         std::ostringstream ss;
         ss << "LoadLibraryExW(\"" << fpath.filename().string() << "\") failed with error 0x" << std::hex << err;
         throw Exception(ss.str());

--- a/gpt4all-backend/dlhandle.cpp
+++ b/gpt4all-backend/dlhandle.cpp
@@ -1,5 +1,7 @@
 #include "dlhandle.h"
 
+#include <string>
+
 #ifndef _WIN32
 #   include <dlfcn.h>
 #else
@@ -12,6 +14,7 @@
 #   include <windows.h>
 #endif
 
+using namespace std::string_literals;
 namespace fs = std::filesystem;
 
 
@@ -20,7 +23,7 @@ namespace fs = std::filesystem;
 Dlhandle::Dlhandle(const fs::path &fpath) {
     chandle = dlopen(fpath.c_str(), RTLD_LAZY | RTLD_LOCAL);
     if (!chandle) {
-        throw Exception("dlopen(\"" + fpath.filename().string() + "\"): " + dlerror());
+        throw Exception("dlopen: "s + dlerror());
     }
 }
 
@@ -50,7 +53,7 @@ Dlhandle::Dlhandle(const fs::path &fpath) {
     if (!chandle) {
         DWORD err = GetLastError();
         std::ostringstream ss;
-        ss << "LoadLibraryExW(\"" << fpath.filename().string() << "\") failed with error 0x" << std::hex << err;
+        ss << "LoadLibraryExW failed with error 0x" << std::hex << err;
         throw Exception(ss.str());
     }
 }

--- a/gpt4all-backend/llmodel.cpp
+++ b/gpt4all-backend/llmodel.cpp
@@ -141,12 +141,18 @@ const std::vector<LLModel::Implementation> &LLModel::Implementation::implementat
                     if (!std::regex_search(p.stem().string(), re)) continue;
 
                     // Add to list if model implementation
+                    Dlhandle dl;
                     try {
-                        Dlhandle dl(p);
-                        if (!isImplementation(dl))
-                            continue;
-                        fres.emplace_back(Implementation(std::move(dl)));
-                    } catch (...) {}
+                        dl = Dlhandle(p);
+                    } catch (const Dlhandle::Exception &e) {
+                        std::cerr << "Failed to load " << p.filename().string() << ": " << e.what() << "\n";
+                        continue;
+                    }
+                    if (!isImplementation(dl)) {
+                        std::cerr << "Not an implementation: " << p.filename().string() << "\n";
+                        continue;
+                    }
+                    fres.emplace_back(Implementation(std::move(dl)));
                 }
             }
         };


### PR DESCRIPTION
This PR improves handling of errors caused by a missing/broken nvcuda.dll. This is an example of what at least two users have seen when nvcuda.dll is incompatible with the CUDA runtime libraries shipped with GPT4All:
![f6f704ce-e0b2-453f-b14f-d5ac378e2ca5](https://github.com/nomic-ai/gpt4all/assets/14168726/9040c7d4-79cb-4cd5-ba76-bfc602d41b0e)

### Without this PR
- If nvcuda.dll, this message is printed[^1] and GPT4All continues without CUDA:
```
constructGlobalLlama: could not find Llama implementation for backend: cuda
```
- If nvcuda.dll does not have a required symbol (which can be simulated by replacing it with an unrelated DLL), two error dialogs similar to the one in the screenshot will appear, this message is printed, and GPT4All continues without CUDA:
```
constructGlobalLlama: could not find Llama implementation for backend: cuda
```

### With this PR
- If nvcuda.dll is missing, you now get these warnings in the console:
```
Failed to load llamamodel-mainline-cuda-avxonly.dll: LoadLibraryExA failed with error 0x7e
Failed to load llamamodel-mainline-cuda.dll: LoadLibraryExA failed with error 0x7e
constructGlobalLlama: could not find Llama implementation for backend: cuda
```
Error 0x7e corresponds to [ERROR_MOD_NOT_FOUND](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-#:~:text=no%20volume%20label.-,ERROR_MOD_NOT_FOUND,-126%20(0x7E)). This typically indicates that no NVIDIA graphics driver is installed.
- If nvcuda.dll does not have a required symbol, you now get these warnings in the console, and no error dialog:
```
Failed to load llamamodel-mainline-cuda-avxonly.dll: LoadLibraryExA failed with error 0x7f
Failed to load llamamodel-mainline-cuda.dll: LoadLibraryExA failed with error 0x7f
constructGlobalLlama: could not find Llama implementation for backend: cuda
```

Error 0x7f corresponds to [ERROR_PROC_NOT_FOUND](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-#:~:text=ERROR_PROC_NOT_FOUND). This typically indicates that the installed NVIDIA graphics driver is too old - in the above screenshot, it appears that the user has a version older than 441.22 from 2019.

[^1]: You can only see these messages when you modify CMakeLists.txt to build GPT4All as a console application. It may be a good idea make it possible to surface these errors to the user without requiring them to build GPT4All from source.