### PR TITLE
database: call cleanDB() on startup

### DIFF
--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -968,6 +968,7 @@ void Database::start()
     if (m_embeddings->fileExists() && !m_embeddings->load())
         qWarning() << "ERROR: Could not load embeddings";
 
+    cleanDB();
     int nAdded = addCurrentFolders();
     Network::globalInstance()->trackEvent("localdocs_startup", { {"doc_collections_total", nAdded} });
 }


### PR DESCRIPTION
If you delete a document from a localdocs collection while GPT4All is not running, it does not notice and continues to reference the document. We already have a cleanDB() function to find deleted documents, but until now it has only run when a collection is modified while GPT4All is running.

Fix this issue by calling cleanDB() on startup. Now, when you delete a document from a localdocs collection, it is no longer referenced after starting GPT4All.