### PR TITLE
Change the font sizing after feedback to:

### DIFF
--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -1065,19 +1065,19 @@ QtObject {
         }
     }
 
-    property real fontSizeLargeCapped: MySettings.fontSize === "Small"  ? 12 : 17
+    property real fontSizeLargeCapped: MySettings.fontSize === "Small"  ? 14 : 16
 
-    property real fontSizeLarge:       MySettings.fontSize === "Small"  ? 12 :
-                                       MySettings.fontSize === "Medium" ? 17 :
-                                                                          22
+    property real fontSizeLarge:       MySettings.fontSize === "Small"  ? 14 :
+                                       MySettings.fontSize === "Medium" ? 16 :
+                                                                          20
 
-    property real fontSizeLargest:     MySettings.fontSize === "Small"  ? 19 :
-                                       MySettings.fontSize === "Medium" ? 24 :
-                                                                          26
+    property real fontSizeLargest:     MySettings.fontSize === "Small"  ? 18 :
+                                       MySettings.fontSize === "Medium" ? 22 :
+                                                                          24
 
     property real fontSizeSmaller:     fontSizeLarge   -  4
     property real fontSizeSmall:       fontSizeLarge   -  2
     property real fontSizeLarger:      fontSizeLarge   +  2
-    property real fontSizeBannerSmall: fontSizeLargest + 10
-    property real fontSizeBanner:      fontSizeLargest + 40
+    property real fontSizeBannerSmall: fontSizeLargest +  8
+    property real fontSizeBanner:      fontSizeLargest + 35
 }


### PR DESCRIPTION
1) Increase the small font size a little
2) Decrease the medium font size very slightly
3) Decrease the large font size a good bit
4) Decrease the sizes of the banner fonts

Overall, this narrows the difference between the three font sizes so as to make the font more evenly sized throughout.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c576e703113b33e2e7b718be7256fdc4fc25468e  | 
|--------|--------|

### Summary:
Adjusted font sizes in `gpt4all-chat/qml/Theme.qml` for better consistency across different settings.

**Key points**:
- Updated `fontSizeLargeCapped` to 14 for 'Small' and 16 for other sizes.
- Updated `fontSizeLarge` to 14 for 'Small', 16 for 'Medium', and 20 for 'Large'.
- Updated `fontSizeLargest` to 18 for 'Small', 22 for 'Medium', and 24 for 'Large'.
- Adjusted `fontSizeBannerSmall` to `fontSizeLargest + 8`.
- Adjusted `fontSizeBanner` to `fontSizeLargest + 35`.
- Changes made in `gpt4all-chat/qml/Theme.qml`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->