### PR TITLE
chat: don't use incomplete types with signals/slots/Q_INVOKABLE

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -4,7 +4,6 @@
 #include "mysettings.h"
 #include "network.h"
 #include "server.h"
-#include "database.h"
 
 #include <QDataStream>
 #include <QDateTime>

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -3,6 +3,7 @@
 
 #include "chatllm.h"
 #include "chatmodel.h"
+#include "database.h" // IWYU pragma: keep
 #include "localdocsmodel.h" // IWYU pragma: keep
 #include "modellist.h"
 
@@ -13,7 +14,6 @@
 #include <QtGlobal>
 
 class QDataStream;
-struct ResultInfo;
 
 class Chat : public QObject
 {

--- a/gpt4all-chat/chatapi.h
+++ b/gpt4all-chat/chatapi.h
@@ -3,6 +3,7 @@
 
 #include "../gpt4all-backend/llmodel.h"
 
+#include <QByteArray>
 #include <QNetworkReply>
 #include <QObject>
 #include <QString>
@@ -16,7 +17,6 @@
 #include <string>
 #include <vector>
 
-class QByteArray;
 class QNetworkAccessManager;
 
 class ChatAPI;

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -2,7 +2,6 @@
 
 #include "chat.h"
 #include "chatapi.h"
-#include "database.h"
 #include "localdocs.h"
 #include "mysettings.h"
 #include "network.h"
@@ -14,7 +13,6 @@
 #include <QIODevice>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QList>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QSet>

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -1,6 +1,7 @@
 #ifndef CHATLLM_H
 #define CHATLLM_H
 
+#include "database.h" // IWYU pragma: keep
 #include "modellist.h"
 
 #include "../gpt4all-backend/llmodel.h"
@@ -8,6 +9,7 @@
 #include <QByteArray>
 #include <QElapsedTimer>
 #include <QFileInfo>
+#include <QList>
 #include <QObject>
 #include <QPair>
 #include <QString>
@@ -21,8 +23,6 @@
 #include <string>
 
 class QDataStream;
-struct ResultInfo;
-template <typename T> class QList;
 
 enum LLModelType {
     GPTJ_,

--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -1,7 +1,6 @@
 #include "database.h"
 
 #include "embeddings.h"
-#include "embllm.h"
 #include "modellist.h"
 #include "mysettings.h"
 #include "network.h"

--- a/gpt4all-chat/database.h
+++ b/gpt4all-chat/database.h
@@ -1,6 +1,8 @@
 #ifndef DATABASE_H
 #define DATABASE_H
 
+#include "embllm.h" // IWYU pragma: keep
+
 #include <QElapsedTimer>
 #include <QFileInfo>
 #include <QLatin1String>
@@ -22,7 +24,6 @@ class QFileSystemWatcher;
 class QSqlError;
 class QTextStream;
 class QTimer;
-struct EmbeddingResult;
 
 struct DocumentInfo
 {

--- a/gpt4all-chat/download.cpp
+++ b/gpt4all-chat/download.cpp
@@ -14,12 +14,10 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QList>
 #include <QNetworkRequest>
 #include <QPair>
 #include <QSettings>
 #include <QSslConfiguration>
-#include <QSslError>
 #include <QSslSocket>
 #include <QStringList>
 #include <QTextStream>

--- a/gpt4all-chat/download.h
+++ b/gpt4all-chat/download.h
@@ -5,18 +5,17 @@
 #include <QDateTime>
 #include <QFile>
 #include <QHash>
+#include <QList>
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
+#include <QSslError>
 #include <QString>
 #include <QThread>
 #include <QtGlobal>
 
 class QByteArray;
-class QFile;
-class QSslError;
-template <typename T> class QList;
 
 struct ReleaseInfo {
     Q_GADGET

--- a/gpt4all-chat/embllm.h
+++ b/gpt4all-chat/embllm.h
@@ -2,7 +2,6 @@
 #define EMBLLM_H
 
 #include <QByteArray>
-#include <QNetworkAccessManager>
 #include <QObject>
 #include <QString>
 #include <QStringList>

--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -25,7 +25,6 @@
 #include <QRegularExpression>
 #include <QSettings>
 #include <QSslConfiguration>
-#include <QSslError>
 #include <QSslSocket>
 #include <QTextStream>
 #include <QTimer>

--- a/gpt4all-chat/modellist.h
+++ b/gpt4all-chat/modellist.h
@@ -12,14 +12,13 @@
 #include <QObject>
 #include <QPair>
 #include <QSortFilterProxyModel>
+#include <QSslError>
 #include <QString>
+#include <QVariant>
+#include <QVector>
 #include <Qt>
 #include <QtGlobal>
 #include <QtQml>
-#include <QVariant>
-#include <QVector>
-
-class QSslError;
 
 struct ModelInfo {
     Q_GADGET

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -1,7 +1,5 @@
 #include "mysettings.h"
 
-#include "modellist.h"
-
 #include "../gpt4all-backend/llmodel.h"
 
 #include <QDebug>

--- a/gpt4all-chat/mysettings.h
+++ b/gpt4all-chat/mysettings.h
@@ -1,7 +1,7 @@
 #ifndef MYSETTINGS_H
 #define MYSETTINGS_H
 
-#include "modellist.h"
+#include "modellist.h" // IWYU pragma: keep
 
 #include <QDateTime>
 #include <QObject>
@@ -9,8 +9,6 @@
 #include <QVector>
 
 #include <cstdint>
-
-struct ModelInfo;
 
 class MySettings : public QObject
 {

--- a/gpt4all-chat/network.cpp
+++ b/gpt4all-chat/network.cpp
@@ -11,7 +11,6 @@
 
 #include "../gpt4all-backend/llmodel.h"
 
-#include <QByteArray>
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDebug>
@@ -20,14 +19,11 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QList>
-#include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QScreen>
 #include <QSettings>
 #include <QSize>
 #include <QSslConfiguration>
-#include <QSslError>
 #include <QSslSocket>
 #include <QSysInfo>
 #include <Qt>

--- a/gpt4all-chat/network.h
+++ b/gpt4all-chat/network.h
@@ -1,18 +1,17 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
+#include <QByteArray>
 #include <QJsonValue>
+#include <QList>
 #include <QMap>
 #include <QNetworkAccessManager>
+#include <QNetworkReply>
 #include <QObject>
+#include <QSslError>
 #include <QString>
 #include <QVariant>
 #include <QVector>
-
-class QByteArray;
-class QNetworkReply;
-class QSslError;
-template <typename T> class QList;
 
 struct KeyValue {
     QString key;

--- a/gpt4all-chat/server.cpp
+++ b/gpt4all-chat/server.cpp
@@ -9,7 +9,6 @@
 #include <QDebug>
 #include <QHostAddress>
 #include <QHttpServer>
-#include <QHttpServerRequest>
 #include <QHttpServerResponder>
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/gpt4all-chat/server.h
+++ b/gpt4all-chat/server.h
@@ -4,6 +4,7 @@
 #include "chatllm.h"
 #include "database.h"
 
+#include <QHttpServerRequest>
 #include <QHttpServerResponse>
 #include <QObject>
 #include <QList>
@@ -11,7 +12,6 @@
 
 class Chat;
 class QHttpServer;
-class QHttpServerRequest;
 
 class Server : public ChatLLM
 {


### PR DESCRIPTION
main fails to build since #2401 (oops).

The error is somewhere deep in C++ code generated by MOC, related to Database::handleEmbeddingsGenerated. It seems like you aren't allowed to use incomplete types with signals, slots, and Q_INVOKABLE methods, so this PR replaces the corresponding forward declarations with #includes.