### PR TITLE
docs: note that the GPT4All backend FAQ is out-of-date

### DIFF
--- a/gpt4all-backend/README.md
+++ b/gpt4all-backend/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This document is largely out-of-date. GPT4All supports more than 20 model architectures via llama.cpp. If you have a question about GPT4All, try asking on our [Discord](https://discord.gg/mGZE39AS3e).
+
 # GPT4ALL Backend
 This directory contains the C/C++ model backend used by GPT4All for inference on the CPU. This backend acts as a universal library/wrapper for all models that the GPT4All ecosystem supports. Language bindings are built on top of this universal library. The native GPT4all Chat application directly uses this library for all inference.
 

--- a/gpt4all-bindings/python/docs/gpt4all_faq.md
+++ b/gpt4all-bindings/python/docs/gpt4all_faq.md
@@ -1,3 +1,6 @@
+# NOTICE
+This document is largely out-of-date. GPT4All supports more than 20 model architectures via llama.cpp. If you have a question about GPT4All, try asking on our [Discord](https://discord.gg/mGZE39AS3e).
+
 # GPT4All FAQ
 
 ## What models are supported by the GPT4All ecosystem?


### PR DESCRIPTION
This document hasn't seen significant updates in over a year, yet it contains detailed descriptions of the GPT4All backend. Obviously, this is stale information that should generally be ignored - e.g., we support way more than three model architectures, and most of them are supported by llama.cpp, not just LLaMA.