### PR TITLE
Fix the open document on windows.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -835,7 +835,15 @@ Rectangle {
                                                     anchors.fill: parent
                                                     hoverEnabled: true
                                                     onClicked: function() {
-                                                        Qt.openUrlExternally("file://" + modelData.path)
+                                                        Qt.openUrlExternally(getAdjustedFileUrl(modelData.path))
+                                                    }
+
+                                                    function getAdjustedFileUrl(filePath) {
+                                                        var url = "file://"
+                                                        if (Qt.platform.os === "windows") {
+                                                            url += "/"
+                                                        }
+                                                        return url + filePath.replace(/\\/g, '/')
                                                     }
                                                 }
 

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -835,15 +835,7 @@ Rectangle {
                                                     anchors.fill: parent
                                                     hoverEnabled: true
                                                     onClicked: function() {
-                                                        Qt.openUrlExternally(getAdjustedFileUrl(modelData.path))
-                                                    }
-
-                                                    function getAdjustedFileUrl(filePath) {
-                                                        var url = "file://"
-                                                        if (Qt.platform.os === "windows") {
-                                                            url += "/"
-                                                        }
-                                                        return url + filePath.replace(/\\/g, '/')
+                                                        Qt.openUrlExternally(modelData.fileUri)
                                                     }
                                                 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b0d3d5f11e4bac06e1d6b5600fb099df3fec12fa  | 
|--------|--------|

### Summary:
Fixes file URL opening on Windows by adding a `fileUri` property to `ResultInfo` and updating the `onClicked` handler in `gpt4all-chat/qml/ChatView.qml`.

**Key points**:
- **Files Modified**: `gpt4all-chat/qml/ChatView.qml`, `gpt4all-chat/database.h`
- **Function Removed**: `getAdjustedFileUrl(filePath)` in `gpt4all-chat/qml/ChatView.qml`
- **Property Added**: `fileUri` in `ResultInfo` struct in `gpt4all-chat/database.h`
- **Behavior Change**: `onClicked` handler for `MouseArea` in `ChatView.qml` now uses `modelData.fileUri` to open file URLs correctly on Windows.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->