### PR TITLE
fix: typos in reset context comments

### DIFF
--- a/gpt4all-chat/chat.cpp
+++ b/gpt4all-chat/chat.cpp
@@ -90,10 +90,10 @@ void Chat::reset()
     emit resetContextRequested();
     m_id = Network::globalInstance()->generateUniqueId();
     emit idChanged(m_id);
-    // NOTE: We deliberately do no reset the name or creation date to indictate that this was originally
+    // NOTE: We deliberately do no reset the name or creation date to indicate that this was originally
     // an older chat that was reset for another purpose. Resetting this data will lead to the chat
     // name label changing back to 'New Chat' and showing up in the chat model list as a 'New Chat'
-    // further down in the list. This might surprise the user. In the future, we me might get rid of
+    // further down in the list. This might surprise the user. In the future, we might get rid of
     // the "reset context" button in the UI. Right now, by changing the model in the combobox dropdown
     // we effectively do a reset context. We *have* to do this right now when switching between different
     // types of models. The only way to get rid of that would be a very long recalculate where we rebuild


### PR DESCRIPTION
Corrected two typos and a grammatical issue in the comments within the reset context code. Specifically:
- Changed "indictate" to "indicate"
- Corrected "me might" to "we might"

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->
