### PR TITLE
[NEW UI] configurable LocalDocs file extensions

### DIFF
--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -34,43 +34,43 @@ using namespace Qt::Literals::StringLiterals;
 
 static int s_batchSize = 100;
 
-static const auto INSERT_CHUNK_SQL = QLatin1String(R"(
+static const QString INSERT_CHUNK_SQL = uR"(
     insert into chunks(document_id, chunk_text,
         file, title, author, subject, keywords, page, line_from, line_to, words)
         values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-    )");
+    )"_s;
 
-static const auto INSERT_CHUNK_FTS_SQL = QLatin1String(R"(
+static const QString INSERT_CHUNK_FTS_SQL = uR"(
     insert into chunks_fts(document_id, chunk_id, chunk_text,
         file, title, author, subject, keywords, page, line_from, line_to)
         values(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-    )");
+    )"_s;
 
-static const auto DELETE_CHUNKS_SQL = QLatin1String(R"(
+static const QString DELETE_CHUNKS_SQL = uR"(
     delete from chunks WHERE document_id = ?;
-    )");
+    )"_s;
 
-static const auto DELETE_CHUNKS_FTS_SQL = QLatin1String(R"(
+static const QString DELETE_CHUNKS_FTS_SQL = uR"(
     delete from chunks_fts WHERE document_id = ?;
-    )");
+    )"_s;
 
-static const auto CHUNKS_SQL = QLatin1String(R"(
+static const QString CHUNKS_SQL = uR"(
     create table chunks(document_id integer, chunk_id integer primary key autoincrement, chunk_text varchar,
         file varchar, title varchar, author varchar, subject varchar, keywords varchar,
         page integer, line_from integer, line_to integer, words integer default 0, tokens integer default 0,
         has_embedding integer default 0);
-    )");
+    )"_s;
 
-static const auto FTS_CHUNKS_SQL = QLatin1String(R"(
+static const QString FTS_CHUNKS_SQL = uR"(
     create virtual table chunks_fts using fts5(document_id unindexed, chunk_id unindexed, chunk_text,
         file, title, author, subject, keywords, page, line_from, line_to, tokenize="trigram");
-    )");
+    )"_s;
 
-static const auto SELECT_CHUNKS_BY_DOCUMENT_SQL = QLatin1String(R"(
+static const QString SELECT_CHUNKS_BY_DOCUMENT_SQL = uR"(
     select chunk_id from chunks WHERE document_id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_CHUNKS_SQL = QLatin1String(R"(
+static const QString SELECT_CHUNKS_SQL = uR"(
     select chunks.chunk_id, documents.document_time,
         chunks.chunk_text, chunks.file, chunks.title, chunks.author, chunks.page,
         chunks.line_from, chunks.line_to
@@ -79,9 +79,9 @@ static const auto SELECT_CHUNKS_SQL = QLatin1String(R"(
     join folders ON documents.folder_id = folders.id
     join collections ON folders.id = collections.folder_id
     where chunks.chunk_id in (%1) and collections.collection_name in (%2);
-)");
+)"_s;
 
-static const auto SELECT_NGRAM_SQL = QLatin1String(R"(
+static const QString SELECT_NGRAM_SQL = uR"(
     select chunks_fts.chunk_id, documents.document_time,
         chunks_fts.chunk_text, chunks_fts.file, chunks_fts.title, chunks_fts.author, chunks_fts.page,
         chunks_fts.line_from, chunks_fts.line_to
@@ -92,13 +92,13 @@ static const auto SELECT_NGRAM_SQL = QLatin1String(R"(
     where chunks_fts match ? and collections.collection_name in (%1)
     order by bm25(chunks_fts)
     limit %2;
-    )");
+    )"_s;
 
-static const auto SELECT_FILE_FOR_CHUNK_SQL = QLatin1String(R"(
+static const QString SELECT_FILE_FOR_CHUNK_SQL = uR"(
     select c.file
     from chunks c
     where c.chunk_id = ?;
-    )");
+    )"_s;
 
 static bool selectFileForChunk(QSqlQuery &q, int chunk_id, QString &file) {
     if (!q.prepare(SELECT_FILE_FOR_CHUNK_SQL))
@@ -112,23 +112,23 @@ static bool selectFileForChunk(QSqlQuery &q, int chunk_id, QString &file) {
     return true;
 }
 
-static const auto SELECT_UNCOMPLETED_CHUNKS_SQL = QLatin1String(R"(
+static const QString SELECT_UNCOMPLETED_CHUNKS_SQL = uR"(
     select c.chunk_id, c.chunk_text as chunk, d.folder_id
     from chunks c
     join documents d ON c.document_id = d.id
     where c.has_embedding != 1 and d.folder_id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_COUNT_CHUNKS_SQL = QLatin1String(R"(
+static const QString SELECT_COUNT_CHUNKS_SQL = uR"(
     select count(c.chunk_id) as total_chunks
     from chunks c
     join documents d on c.document_id = d.id
     where d.folder_id = ?;
-    )");
+    )"_s;
 
-static const auto UPDATE_CHUNK_HAS_EMBEDDING = QLatin1String(R"(
+static const QString UPDATE_CHUNK_HAS_EMBEDDING_SQL = uR"(
     update chunks set has_embedding = 1 where chunk_id = ?;
-    )");
+    )"_s;
 
 static bool addChunk(QSqlQuery &q, int document_id, const QString &chunk_text, const QString &file,
                      const QString &title, const QString &author, const QString &subject, const QString &keywords,
@@ -228,7 +228,7 @@ static bool selectCountChunks(QSqlQuery &q, int folder_id, int &count) {
 }
 
 static bool updateChunkHasEmbedding(QSqlQuery &q, int chunk_id) {
-    if (!q.prepare(UPDATE_CHUNK_HAS_EMBEDDING))
+    if (!q.prepare(UPDATE_CHUNK_HAS_EMBEDDING_SQL))
         return false;
     q.addBindValue(chunk_id);
     if (!q.exec())
@@ -298,48 +298,48 @@ static bool selectChunk(QSqlQuery &q, const QList<QString> &collection_names, co
     return true;
 }
 
-static const auto INSERT_COLLECTION_SQL = QLatin1String(R"(
+static const QString INSERT_COLLECTION_SQL = uR"(
     insert into collections(collection_name, folder_id, last_update_time, embedding_model, force_indexing) values(?, ?, ?, ?, ?);
-    )");
+    )"_s;
 
-static const auto DELETE_COLLECTION_SQL = QLatin1String(R"(
+static const QString DELETE_COLLECTION_SQL = uR"(
     delete from collections where collection_name = ? and folder_id = ?;
-    )");
+    )"_s;
 
-static const auto COLLECTIONS_SQL = QLatin1String(R"(
+static const QString COLLECTIONS_SQL = uR"(
     create table collections(collection_name varchar, folder_id integer, last_update_time integer, embedding_model varchar, force_indexing integer, unique(collection_name, folder_id));
-    )");
+    )"_s;
 
-static const auto SELECT_FOLDERS_FROM_COLLECTIONS_SQL = QLatin1String(R"(
+static const QString SELECT_FOLDERS_FROM_COLLECTIONS_SQL = uR"(
     select f.id, f.folder_path
     from collections c
     join folders f on c.folder_id = f.id
     where collection_name = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_COLLECTIONS_FROM_FOLDER_SQL = QLatin1String(R"(
+static const QString SELECT_COLLECTIONS_FROM_FOLDER_SQL = uR"(
     select collection_name from collections where folder_id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_COLLECTIONS_SQL_V1 = QLatin1String(R"(
+static const QString SELECT_COLLECTIONS_SQL_V1 = uR"(
     select c.collection_name, f.folder_path, f.id
     from collections c
     join folders f on c.folder_id = f.id
     order by c.collection_name asc, f.folder_path asc;
-    )");
+    )"_s;
 
-static const auto SELECT_COLLECTIONS_SQL_V2 = QLatin1String(R"(
+static const QString SELECT_COLLECTIONS_SQL_V2 = uR"(
     select c.collection_name, f.folder_path, f.id, c.last_update_time, c.embedding_model, c.force_indexing
     from collections c
     join folders f on c.folder_id = f.id
     order by c.collection_name asc, f.folder_path asc;
-    )");
+    )"_s;
 
-static const auto UPDATE_COLLECTION_FORCE_INDEXING = QLatin1String(R"(
+static const QString UPDATE_COLLECTION_FORCE_INDEXING_SQL = uR"(
     update collections
     set force_indexing = 0
     where collection_name = ?;
-    )");
+    )"_s;
 
 static bool addCollection(QSqlQuery &q, const QString &collection_name, int folder_id, const QDateTime &last_update,
                           const QString &embedding_model, bool force_indexing)
@@ -427,35 +427,35 @@ static bool selectAllFromCollections(QSqlQuery &q, QList<CollectionItem> *collec
 }
 
 static bool updateCollectionForceIndexing(QSqlQuery &q, const QString &collection_name) {
-    if (!q.prepare(UPDATE_COLLECTION_FORCE_INDEXING))
+    if (!q.prepare(UPDATE_COLLECTION_FORCE_INDEXING_SQL))
         return false;
     q.addBindValue(collection_name);
     return q.exec();
 }
 
-static const auto INSERT_FOLDERS_SQL = QLatin1String(R"(
+static const QString INSERT_FOLDERS_SQL = uR"(
     insert into folders(folder_path) values(?);
-    )");
+    )"_s;
 
-static const auto DELETE_FOLDERS_SQL = QLatin1String(R"(
+static const QString DELETE_FOLDERS_SQL = uR"(
     delete from folders where id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_FOLDERS_FROM_PATH_SQL = QLatin1String(R"(
+static const QString SELECT_FOLDERS_FROM_PATH_SQL = uR"(
     select id from folders where folder_path = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_FOLDERS_FROM_ID_SQL = QLatin1String(R"(
+static const QString SELECT_FOLDERS_FROM_ID_SQL = uR"(
     select folder_path from folders where id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_ALL_FOLDERPATHS_SQL = QLatin1String(R"(
+static const QString SELECT_ALL_FOLDERPATHS_SQL = uR"(
     select folder_path from folders;
-    )");
+    )"_s;
 
-static const auto FOLDERS_SQL = QLatin1String(R"(
+static const QString FOLDERS_SQL = uR"(
     create table folders(id integer primary key, folder_path varchar unique);
-    )");
+    )"_s;
 
 static bool addFolderToDB(QSqlQuery &q, const QString &folder_path, int *folder_id)
 {
@@ -509,40 +509,40 @@ static bool selectAllFolderPaths(QSqlQuery &q, QList<QString> *folder_paths) {
     return true;
 }
 
-static const auto INSERT_DOCUMENTS_SQL = QLatin1String(R"(
+static const QString INSERT_DOCUMENTS_SQL = uR"(
     insert into documents(folder_id, document_time, document_path) values(?, ?, ?);
-    )");
+    )"_s;
 
-static const auto UPDATE_DOCUMENT_TIME_SQL = QLatin1String(R"(
+static const QString UPDATE_DOCUMENT_TIME_SQL = uR"(
     update documents set document_time = ? where id = ?;
-    )");
+    )"_s;
 
-static const auto DELETE_DOCUMENTS_SQL = QLatin1String(R"(
+static const QString DELETE_DOCUMENTS_SQL = uR"(
     delete from documents where id = ?;
-    )");
+    )"_s;
 
-static const auto DOCUMENTS_SQL = QLatin1String(R"(
+static const QString DOCUMENTS_SQL = uR"(
     create table documents(id integer primary key, folder_id integer, document_time integer, document_path varchar unique);
-    )");
+    )"_s;
 
-static const auto SELECT_DOCUMENT_SQL = QLatin1String(R"(
+static const QString SELECT_DOCUMENT_SQL = uR"(
     select id, document_time from documents where document_path = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_DOCUMENTS_SQL = QLatin1String(R"(
+static const QString SELECT_DOCUMENTS_SQL = uR"(
     select id from documents where folder_id = ?;
-    )");
+    )"_s;
 
-static const auto SELECT_ALL_DOCUMENTS_SQL = QLatin1String(R"(
+static const QString SELECT_ALL_DOCUMENTS_SQL = uR"(
     select id, document_path from documents;
-    )");
+    )"_s;
 
-static const auto SELECT_COUNT_STATISTICS_SQL = QLatin1String(R"(
+static const QString SELECT_COUNT_STATISTICS_SQL = uR"(
     select count(distinct d.id) as total_docs, sum(c.words) as total_words, sum(c.tokens) as total_tokens
     from documents d
     left join chunks c on d.id = c.document_id
     where d.folder_id = ?;
-    )");
+    )"_s;
 
 static bool addDocument(QSqlQuery &q, int folder_id, qint64 document_time, const QString &document_path, int *document_id)
 {

--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -1182,11 +1182,17 @@ bool Database::scanQueue(QList<int> &chunksToRemove)
         const size_t bytes = info.doc.size();
         QTextStream stream(&file);
         const size_t byteIndex = info.currentPosition;
-        if (!stream.seek(byteIndex)) {
-            handleDocumentError("ERROR: Cannot seek to pos for scanning",
-                                existing_id, document_path, q.lastError());
-            scheduleNext(folder_id, countForFolder);
-            return false;
+        if (byteIndex) {
+            /* Read the Unicode BOM to detect the encoding. Without this, QTextStream will
+             * always interpret the text as UTF-8 when byteIndex is nonzero. */
+            stream.read(1);
+
+            if (!stream.seek(byteIndex)) {
+                handleDocumentError("ERROR: Cannot seek to pos for scanning",
+                                    existing_id, document_path, q.lastError());
+                scheduleNext(folder_id, countForFolder);
+                return false;
+            }
         }
 #if defined(DEBUG)
         qDebug() << "scanning byteIndex" << byteIndex << "of" << bytes << document_path;

--- a/gpt4all-chat/database.h
+++ b/gpt4all-chat/database.h
@@ -140,7 +140,7 @@ private:
     void removeFolderFromDocumentQueue(int folder_id);
     void enqueueDocumentInternal(const DocumentInfo &info, bool prepend = false);
     void enqueueDocuments(int folder_id, const QVector<DocumentInfo> &infos);
-    bool scanQueue(QList<int> &chunksToRemove);
+    void scanQueue(QList<int> &chunksToRemove);
     bool cleanDB();
     void addFolderToWatch(const QString &path);
     void removeFolderFromWatch(const QString &path);

--- a/gpt4all-chat/database.h
+++ b/gpt4all-chat/database.h
@@ -81,7 +81,7 @@ class Database : public QObject
 {
     Q_OBJECT
 public:
-    Database(int chunkSize);
+    Database(int chunkSize, const QStringList &extensions);
     virtual ~Database();
 
     bool isValid() const { return m_databaseValid; }
@@ -95,6 +95,7 @@ public Q_SLOTS:
     void removeFolder(const QString &collection, const QString &path);
     void retrieveFromDB(const QList<QString> &collections, const QString &text, int retrievalSize, QList<ResultInfo> *results);
     void changeChunkSize(int chunkSize);
+    void changeFileExtensions(const QStringList &extensions);
 
 Q_SIGNALS:
     // Signals for the gui only
@@ -155,6 +156,7 @@ private:
 private:
     QSqlDatabase m_db;
     int m_chunkSize;
+    QStringList m_scannedFileExtensions;
     QTimer *m_scanTimer;
     QMap<int, QQueue<DocumentInfo>> m_docsToScan;
     QList<ResultInfo> m_retrieve;

--- a/gpt4all-chat/localdocs.cpp
+++ b/gpt4all-chat/localdocs.cpp
@@ -22,9 +22,11 @@ LocalDocs::LocalDocs()
     , m_database(nullptr)
 {
     connect(MySettings::globalInstance(), &MySettings::localDocsChunkSizeChanged, this, &LocalDocs::handleChunkSizeChanged);
+    connect(MySettings::globalInstance(), &MySettings::localDocsFileExtensionsChanged, this, &LocalDocs::handleFileExtensionsChanged);
 
     // Create the DB with the chunk size from settings
-    m_database = new Database(MySettings::globalInstance()->localDocsChunkSize());
+    m_database = new Database(MySettings::globalInstance()->localDocsChunkSize(),
+                              MySettings::globalInstance()->localDocsFileExtensions());
 
     connect(this, &LocalDocs::requestStart, m_database,
         &Database::start, Qt::QueuedConnection);
@@ -36,6 +38,8 @@ LocalDocs::LocalDocs()
         &Database::removeFolder, Qt::QueuedConnection);
     connect(this, &LocalDocs::requestChunkSizeChange, m_database,
         &Database::changeChunkSize, Qt::QueuedConnection);
+    connect(this, &LocalDocs::requestFileExtensionsChange, m_database,
+        &Database::changeFileExtensions, Qt::QueuedConnection);
     connect(m_database, &Database::databaseValidChanged,
         this, &LocalDocs::databaseValidChanged, Qt::QueuedConnection);
 
@@ -79,4 +83,9 @@ void LocalDocs::removeFolder(const QString &collection, const QString &path)
 void LocalDocs::handleChunkSizeChanged()
 {
     emit requestChunkSizeChange(MySettings::globalInstance()->localDocsChunkSize());
+}
+
+void LocalDocs::handleFileExtensionsChanged()
+{
+    emit requestFileExtensionsChange(MySettings::globalInstance()->localDocsFileExtensions());
 }

--- a/gpt4all-chat/localdocs.h
+++ b/gpt4all-chat/localdocs.h
@@ -28,6 +28,7 @@ public:
 
 public Q_SLOTS:
     void handleChunkSizeChanged();
+    void handleFileExtensionsChanged();
     void aboutToQuit();
 
 Q_SIGNALS:
@@ -36,6 +37,7 @@ Q_SIGNALS:
     void requestAddFolder(const QString &collection, const QString &path);
     void requestRemoveFolder(const QString &collection, const QString &path);
     void requestChunkSizeChange(int chunkSize);
+    void requestFileExtensionsChange(const QStringList &extensions);
     void localDocsModelChanged();
     void databaseValidChanged();
 

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -45,6 +45,7 @@ static const QVariantMap basicDefaults {
     { "localdocs/chunkSize",      256 },
     { "localdocs/retrievalSize",  3 },
     { "localdocs/showReferences", true },
+    { "localdocs/fileExtensions", QStringList { "txt", "pdf", "md", "rst" } },
     { "network/attribution",      "" },
 };
 
@@ -364,29 +365,31 @@ void MySettings::setThreadCount(int value)
     emit threadCountChanged();
 }
 
-bool    MySettings::saveChatsContext() const        { return getBasicSetting("saveChatsContext"        ).toBool(); }
-bool    MySettings::serverChat() const              { return getBasicSetting("serverChat"              ).toBool(); }
-int     MySettings::networkPort() const             { return getBasicSetting("networkPort"             ).toInt(); }
-QString MySettings::userDefaultModel() const        { return getBasicSetting("userDefaultModel"        ).toString(); }
-QString MySettings::chatTheme() const               { return getBasicSetting("chatTheme"               ).toString(); }
-QString MySettings::fontSize() const                { return getBasicSetting("fontSize"                ).toString(); }
-QString MySettings::lastVersionStarted() const      { return getBasicSetting("lastVersionStarted"      ).toString(); }
-int     MySettings::localDocsChunkSize() const      { return getBasicSetting("localdocs/chunkSize"     ).toInt(); }
-int     MySettings::localDocsRetrievalSize() const  { return getBasicSetting("localdocs/retrievalSize" ).toInt(); }
-bool    MySettings::localDocsShowReferences() const { return getBasicSetting("localdocs/showReferences").toBool(); }
-QString MySettings::networkAttribution() const      { return getBasicSetting("network/attribution"     ).toString(); }
+bool        MySettings::saveChatsContext() const        { return getBasicSetting("saveChatsContext"        ).toBool(); }
+bool        MySettings::serverChat() const              { return getBasicSetting("serverChat"              ).toBool(); }
+int         MySettings::networkPort() const             { return getBasicSetting("networkPort"             ).toInt(); }
+QString     MySettings::userDefaultModel() const        { return getBasicSetting("userDefaultModel"        ).toString(); }
+QString     MySettings::chatTheme() const               { return getBasicSetting("chatTheme"               ).toString(); }
+QString     MySettings::fontSize() const                { return getBasicSetting("fontSize"                ).toString(); }
+QString     MySettings::lastVersionStarted() const      { return getBasicSetting("lastVersionStarted"      ).toString(); }
+int         MySettings::localDocsChunkSize() const      { return getBasicSetting("localdocs/chunkSize"     ).toInt(); }
+int         MySettings::localDocsRetrievalSize() const  { return getBasicSetting("localdocs/retrievalSize" ).toInt(); }
+bool        MySettings::localDocsShowReferences() const { return getBasicSetting("localdocs/showReferences").toBool(); }
+QStringList MySettings::localDocsFileExtensions() const { return getBasicSetting("localdocs/fileExtensions").toStringList(); }
+QString     MySettings::networkAttribution() const      { return getBasicSetting("network/attribution"     ).toString(); }
 
-void MySettings::setSaveChatsContext(bool value)             { setBasicSetting("saveChatsContext",         value); }
-void MySettings::setServerChat(bool value)                   { setBasicSetting("serverChat",               value); }
-void MySettings::setNetworkPort(int value)                   { setBasicSetting("networkPort",              value); }
-void MySettings::setUserDefaultModel(const QString &value)   { setBasicSetting("userDefaultModel",         value); }
-void MySettings::setChatTheme(const QString &value)          { setBasicSetting("chatTheme",                value); }
-void MySettings::setFontSize(const QString &value)           { setBasicSetting("fontSize",                 value); }
-void MySettings::setLastVersionStarted(const QString &value) { setBasicSetting("lastVersionStarted",       value); }
-void MySettings::setLocalDocsChunkSize(int value)            { setBasicSetting("localdocs/chunkSize",      value, "localDocsChunkSize"); }
-void MySettings::setLocalDocsRetrievalSize(int value)        { setBasicSetting("localdocs/retrievalSize",  value, "localDocsRetrievalSize"); }
-void MySettings::setLocalDocsShowReferences(bool value)      { setBasicSetting("localdocs/showReferences", value, "localDocsShowReferences"); }
-void MySettings::setNetworkAttribution(const QString &value) { setBasicSetting("network/attribution",      value, "networkAttribution"); }
+void MySettings::setSaveChatsContext(bool value)                      { setBasicSetting("saveChatsContext",         value); }
+void MySettings::setServerChat(bool value)                            { setBasicSetting("serverChat",               value); }
+void MySettings::setNetworkPort(int value)                            { setBasicSetting("networkPort",              value); }
+void MySettings::setUserDefaultModel(const QString &value)            { setBasicSetting("userDefaultModel",         value); }
+void MySettings::setChatTheme(const QString &value)                   { setBasicSetting("chatTheme",                value); }
+void MySettings::setFontSize(const QString &value)                    { setBasicSetting("fontSize",                 value); }
+void MySettings::setLastVersionStarted(const QString &value)          { setBasicSetting("lastVersionStarted",       value); }
+void MySettings::setLocalDocsChunkSize(int value)                     { setBasicSetting("localdocs/chunkSize",      value, "localDocsChunkSize"); }
+void MySettings::setLocalDocsRetrievalSize(int value)                 { setBasicSetting("localdocs/retrievalSize",  value, "localDocsRetrievalSize"); }
+void MySettings::setLocalDocsShowReferences(bool value)               { setBasicSetting("localdocs/showReferences", value, "localDocsShowReferences"); }
+void MySettings::setLocalDocsFileExtensions(const QStringList &value) { setBasicSetting("localdocs/fileExtensions", value, "localDocsFileExtensions"); }
+void MySettings::setNetworkAttribution(const QString &value)          { setBasicSetting("network/attribution",      value, "networkAttribution"); }
 
 QString MySettings::modelPath()
 {

--- a/gpt4all-chat/mysettings.h
+++ b/gpt4all-chat/mysettings.h
@@ -27,6 +27,7 @@ class MySettings : public QObject
     Q_PROPERTY(int localDocsChunkSize READ localDocsChunkSize WRITE setLocalDocsChunkSize NOTIFY localDocsChunkSizeChanged)
     Q_PROPERTY(int localDocsRetrievalSize READ localDocsRetrievalSize WRITE setLocalDocsRetrievalSize NOTIFY localDocsRetrievalSizeChanged)
     Q_PROPERTY(bool localDocsShowReferences READ localDocsShowReferences WRITE setLocalDocsShowReferences NOTIFY localDocsShowReferencesChanged)
+    Q_PROPERTY(QStringList localDocsFileExtensions READ localDocsFileExtensions WRITE setLocalDocsFileExtensions NOTIFY localDocsFileExtensionsChanged)
     Q_PROPERTY(QString networkAttribution READ networkAttribution WRITE setNetworkAttribution NOTIFY networkAttributionChanged)
     Q_PROPERTY(bool networkIsActive READ networkIsActive WRITE setNetworkIsActive NOTIFY networkIsActiveChanged)
     Q_PROPERTY(bool networkUsageStatsActive READ networkUsageStatsActive WRITE setNetworkUsageStatsActive NOTIFY networkUsageStatsActiveChanged)
@@ -128,6 +129,8 @@ public:
     void setLocalDocsRetrievalSize(int value);
     bool localDocsShowReferences() const;
     void setLocalDocsShowReferences(bool value);
+    QStringList localDocsFileExtensions() const;
+    void setLocalDocsFileExtensions(const QStringList &value);
 
     // Network settings
     QString networkAttribution() const;
@@ -172,6 +175,7 @@ Q_SIGNALS:
     void localDocsChunkSizeChanged();
     void localDocsRetrievalSizeChanged();
     void localDocsShowReferencesChanged();
+    void localDocsFileExtensionsChanged();
     void networkAttributionChanged();
     void networkIsActiveChanged();
     void networkPortChanged();

--- a/gpt4all-chat/qml/ApplicationSettings.qml
+++ b/gpt4all-chat/qml/ApplicationSettings.qml
@@ -332,15 +332,66 @@ MySettingsTab {
             Accessible.name: serverPortField.text
             Accessible.description: ToolTip.text
         }
+
+        MySettingsLabel {
+            id: extsLabel
+            text: qsTr("Allowed File Extensions")
+            helpText: qsTr("Comma-separated list. LocalDocs will only attempt to process files with these extensions.")
+            Layout.row: 11
+            Layout.column: 0
+        }
+        MyTextField {
+            id: extsField
+            text: MySettings.localDocsFileExtensions.join(',')
+            color: theme.textColor
+            font.pixelSize: theme.fontSizeLarge
+            ToolTip.text: extsLabel.helpText
+            ToolTip.visible: hovered
+            Layout.alignment: Qt.AlignRight
+            Layout.row: 11
+            Layout.column: 2
+            Layout.minimumWidth: 200
+            validator: RegularExpressionValidator {
+                regularExpression: /([^ ,\/"']+,?)*/
+            }
+            onEditingFinished: {
+                // split and remove empty elements
+                var exts = text.split(',').filter(e => e);
+                // normalize and deduplicate
+                exts = exts.map(e => e.toLowerCase());
+                exts = Array.from(new Set(exts));
+                /* Blacklist common unsupported file extensions. We only support plain text and PDFs, and although we
+                 * reject binary data, we don't want to waste time trying to index files that we don't support. */
+                exts = exts.filter(e => ![
+                    /* Microsoft documents  */ "rtf", "docx", "ppt", "pptx", "xls", "xlsx",
+                    /* OpenOffice           */ "odt", "ods", "odp", "odg",
+                    /* photos               */ "jpg", "jpeg", "png", "gif", "bmp", "tif", "tiff", "webp",
+                    /* audio                */ "mp3", "wma", "m4a", "wav", "flac",
+                    /* videos               */ "mp4", "mov", "webm", "mkv", "avi", "flv", "wmv",
+                    /* executables          */ "exe", "com", "dll", "so", "dylib", "msi",
+                    /* binary images        */ "iso", "img", "dmg",
+                    /* archives             */ "zip", "jar", "apk", "rar", "7z", "tar", "gz", "xz", "bz2", "tar.gz",
+                                               "tgz", "tar.xz", "tar.bz2",
+                    /* misc                 */ "bin",
+                ].includes(e));
+                MySettings.localDocsFileExtensions = exts;
+                extsField.text = exts.join(',');
+                focus = false;
+            }
+            Accessible.role: Accessible.EditableText
+            Accessible.name: extsLabel.text
+            Accessible.description: ToolTip.text
+        }
+
         MySettingsLabel {
             id: gpuOverrideLabel
             text: qsTr("Force Metal (macOS+arm)")
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 0
         }
         MyCheckBox {
             id: gpuOverrideBox
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             checked: MySettings.forceMetal
@@ -352,7 +403,7 @@ MySettingsTab {
         }
 
         Rectangle {
-            Layout.row: 12
+            Layout.row: 13
             Layout.column: 0
             Layout.columnSpan: 3
             Layout.fillWidth: true


### PR DESCRIPTION
The feature is fully implemented, except for the fact that there is no place for LocalDocs settings yet, so the setting is on the Application page.

Common binary file extensions (e.g. docx) are rejected and files containing binary data are ignored (they are counted as a file with no chunks - not counting the file would require a schema change or we would have to exclude all empty files).

![gpt4all-fextconfig](https://github.com/nomic-ai/gpt4all/assets/14168726/5fd3ef4b-2c0b-471f-b439-a655e44c3995)