### PR TITLE
Go ahead and try to handle links in the text by opening them externally.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -850,7 +850,8 @@ Rectangle {
                                         }
 
                                         onLinkHovered: function (link) {
-                                            statusBar.hoveredLink = link
+                                            if (!currentResponse || !currentChat.responseInProgress)
+                                                statusBar.hoveredLink = link
                                         }
 
                                         Menu {

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -844,6 +844,10 @@ Rectangle {
                                             }
                                         }
 
+                                        onLinkActivated: function(link) {
+                                            Qt.openUrlExternally(link)
+                                        }
+
                                         Menu {
                                             id: conversationContextMenu
                                             MenuItem {

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -845,7 +845,12 @@ Rectangle {
                                         }
 
                                         onLinkActivated: function(link) {
-                                            Qt.openUrlExternally(link)
+                                            if (!currentResponse || !currentChat.responseInProgress)
+                                                Qt.openUrlExternally(link)
+                                        }
+
+                                        onLinkHovered: function (link) {
+                                            statusBar.hoveredLink = link
                                         }
 
                                         Menu {
@@ -1324,7 +1329,8 @@ Rectangle {
             }
 
             Text {
-                id: device
+                id: statusBar
+                property string hoveredLink: ""
                 anchors.top: textInputView.bottom
                 anchors.bottom: parent.bottom
                 anchors.right: parent.right
@@ -1334,10 +1340,13 @@ Rectangle {
                 horizontalAlignment: Qt.AlignRight
                 verticalAlignment: Qt.AlignVCenter
                 color: theme.mutedTextColor
-                visible: currentChat.tokenSpeed !== ""
+                visible: currentChat.tokenSpeed !== "" || hoveredLink !== ""
                 elide: Text.ElideRight
                 wrapMode: Text.WordWrap
                 text: {
+                    if (hoveredLink !== "")
+                        return hoveredLink
+
                     const segments = [currentChat.tokenSpeed];
                     const device = currentChat.device;
                     const backend = currentChat.deviceBackend;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7a1a867aace1c752c9d448c5627c0068f4f3d8b8  | 
|--------|--------|

### Summary:
Added functionality to open links externally in the default web browser and updated the status bar to show hovered links in `gpt4all-chat/qml/ChatView.qml`.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/ChatView.qml`
- **Function Added**: `onLinkActivated` in `TextArea`
- **Behavior**: Opens links in the default web browser when clicked within the chat text.
- **Specific Change**: Added `Qt.openUrlExternally(link)` to handle external link opening.
- **Additional Change**: Updated `statusBar` to show the hovered link using `onLinkHovered`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->