### PR TITLE
Windows offline signing workflow

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -263,6 +263,18 @@ jobs:
             Invoke-WebRequest -Uri https://developer.download.nvidia.com/compute/cuda/12.4.1/network_installers/cuda_12.4.1_windows_network.exe -OutFile cuda_12.4.1_windows_network.exe
             .\cuda_12.4.1_windows_network.exe -s cudart_12.4 nvcc_12.4 cublas_12.4 cublas_dev_12.4
       - run:
+          name: "Install Dotnet 8"
+          command: |
+            mkdir dotnet
+            cd dotnet
+            $dotnet_url="https://download.visualstudio.microsoft.com/download/pr/5af098e1-e433-4fda-84af-3f54fd27c108/6bd1c6e48e64e64871957289023ca590/dotnet-sdk-8.0.302-win-x64.zip"
+            Invoke-WebRequest -Uri $dotnet_url -Outfile dotnet-sdk-8.0.302-win-x64.zip
+            Expand-Archive -LiteralPath .\dotnet-sdk-8.0.302-win-x64.zip
+            $Env:DOTNET_ROOT="$($(Get-Location).Path)\dotnet-sdk-8.0.302-win-x64"
+            $Env:PATH="$Env:DOTNET_ROOT;$Env:PATH"
+            $Env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=$true
+            dotnet tool install --global AzureSignTool
+      - run:
           name: Build
           command: |
             $Env:PATH = "${Env:PATH};C:\Program Files (x86)\Windows Kits\10\bin\x64"
@@ -300,6 +312,41 @@ jobs:
             copy gpt4all-installer-win64.exe upload
       - store_artifacts:
           path: build/upload
+            # add workspace so signing jobs can connect & obtain dmg
+      - persist_to_workspace:
+          root: build
+          # specify path to only include components we want to persist
+          # accross builds
+          paths:
+            - upload
+  sign-offline-chat-installer-windows:
+    machine:
+      image: 'windows-server-2019-vs2019:2022.08.1'
+      resource_class: windows.large
+      shell: powershell.exe -ExecutionPolicy Bypass
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: "Install Dotnet 8 && Azure Sign Tool"
+          command: |
+            mkdir dotnet
+            cd dotnet
+            $dotnet_url="https://download.visualstudio.microsoft.com/download/pr/5af098e1-e433-4fda-84af-3f54fd27c108/6bd1c6e48e64e64871957289023ca590/dotnet-sdk-8.0.302-win-x64.zip"
+            Invoke-WebRequest -Uri $dotnet_url -Outfile dotnet-sdk-8.0.302-win-x64.zip
+            Expand-Archive -LiteralPath .\dotnet-sdk-8.0.302-win-x64.zip
+            $Env:DOTNET_ROOT="$($(Get-Location).Path)\dotnet-sdk-8.0.302-win-x64"
+            $Env:PATH="$Env:DOTNET_ROOT;$Env:PATH"
+            $Env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=$true
+            dotnet tool install --global AzureSignTool
+      - run:
+          name: "Sign Windows Installer With AST"
+          command: |
+            AzureSignTool.exe sign -du "https://gpt4all.io/index.html" -kvu https://gpt4all.vault.azure.net -kvi "$Env:AZSignGUID" -kvs "$Env:AZSignPWD" -kvc "$Env:AZSignCertName" -kvt "$Env:AZSignTID" -tr http://timestamp.digicert.com -v "$($(Get-Location).Path)\build\upload\gpt4all-installer-win64.exe"
+      - store_artifacts:
+          path: build/upload
+
   build-gpt4all-chat-linux:
     machine:
       image: ubuntu-2204:2023.04.2
@@ -949,6 +996,9 @@ workflows:
       - build-offline-chat-installer-windows:
           requires:
             - hold
+      - sign-offline-chat-installer-windows:
+          requires:
+            - build-offline-chat-installer-windows
       - build-offline-chat-installer-linux:
           requires:
             - hold

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -22,6 +22,8 @@ set(APP_VERSION_PATCH 0)
 set(APP_VERSION_BASE "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}")
 set(APP_VERSION "${APP_VERSION_BASE}-rc5")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
+
 # Include the binary directory for the generated header file
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -287,10 +289,6 @@ target_link_libraries(chat
 
 # -- install --
 
-function(install_sign_osx tgt)
-    install(CODE "execute_process(COMMAND codesign --options runtime --timestamp -s \"${MAC_SIGNING_IDENTITY}\" $<TARGET_FILE:${tgt}>)")
-endfunction()
-
 set(COMPONENT_NAME_MAIN ${PROJECT_NAME})
 
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
@@ -334,10 +332,20 @@ install(
 )
 
 if(APPLE AND GPT4ALL_SIGN_INSTALL)
+    include(SignMacOSBinaries)
     install_sign_osx(chat)
     install_sign_osx(llmodel)
     foreach(tgt ${MODEL_IMPL_TARGETS})
         install_sign_osx(${tgt})
+    endforeach()
+endif()
+
+if(WIN32 AND GPT4ALL_SIGN_INSTALL)
+    include(SignWindowsBinaries)
+    sign_target_windows(chat)
+    sign_target_windows(llmodel)
+    foreach(tgt ${MODEL_IMPL_TARGETS})
+        sign_target_windows(${tgt})
     endforeach()
 endif()
 

--- a/gpt4all-chat/cmake/Modules/SignMacOSBinaries.cmake
+++ b/gpt4all-chat/cmake/Modules/SignMacOSBinaries.cmake
@@ -1,0 +1,3 @@
+function(install_sign_osx tgt)
+    install(CODE "execute_process(COMMAND codesign --options runtime --timestamp -s \"${MAC_SIGNING_IDENTITY}\" $<TARGET_FILE:${tgt}>)")
+endfunction()

--- a/gpt4all-chat/cmake/Modules/SignWindowsBinaries.cmake
+++ b/gpt4all-chat/cmake/Modules/SignWindowsBinaries.cmake
@@ -1,0 +1,17 @@
+function(sign_target_windows tgt)
+    if(WIN32 AND GPT4ALL_SIGN_INSTALL)
+        add_custom_command(TARGET ${tgt}
+            POST_BUILD
+            COMMAND AzureSignTool.exe sign
+                -du "https://gpt4all.io/index.html"
+                -kvu https://gpt4all.vault.azure.net
+                -kvi "$Env{AZSignGUID}"
+                -kvs "$Env{AZSignPWD}"
+                -kvc "$Env{AZSignCertName}"
+                -kvt "$Env{AZSignTID}"
+                -tr http://timestamp.digicert.com
+                -v
+                $<TARGET_FILE:${tgt}>
+        )
+    endif()
+endfunction()


### PR DESCRIPTION
## Describe your changes

Adds a Windows workflow signing produced Windows installers via the Azure Sign tool from certificates hosted in the AKV.

cc @manyoso 
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6213a47f7a6a39a08133044e1a31714ce064748e  | 
|--------|--------|

### Summary:
Added a Windows workflow for signing installers using Azure Sign Tool with certificates from Azure Key Vault, including necessary steps in CircleCI and CMake configurations.

**Key points**:
- Added Windows workflow for signing installers using Azure Sign Tool in `.circleci/continue_config.yml`.
- Included steps to install .NET 8 and Azure Sign Tool in `build-offline-chat-installer-windows` and `sign-offline-chat-installer-windows` jobs.
- Updated `gpt4all-chat/CMakeLists.txt` to include `SignWindowsBinaries.cmake` for signing Windows binaries.
- Created `gpt4all-chat/cmake/Modules/SignWindowsBinaries.cmake` for defining the `sign_target_windows` function.
- Ensured Windows binaries are signed post-build if `GPT4ALL_SIGN_INSTALL` is enabled.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->