### PR TITLE
Improved markdown support:

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -109,6 +109,7 @@ qt_add_executable(chat
     chatllm.h chatllm.cpp
     chatmodel.h chatlistmodel.h chatlistmodel.cpp
     chatapi.h chatapi.cpp
+    chatviewtextprocessor.h chatviewtextprocessor.cpp
     database.h database.cpp
     download.h download.cpp
     embllm.cpp embllm.h
@@ -119,7 +120,6 @@ qt_add_executable(chat
     network.h network.cpp
     server.h server.cpp
     logger.h logger.cpp
-    responsetext.h responsetext.cpp
     ${APP_ICON_RESOURCE}
     ${CHAT_EXE_RESOURCES}
 )

--- a/gpt4all-chat/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/chatviewtextprocessor.cpp
@@ -23,6 +23,9 @@
 #include <Qt>
 #include <QtGlobal>
 
+#include <algorithm>
+#include <functional>
+
 enum Language {
     None,
     Python,
@@ -1191,9 +1194,7 @@ void ChatViewTextProcessor::handleMarkdown()
 
 
     if (!hasAlreadyProcessedMarkdown) {
-        std::sort(codeBlockPositions.begin(), codeBlockPositions.end(), [](const QPair<int, int> &a, const QPair<int, int> &b) {
-            return a.first > b.first;
-        });
+        std::sort(codeBlockPositions.begin(), codeBlockPositions.end(), std::greater<>());
 
         int lastIndex = doc->characterCount() - 1;
         for (const auto &pos : codeBlockPositions) {

--- a/gpt4all-chat/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/chatviewtextprocessor.cpp
@@ -1157,7 +1157,9 @@ void replaceAndInsertMarkdown(int startIndex, int endIndex, QTextDocument *doc)
     QTextDocumentFragment fragment(cursor);
     const QString plainText = fragment.toPlainText();
     cursor.removeSelectedText();
-    cursor.insertMarkdown(plainText, QTextDocument::MarkdownNoHTML);
+    QTextDocument::MarkdownFeatures features = static_cast<QTextDocument::MarkdownFeatures>(
+        QTextDocument::MarkdownNoHTML | QTextDocument::MarkdownDialectGitHub);
+    cursor.insertMarkdown(plainText, features);
     cursor.block().setUserState(Markdown);
 }
 

--- a/gpt4all-chat/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/chatviewtextprocessor.cpp
@@ -24,7 +24,6 @@
 #include <QtGlobal>
 
 #include <algorithm>
-#include <functional>
 
 enum Language {
     None,
@@ -1194,7 +1193,9 @@ void ChatViewTextProcessor::handleMarkdown()
 
 
     if (!hasAlreadyProcessedMarkdown) {
-        std::sort(codeBlockPositions.begin(), codeBlockPositions.end(), std::greater<>());
+        std::sort(codeBlockPositions.begin(), codeBlockPositions.end(), [](const QPair<int, int> &a, const QPair<int, int> &b) {
+            return a.first > b.first;
+        });
 
         int lastIndex = doc->characterCount() - 1;
         for (const auto &pos : codeBlockPositions) {

--- a/gpt4all-chat/chatviewtextprocessor.h
+++ b/gpt4all-chat/chatviewtextprocessor.h
@@ -1,5 +1,5 @@
-#ifndef RESPONSETEXT_H
-#define RESPONSETEXT_H
+#ifndef CHATVIEWTEXTPROCESSOR_H
+#define CHATVIEWTEXTPROCESSOR_H
 
 #include <QColor>
 #include <QObject>
@@ -37,13 +37,14 @@ struct CodeCopy {
     QString text;
 };
 
-class ResponseText : public QObject
+class ChatViewTextProcessor : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QQuickTextDocument* textDocument READ textDocument WRITE setTextDocument NOTIFY textDocumentChanged())
+    Q_PROPERTY(bool shouldProcessText READ shouldProcessText WRITE setShouldProcessText NOTIFY shouldProcessTextChanged())
     QML_ELEMENT
 public:
-    explicit ResponseText(QObject *parent = nullptr);
+    explicit ChatViewTextProcessor(QObject *parent = nullptr);
 
     QQuickTextDocument* textDocument() const;
     void setTextDocument(QQuickTextDocument* textDocument);
@@ -53,12 +54,17 @@ public:
 
     Q_INVOKABLE bool tryCopyAtPosition(int position) const;
 
+    bool shouldProcessText() const;
+    void setShouldProcessText(bool b);
+
 Q_SIGNALS:
     void textDocumentChanged();
+    void shouldProcessTextChanged();
 
 private Q_SLOTS:
     void handleTextChanged();
     void handleCodeBlocks();
+    void handleMarkdown();
 
 private:
     QQuickTextDocument *m_textDocument;
@@ -67,7 +73,8 @@ private:
     QVector<CodeCopy> m_copies;
     QColor m_linkColor;
     QColor m_headerColor;
+    bool m_shouldProcessText = false;
     bool m_isProcessingText = false;
 };
 
-#endif // RESPONSETEXT_H
+#endif // CHATVIEWTEXTPROCESSOR_H

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -824,7 +824,7 @@ Rectangle {
                                             id: tapHandler
                                             onTapped: function(eventPoint, button) {
                                                 var clickedPos = myTextArea.positionAt(eventPoint.position.x, eventPoint.position.y);
-                                                var success = responseText.tryCopyAtPosition(clickedPos);
+                                                var success = textProcessor.tryCopyAtPosition(clickedPos);
                                                 if (success)
                                                     copyCodeMessage.open();
                                             }
@@ -862,16 +862,24 @@ Rectangle {
                                                     myTextArea.deselect()
                                                 }
                                             }
+                                            MenuItem {
+                                                text: textProcessor.shouldProcessText ? qsTr("Disable markdown") : qsTr("Enable markdown")
+                                                height: enabled ? implicitHeight : 0
+                                                onTriggered: {
+                                                    textProcessor.shouldProcessText = !textProcessor.shouldProcessText;
+                                                    myTextArea.text = value
+                                                }
+                                            }
                                         }
 
-                                        ResponseText {
-                                            id: responseText
+                                        ChatViewTextProcessor {
+                                            id: textProcessor
                                         }
 
                                         Component.onCompleted: {
-                                            responseText.setLinkColor(theme.linkColor);
-                                            responseText.setHeaderColor(name === qsTr("Response: ") ? theme.darkContrast : theme.lightContrast);
-                                            responseText.textDocument = textDocument
+                                            textProcessor.setLinkColor(theme.linkColor);
+                                            textProcessor.setHeaderColor(name === qsTr("Response: ") ? theme.darkContrast : theme.lightContrast);
+                                            textProcessor.textDocument = textDocument
                                         }
 
                                         Accessible.role: Accessible.Paragraph


### PR DESCRIPTION
* Correctly displays inline code blocks with syntax highlighting turned on as well as markdown at the same time
* Adds a context menu item for toggling markdown on and off which also which essentially turns on/off all text processing
* Uses QTextDocument::MarkdownNoHTML to handle markdown in QTextDocument which allows display of html tags like normal, but unfortunately does not allow display of markdown tables as markdown

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1ce5785f99731ea3cf0930f02957ae05c94d747b  | 
|--------|--------|

### Summary:
Enhanced markdown support with syntax highlighting and a context menu for toggling markdown processing, implemented via the new `ChatViewTextProcessor` class.

**Key points**:
* Correctly displays inline code blocks with syntax highlighting turned on as well as markdown at the same time
* Adds a context menu item for toggling markdown on and off which also which essentially turns on/off all text processing
* Uses QTextDocument::MarkdownNoHTML to handle markdown in QTextDocument which allows display of html tags like normal, but unfortunately does not allow display of markdown tables as markdown
* Enhanced markdown support with syntax highlighting for inline code blocks (`gpt4all-chat/chatviewtextprocessor.cpp`, `gpt4all-chat/chatviewtextprocessor.h`)
* Added `ChatViewTextProcessor` class to handle text processing (`gpt4all-chat/chatviewtextprocessor.cpp`, `gpt4all-chat/chatviewtextprocessor.h`)
* Introduced context menu item for toggling markdown processing (`gpt4all-chat/qml/ChatView.qml`)
* Utilized `QTextDocument::MarkdownNoHTML` for markdown handling, allowing HTML tag display but not markdown tables (`gpt4all-chat/chatviewtextprocessor.cpp`)
* Removed `responsetext.*` files and replaced with `chatviewtextprocessor.*` in `CMakeLists.txt`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->