### PR TITLE
embllm: fix use of llama ctx before loading

### DIFF
--- a/gpt4all-chat/embllm.cpp
+++ b/gpt4all-chat/embllm.cpp
@@ -84,10 +84,6 @@ bool EmbeddingLLMWorker::loadModel()
         return false;
     }
 
-    // FIXME(jared): the user may want this to take effect without having to restart
-    int n_threads = MySettings::globalInstance()->threadCount();
-    m_model->setThreadCount(n_threads);
-
     // NOTE: explicitly loads model on CPU to avoid GPU OOM
     // TODO(cebtenzzre): support GPU-accelerated embeddings
     bool success = m_model->loadModel(filePath.toStdString(), 2048, 0);
@@ -104,6 +100,11 @@ bool EmbeddingLLMWorker::loadModel()
         m_model = nullptr;
         return false;
     }
+
+    // FIXME(jared): the user may want this to take effect without having to restart
+    int n_threads = MySettings::globalInstance()->threadCount();
+    m_model->setThreadCount(n_threads);
+
     return true;
 }
 


### PR DESCRIPTION
This fixes a regression in PR #2396.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 36266148d1a75f107bf58bcae8e1ff59fdcb4330  | 
|--------|--------|

### Summary:
Fixes regression by moving thread count setting after model loading in `EmbeddingLLMWorker::loadModel`.

**Key points**:
- Fixes regression from PR #2396 in `gpt4all-chat/embllm.cpp`.
- Moves `setThreadCount` call after `loadModel` in `EmbeddingLLMWorker::loadModel`.
- Ensures model is initialized before setting thread count.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->