### PR TITLE
Markdown support

### DIFF
--- a/gpt4all-chat/qml/ApplicationSettings.qml
+++ b/gpt4all-chat/qml/ApplicationSettings.qml
@@ -77,7 +77,7 @@ MySettingsTab {
 
             Rectangle {
                 Layout.fillWidth: true
-                height: 2
+                height: 1
                 color: theme.settingsDivider
             }
         }
@@ -307,7 +307,7 @@ MySettingsTab {
 
             Rectangle {
                 Layout.fillWidth: true
-                height: 2
+                height: 1
                 color: theme.settingsDivider
             }
         }
@@ -463,7 +463,7 @@ MySettingsTab {
             Layout.column: 0
             Layout.columnSpan: 3
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.settingsDivider
         }
     }

--- a/gpt4all-chat/qml/ChatDrawer.qml
+++ b/gpt4all-chat/qml/ChatDrawer.qml
@@ -23,7 +23,7 @@ Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.right: parent.right
-        width: 2
+        width: 1
         color: theme.dividerColor
     }
 
@@ -44,8 +44,8 @@ Rectangle {
             anchors.right: parent.right
             anchors.margins: 20
             font.pixelSize: theme.fontSizeLarger
-            topPadding: 20
-            bottomPadding: 20
+            topPadding: 24
+            bottomPadding: 24
             text: qsTr("\uFF0B New chat")
             Accessible.description: qsTr("Create a new chat")
             onClicked: {
@@ -59,7 +59,7 @@ Rectangle {
             id: divider
             anchors.top: newChat.bottom
             anchors.margins: 20
-            anchors.topMargin: 15
+            anchors.topMargin: 14
             anchors.left: parent.left
             anchors.right: parent.right
             height: 1

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -525,7 +525,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.right: parent.right
             color: theme.conversationDivider
-            height: 2
+            height: 1
         }
 
         CollectionsDrawer {

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -714,7 +714,7 @@ Rectangle {
                             Accessible.description: qsTr("prompt / response pairs from the conversation")
 
                             delegate: GridLayout {
-                                width: listView.contentItem.width
+                                width: listView.contentItem.width - 15
                                 rows: 3
                                 columns: 2
 

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1001,7 +1001,7 @@ Rectangle {
                                             }
 
                                             TextArea {
-                                                text: consolidatedSources.length + " " + qsTr("Local Sources")
+                                                text: consolidatedSources.length + " " + qsTr("Sources")
                                                 padding: 0
                                                 readOnly: true
                                                 font.pixelSize: theme.fontSizeLarge

--- a/gpt4all-chat/qml/CollectionsDrawer.qml
+++ b/gpt4all-chat/qml/CollectionsDrawer.qml
@@ -21,7 +21,7 @@ Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
-        width: 2
+        width: 1
         color: theme.dividerColor
     }
 

--- a/gpt4all-chat/qml/LocalDocsSettings.qml
+++ b/gpt4all-chat/qml/LocalDocsSettings.qml
@@ -31,7 +31,7 @@ MySettingsTab {
         Rectangle {
             Layout.bottomMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.settingsDivider
         }
 
@@ -92,7 +92,7 @@ MySettingsTab {
         Rectangle {
             Layout.bottomMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.grayRed500
         }
 
@@ -154,7 +154,7 @@ MySettingsTab {
         Rectangle {
             Layout.bottomMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.grayRed500
         }
 
@@ -184,7 +184,7 @@ MySettingsTab {
         Rectangle {
             Layout.bottomMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.settingsDivider
         }
 
@@ -254,7 +254,7 @@ MySettingsTab {
         Rectangle {
             Layout.topMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.settingsDivider
         }
      }

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -38,7 +38,7 @@ MySettingsTab {
 
             Rectangle {
                 Layout.fillWidth: true
-                height: 2
+                height: 1
                 color: theme.settingsDivider
             }
         }
@@ -803,7 +803,7 @@ MySettingsTab {
             Layout.columnSpan: 2
             Layout.topMargin: 15
             Layout.fillWidth: true
-            height: 2
+            height: 1
             color: theme.settingsDivider
         }
     }

--- a/gpt4all-chat/qml/MySettingsStack.qml
+++ b/gpt4all-chat/qml/MySettingsStack.qml
@@ -57,7 +57,7 @@ Item {
         anchors.rightMargin: 15
         anchors.left: parent.left
         anchors.right: parent.right
-        height: 2
+        height: 1
         color: theme.settingsDivider
     }
 

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -195,14 +195,7 @@ QtObject {
     }
 
     property color conversationDivider: {
-        switch (MySettings.chatTheme) {
-            case "LegacyDark":
-                return blue900;
-            case "Dark":
-                return darkgray100;
-            default:
-                return gray100;
-        }
+        return dividerColor;
     }
 
     property color settingsDivider: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cb8a4c42b1e34d0b02f22739feb76df9ba9333d6  | 
|--------|--------|

### Summary:
Added markdown support in `ResponseText`, adjusted UI element widths, and modified divider heights and colors in various QML files.

**Key points**:
- **Added**: `replaceAndInsertMarkdown` function in `gpt4all-chat/responsetext.cpp` to handle markdown insertion.
- **Modified**: `ResponseText::handleCodeBlocks` in `gpt4all-chat/responsetext.cpp` to process non-code blocks as markdown.
- **Adjusted**: Width of `listView.contentItem` in `gpt4all-chat/qml/ChatView.qml` by subtracting 15 units.
- **Reduced**: Divider heights in multiple QML files (`gpt4all-chat/qml/ApplicationSettings.qml`, `gpt4all-chat/qml/ChatDrawer.qml`, `gpt4all-chat/qml/ChatView.qml`, `gpt4all-chat/qml/CollectionsDrawer.qml`, `gpt4all-chat/qml/LocalDocsSettings.qml`, `gpt4all-chat/qml/ModelSettings.qml`, `gpt4all-chat/qml/MySettingsStack.qml`) from 2 to 1 unit.
- **Unified**: `conversationDivider` color in `gpt4all-chat/qml/Theme.qml` to use `dividerColor`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->