### PR TITLE
Update checkout action to v4 in codespell workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
## Describe your changes

This addresses the "Node.js 16 actions are deprecated" warning in GitHub Action runs of the codespell workflow by increasing the checkout action's version to v4.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce

Previous runs show the deprecation warning `Node.js 16 actions are deprecated`, e.g. on [this run](https://github.com/nomic-ai/gpt4all/actions/runs/9386591872)
