### PR TITLE
chat: fix blank device in UI after model switch and improve Mixpanel reporting

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -711,24 +711,15 @@ bool LLamaModel::initializeGPUDevice(int device, std::string *unavail_reason) co
 #endif
 }
 
-bool LLamaModel::hasGPUDevice() const
-{
-#if defined(GGML_USE_KOMPUTE) || defined(GGML_USE_VULKAN) || defined(GGML_USE_CUDA)
-    return d_ptr->device != -1;
-#else
-    return false;
-#endif
-}
-
 bool LLamaModel::usingGPUDevice() const
 {
     bool hasDevice;
 
 #ifdef GGML_USE_KOMPUTE
-    hasDevice = hasGPUDevice() && d_ptr->model_params.n_gpu_layers > 0;
+    hasDevice = d_ptr->device != -1 && d_ptr->model_params.n_gpu_layers > 0;
     assert(!hasDevice || ggml_vk_has_device());
 #elif defined(GGML_USE_VULKAN) || defined(GGML_USE_CUDA)
-    hasDevice = hasGPUDevice() && d_ptr->model_params.n_gpu_layers > 0;
+    hasDevice = d_ptr->device != -1 && d_ptr->model_params.n_gpu_layers > 0;
 #elif defined(GGML_USE_METAL)
     hasDevice = true;
 #else

--- a/gpt4all-backend/llamamodel_impl.h
+++ b/gpt4all-backend/llamamodel_impl.h
@@ -34,7 +34,6 @@ public:
     std::vector<GPUDevice> availableGPUDevices(size_t memoryRequired = 0) const override;
     bool initializeGPUDevice(size_t memoryRequired, const std::string &name) const override;
     bool initializeGPUDevice(int device, std::string *unavail_reason = nullptr) const override;
-    bool hasGPUDevice() const override;
     bool usingGPUDevice() const override;
     const char *backendName() const override;
     const char *gpuDeviceName() const override;

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -60,8 +60,10 @@ public:
 
         std::string selectionName() const {
             assert(backend == "cuda"s || backend == "kompute"s);
-            return s_backendNames.at(backend) + ": " + name;
+            return backendName() + ": " + name;
         }
+
+        std::string backendName() const { return backendIdToName(backend); }
 
         static std::string backendIdToName(const std::string &backend) { return s_backendNames.at(backend); }
 

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -196,7 +196,6 @@ public:
         return false;
     }
 
-    virtual bool hasGPUDevice() const { return false; }
     virtual bool usingGPUDevice() const { return false; }
     virtual const char *backendName() const { return "cpu"; }
     virtual const char *gpuDeviceName() const { return nullptr; }

--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -2,6 +2,7 @@
 #define LLMODEL_H
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -57,23 +58,27 @@ public:
             backend(backend), index(index), type(type), heapSize(heapSize), name(std::move(name)),
             vendor(std::move(vendor)) {}
 
-        std::string selectionName() const { return m_backendNames.at(backend) + ": " + name; }
-        std::string reportedName()  const { return name + " (" + m_backendNames.at(backend) + ")"; }
+        std::string selectionName() const {
+            assert(backend == "cuda"s || backend == "kompute"s);
+            return s_backendNames.at(backend) + ": " + name;
+        }
+
+        static std::string backendIdToName(const std::string &backend) { return s_backendNames.at(backend); }
 
         static std::string updateSelectionName(const std::string &name) {
             if (name == "Auto" || name == "CPU" || name == "Metal")
                 return name;
-            auto it = std::find_if(m_backendNames.begin(), m_backendNames.end(), [&name](const auto &entry) {
+            auto it = std::find_if(s_backendNames.begin(), s_backendNames.end(), [&name](const auto &entry) {
                 return name.starts_with(entry.second + ": ");
             });
-            if (it != m_backendNames.end())
+            if (it != s_backendNames.end())
                 return name;
             return "Vulkan: " + name; // previously, there were only Vulkan devices
         }
 
     private:
-        static inline const std::unordered_map<std::string, std::string> m_backendNames {
-            {"cuda", "CUDA"}, {"kompute", "Vulkan"},
+        static inline const std::unordered_map<std::string, std::string> s_backendNames {
+            {"cpu", "CPU"}, {"metal", "Metal"}, {"cuda", "CUDA"}, {"kompute", "Vulkan"},
         };
     };
 

--- a/gpt4all-backend/llmodel_c.cpp
+++ b/gpt4all-backend/llmodel_c.cpp
@@ -283,12 +283,6 @@ bool llmodel_gpu_init_gpu_device_by_int(llmodel_model model, int device)
     return wrapper->llModel->initializeGPUDevice(device);
 }
 
-bool llmodel_has_gpu_device(llmodel_model model)
-{
-    const auto *wrapper = static_cast<LLModelWrapper *>(model);
-    return wrapper->llModel->hasGPUDevice();
-}
-
 const char *llmodel_model_backend_name(llmodel_model model)
 {
     const auto *wrapper = static_cast<LLModelWrapper *>(model);

--- a/gpt4all-backend/llmodel_c.h
+++ b/gpt4all-backend/llmodel_c.h
@@ -292,11 +292,6 @@ bool llmodel_gpu_init_gpu_device_by_struct(llmodel_model model, const llmodel_gp
 bool llmodel_gpu_init_gpu_device_by_int(llmodel_model model, int device);
 
 /**
- * @return True if a GPU device is successfully initialized, false otherwise.
- */
-bool llmodel_has_gpu_device(llmodel_model model);
-
-/**
  * @return The name of the llama.cpp backend currently in use. One of "cpu", "kompute", or "metal".
  */
 const char *llmodel_model_backend_name(llmodel_model model);

--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -177,9 +177,6 @@ llmodel.llmodel_gpu_init_gpu_device_by_struct.restype = ctypes.c_bool
 llmodel.llmodel_gpu_init_gpu_device_by_int.argtypes = [ctypes.c_void_p, ctypes.c_int32]
 llmodel.llmodel_gpu_init_gpu_device_by_int.restype = ctypes.c_bool
 
-llmodel.llmodel_has_gpu_device.argtypes = [ctypes.c_void_p]
-llmodel.llmodel_has_gpu_device.restype = ctypes.c_bool
-
 llmodel.llmodel_model_backend_name.argtypes = [ctypes.c_void_p]
 llmodel.llmodel_model_backend_name.restype = ctypes.c_char_p
 

--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -50,8 +50,7 @@ void Chat::connectLLM()
     connect(m_llmodel, &ChatLLM::recalcChanged, this, &Chat::handleRecalculating, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::generatedNameChanged, this, &Chat::generatedNameChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::reportSpeed, this, &Chat::handleTokenSpeedChanged, Qt::QueuedConnection);
-    connect(m_llmodel, &ChatLLM::reportDevice, this, &Chat::handleDeviceChanged, Qt::QueuedConnection);
-    connect(m_llmodel, &ChatLLM::reportFallbackReason, this, &Chat::handleFallbackReasonChanged, Qt::QueuedConnection);
+    connect(m_llmodel, &ChatLLM::loadedModelInfoChanged, this, &Chat::loadedModelInfoChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::databaseResultsChanged, this, &Chat::handleDatabaseResultsChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::modelInfoChanged, this, &Chat::handleModelInfoChanged, Qt::QueuedConnection);
     connect(m_llmodel, &ChatLLM::trySwitchContextOfLoadedModelCompleted, this, &Chat::handleTrySwitchContextOfLoadedModelCompleted, Qt::QueuedConnection);
@@ -350,16 +349,19 @@ void Chat::handleTokenSpeedChanged(const QString &tokenSpeed)
     emit tokenSpeedChanged();
 }
 
-void Chat::handleDeviceChanged(const QString &device)
-{
-    m_device = device;
-    emit deviceChanged();
+QVariant Chat::deviceBackend() const {
+    auto backend = m_llmodel->deviceBackend();
+    return backend ? QVariant(backend.value()) : QVariant();
 }
 
-void Chat::handleFallbackReasonChanged(const QString &fallbackReason)
-{
-    m_fallbackReason = fallbackReason;
-    emit fallbackReasonChanged();
+QVariant Chat::device() const {
+    auto device = m_llmodel->device();
+    return device ? QVariant(device.value()) : QVariant();
+}
+
+QVariant Chat::fallbackReason() const {
+    auto fallbackReason = m_llmodel->fallbackReason();
+    return fallbackReason ? QVariant(fallbackReason.value()) : QVariant();
 }
 
 void Chat::handleDatabaseResultsChanged(const QList<ResultInfo> &results)

--- a/gpt4all-chat/chat.h
+++ b/gpt4all-chat/chat.h
@@ -28,8 +28,9 @@ class Chat : public QObject
     Q_PROPERTY(QList<QString> collectionList READ collectionList NOTIFY collectionListChanged)
     Q_PROPERTY(QString modelLoadingError READ modelLoadingError NOTIFY modelLoadingErrorChanged)
     Q_PROPERTY(QString tokenSpeed READ tokenSpeed NOTIFY tokenSpeedChanged);
-    Q_PROPERTY(QString device READ device NOTIFY deviceChanged);
-    Q_PROPERTY(QString fallbackReason READ fallbackReason NOTIFY fallbackReasonChanged);
+    Q_PROPERTY(QVariant deviceBackend READ deviceBackend NOTIFY loadedModelInfoChanged)
+    Q_PROPERTY(QVariant device READ device NOTIFY loadedModelInfoChanged)
+    Q_PROPERTY(QVariant fallbackReason READ fallbackReason NOTIFY loadedModelInfoChanged)
     Q_PROPERTY(LocalDocsCollectionsModel *collectionModel READ collectionModel NOTIFY collectionModelChanged)
     // 0=no, 1=waiting, 2=working
     Q_PROPERTY(int trySwitchContextInProgress READ trySwitchContextInProgress NOTIFY trySwitchContextInProgressChanged)
@@ -106,8 +107,10 @@ public:
     QString modelLoadingError() const { return m_modelLoadingError; }
 
     QString tokenSpeed() const { return m_tokenSpeed; }
-    QString device() const { return m_device; }
-    QString fallbackReason() const { return m_fallbackReason; }
+    QVariant deviceBackend() const;
+    QVariant device() const;
+    // not loaded -> null, no fallback -> empty string
+    QVariant fallbackReason() const;
 
     int trySwitchContextInProgress() const { return m_trySwitchContextInProgress; }
 
@@ -144,6 +147,7 @@ Q_SIGNALS:
     void fallbackReasonChanged();
     void collectionModelChanged();
     void trySwitchContextInProgressChanged();
+    void loadedModelInfoChanged();
 
 private Q_SLOTS:
     void handleResponseChanged(const QString &response);
@@ -154,8 +158,6 @@ private Q_SLOTS:
     void handleRecalculating();
     void handleModelLoadingError(const QString &error);
     void handleTokenSpeedChanged(const QString &tokenSpeed);
-    void handleDeviceChanged(const QString &device);
-    void handleFallbackReasonChanged(const QString &device);
     void handleDatabaseResultsChanged(const QList<ResultInfo> &results);
     void handleModelInfoChanged(const ModelInfo &modelInfo);
     void handleTrySwitchContextOfLoadedModelCompleted(int value);

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -77,6 +77,12 @@ void LLModelStore::destroy()
     m_availableModel.reset();
 }
 
+void LLModelInfo::resetModel(ChatLLM *cllm, LLModel *model) {
+    this->model.reset(model);
+    fallbackReason.reset();
+    emit cllm->loadedModelInfoChanged();
+}
+
 ChatLLM::ChatLLM(Chat *parent, bool isServer)
     : QObject{nullptr}
     , m_promptResponseTokens(0)
@@ -125,7 +131,7 @@ void ChatLLM::destroy()
     // The only time we should have a model loaded here is on shutdown
     // as we explicitly unload the model in all other circumstances
     if (isModelLoaded()) {
-        m_llModelInfo.model.reset();
+        m_llModelInfo.resetModel(this);
     }
 }
 
@@ -192,7 +198,7 @@ void ChatLLM::trySwitchContextOfLoadedModel(const ModelInfo &modelInfo)
     QString filePath = modelInfo.dirpath + modelInfo.filename();
     QFileInfo fileInfo(filePath);
 
-    m_llModelInfo = LLModelStore::globalInstance()->acquireModel();
+    acquireModel();
 #if defined(DEBUG_MODEL_LOADING)
         qDebug() << "acquired model from store" << m_llmThread.objectName() << m_llModelInfo.model.get();
 #endif
@@ -235,8 +241,6 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
     // reset status
     emit modelLoadingPercentageChanged(std::numeric_limits<float>::min()); // small non-zero positive value
     emit modelLoadingError("");
-    emit reportFallbackReason("");
-    emit reportDevice("");
     m_pristineLoadedState = false;
 
     QString filePath = modelInfo.dirpath + modelInfo.filename();
@@ -249,12 +253,12 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
 #if defined(DEBUG_MODEL_LOADING)
         qDebug() << "already acquired model deleted" << m_llmThread.objectName() << m_llModelInfo.model.get();
 #endif
-        m_llModelInfo.model.reset();
+        m_llModelInfo.resetModel(this);
     } else if (!m_isServer) {
         // This is a blocking call that tries to retrieve the model we need from the model store.
         // If it succeeds, then we just have to restore state. If the store has never had a model
         // returned to it, then the modelInfo.model pointer should be null which will happen on startup
-        m_llModelInfo = LLModelStore::globalInstance()->acquireModel();
+        acquireModel();
 #if defined(DEBUG_MODEL_LOADING)
         qDebug() << "acquired model from store" << m_llmThread.objectName() << m_llModelInfo.model.get();
 #endif
@@ -289,7 +293,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
 #if defined(DEBUG_MODEL_LOADING)
             qDebug() << "deleting model" << m_llmThread.objectName() << m_llModelInfo.model.get();
 #endif
-            m_llModelInfo.model.reset();
+            m_llModelInfo.resetModel(this);
         }
     }
 
@@ -319,7 +323,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
             model->setModelName(modelName);
             model->setRequestURL(modelInfo.url());
             model->setAPIKey(apiKey);
-            m_llModelInfo.model.reset(model);
+            m_llModelInfo.resetModel(this, model);
         } else {
             QElapsedTimer modelLoadTimer;
             modelLoadTimer.start();
@@ -344,10 +348,10 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
 #endif
 
             QString constructError;
-            m_llModelInfo.model.reset();
+            m_llModelInfo.resetModel(this);
             try {
                 auto *model = LLModel::Implementation::construct(filePath.toStdString(), backend, n_ctx);
-                m_llModelInfo.model.reset(model);
+                m_llModelInfo.resetModel(this, model);
             } catch (const LLModel::MissingImplementationError &e) {
                 modelLoadProps.insert("error", "missing_model_impl");
                 constructError = e.what();
@@ -399,11 +403,11 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     }
                 }
 
-                QString actualDevice("CPU");
+                bool actualDeviceIsCPU = true;
 
 #if defined(Q_OS_MAC) && defined(__aarch64__)
                 if (m_llModelInfo.model->implementation().buildVariant() == "metal")
-                    actualDevice = "Metal";
+                    actualDeviceIsCPU = false;
 #else
                 if (requestedDevice != "CPU") {
                     const auto *device = defaultDevice;
@@ -421,41 +425,39 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     if (!device) {
                         // GPU not available
                     } else if (!m_llModelInfo.model->initializeGPUDevice(device->index, &unavail_reason)) {
-                        emit reportFallbackReason(QString::fromStdString("<br>" + unavail_reason));
+                        m_llModelInfo.fallbackReason = QString::fromStdString(unavail_reason);
                     } else {
-                        actualDevice = QString::fromStdString(device->reportedName());
+                        actualDeviceIsCPU = false;
                         modelLoadProps.insert("requested_device_mem", approxDeviceMemGB(device));
                     }
                 }
 #endif
 
                 // Report which device we're actually using
-                emit reportDevice(actualDevice);
                 bool success = m_llModelInfo.model->loadModel(filePath.toStdString(), n_ctx, ngl);
 
                 if (!m_shouldBeLoaded) {
-                    m_llModelInfo.model.reset();
+                    m_llModelInfo.resetModel(this);
                     if (!m_isServer)
                         LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
-                    m_llModelInfo = LLModelInfo();
+                    resetModel();
                     emit modelLoadingPercentageChanged(0.0f);
                     return false;
                 }
 
-                if (actualDevice == "CPU") {
+                if (actualDeviceIsCPU) {
                     // we asked llama.cpp to use the CPU
                 } else if (!success) {
                     // llama_init_from_file returned nullptr
-                    emit reportDevice("CPU");
-                    emit reportFallbackReason("<br>GPU loading failed (out of VRAM?)");
+                    m_llModelInfo.fallbackReason = "GPU loading failed (out of VRAM?)";
                     modelLoadProps.insert("cpu_fallback_reason", "gpu_load_failed");
                     success = m_llModelInfo.model->loadModel(filePath.toStdString(), n_ctx, 0);
 
                     if (!m_shouldBeLoaded) {
-                        m_llModelInfo.model.reset();
+                        m_llModelInfo.resetModel(this);
                         if (!m_isServer)
                             LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
-                        m_llModelInfo = LLModelInfo();
+                        resetModel();
                         emit modelLoadingPercentageChanged(0.0f);
                         return false;
                     }
@@ -463,16 +465,15 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     // ggml_vk_init was not called in llama.cpp
                     // We might have had to fallback to CPU after load if the model is not possible to accelerate
                     // for instance if the quantization method is not supported on Vulkan yet
-                    emit reportDevice("CPU");
-                    emit reportFallbackReason("<br>model or quant has no GPU support");
+                    m_llModelInfo.fallbackReason = "model or quant has no GPU support";
                     modelLoadProps.insert("cpu_fallback_reason", "gpu_unsupported_model");
                 }
 
                 if (!success) {
-                    m_llModelInfo.model.reset();
+                    m_llModelInfo.resetModel(this);
                     if (!m_isServer)
                         LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
-                    m_llModelInfo = LLModelInfo();
+                    resetModel();
                     emit modelLoadingError(QString("Could not load model due to invalid model file for %1").arg(modelInfo.filename()));
                     modelLoadProps.insert("error", "loadmodel_failed");
                 } else {
@@ -481,10 +482,10 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                     case 'G': m_llModelType = LLModelType::GPTJ_; break;
                     default:
                         {
-                            m_llModelInfo.model.reset();
+                            m_llModelInfo.resetModel(this);
                             if (!m_isServer)
                                 LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
-                            m_llModelInfo = LLModelInfo();
+                            resetModel();
                             emit modelLoadingError(QString("Could not determine model type for %1").arg(modelInfo.filename()));
                         }
                     }
@@ -494,7 +495,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
             } else {
                 if (!m_isServer)
                     LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo));
-                m_llModelInfo = LLModelInfo();
+                resetModel();
                 emit modelLoadingError(QString("Error loading %1: %2").arg(modelInfo.filename()).arg(constructError));
             }
         }
@@ -507,6 +508,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
         fflush(stdout);
 #endif
         emit modelLoadingPercentageChanged(isModelLoaded() ? 1.0f : 0.0f);
+        emit loadedModelInfoChanged();
 
         modelLoadProps.insert("requestedDevice", MySettings::globalInstance()->device());
         modelLoadProps.insert("model", modelInfo.filename());
@@ -514,7 +516,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
     } else {
         if (!m_isServer)
             LLModelStore::globalInstance()->releaseModel(std::move(m_llModelInfo)); // release back into the store
-        m_llModelInfo = LLModelInfo();
+        resetModel();
         emit modelLoadingError(QString("Could not find file for model %1").arg(modelInfo.filename()));
     }
 
@@ -601,6 +603,16 @@ void ChatLLM::setModelInfo(const ModelInfo &modelInfo)
 {
     m_modelInfo = modelInfo;
     emit modelInfoChanged(modelInfo);
+}
+
+void ChatLLM::acquireModel() {
+    m_llModelInfo = LLModelStore::globalInstance()->acquireModel();
+    emit loadedModelInfoChanged();
+}
+
+void ChatLLM::resetModel() {
+    m_llModelInfo = {};
+    emit loadedModelInfoChanged();
 }
 
 void ChatLLM::modelChangeRequested(const ModelInfo &modelInfo)
@@ -787,7 +799,7 @@ void ChatLLM::unloadModel()
 #endif
 
     if (m_forceUnloadModel) {
-        m_llModelInfo.model.reset();
+        m_llModelInfo.resetModel(this);
         m_forceUnloadModel = false;
     }
 

--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -400,6 +400,7 @@ bool ChatLLM::loadModel(const ModelInfo &modelInfo)
                         memGB = std::floor(memGB * 10.f) / 10.f; // truncate to 1 decimal place
                         modelLoadProps.insert("default_device", QString::fromStdString(defaultDevice->name));
                         modelLoadProps.insert("default_device_mem", approxDeviceMemGB(defaultDevice));
+                        modelLoadProps.insert("default_device_backend", QString::fromStdString(defaultDevice->backendName()));
                     }
                 }
 

--- a/gpt4all-chat/network.cpp
+++ b/gpt4all-chat/network.cpp
@@ -276,7 +276,7 @@ void Network::trackChatEvent(const QString &ev, QVariantMap props)
     const auto &curChat = ChatListModel::globalInstance()->currentChat();
     if (!props.contains("model"))
         props.insert("model", curChat->modelInfo().filename());
-    props.insert("deviceBackend", curChat->deviceBackend());
+    props.insert("device_backend", curChat->deviceBackend());
     props.insert("actualDevice", curChat->device());
     props.insert("doc_collections_enabled", curChat->collectionList().count());
     props.insert("doc_collections_total", LocalDocs::globalInstance()->localDocsModel()->rowCount());

--- a/gpt4all-chat/network.cpp
+++ b/gpt4all-chat/network.cpp
@@ -276,6 +276,7 @@ void Network::trackChatEvent(const QString &ev, QVariantMap props)
     const auto &curChat = ChatListModel::globalInstance()->currentChat();
     if (!props.contains("model"))
         props.insert("model", curChat->modelInfo().filename());
+    props.insert("deviceBackend", curChat->deviceBackend());
     props.insert("actualDevice", curChat->device());
     props.insert("doc_collections_enabled", curChat->collectionList().count());
     props.insert("doc_collections_total", LocalDocs::globalInstance()->localDocsModel()->rowCount());

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1363,7 +1363,21 @@ Rectangle {
             anchors.rightMargin: 30
             color: theme.mutedTextColor
             visible: currentChat.tokenSpeed !== ""
-            text: qsTr("Speed: ") + currentChat.tokenSpeed + "<br>" + qsTr("Device: ") + currentChat.device + currentChat.fallbackReason
+            text: {
+                const lines = [qsTr("Speed: ") + currentChat.tokenSpeed];
+                const device = currentChat.device;
+                const backend = currentChat.deviceBackend;
+                if (device !== null) {
+                    var deviceLine = qsTr("Device: ") + device;
+                    if (backend === "CUDA" || backend === "Vulkan")
+                        deviceLine += ` (${backend})`;
+                    lines.push(deviceLine);
+                }
+                const fallbackReason = currentChat.fallbackReason;
+                if (fallbackReason !== null && fallbackReason !== "")
+                    lines.push(fallbackReason);
+                return lines.join("<br/>");
+            }
             font.pixelSize: theme.fontSizeLarge
         }
 


### PR DESCRIPTION
### Functional Changes
- When you switch chats in the UI and they both use the same model, the device and fallback reason reported in the lower-right corner of the chat no longer become blank.
- In Mixpanel, actualDevice was blank about 7% of the time because of the above issue. This is now fixed.
- In Mixpanel, v2.8.0 reported devices as e.g. `actualDevice="GTX 970 (CUDA)"` and `actualDevice="Tesla P40 (Vulkan)"`. Now they are reported as `actualDevice="GTX 970", device_backend="CUDA"` and `actualDevice="Tesla P40", device_backend="Vulkan"`.
- `default_device` on Mixpanel still shows plain device names in v2.8.0. `default_device_backend` is added to supplement this (should always be "Vulkan" in official releases).

### Other Changes
- Remove LLModel::hasGPUDevice and llmodel_has_gpu_device. In current GPT4All, it is always true if the last call to initializeGPUDevice returned true. There are no users of this function. (cc @jacoobes @iimez - the ts bindings still reference this, likely incorrectly)
- Replace the llama.cpp hack that sets n_gpu_layers to zero when Kompute falls back to CPU with a more reasonable API that introduces llama_model_using_gpu.