### PR TITLE
Change the name of this property to not conflict.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -850,7 +850,7 @@ Rectangle {
 
                                         onLinkHovered: function (link) {
                                             if (!currentResponse || !currentChat.responseInProgress)
-                                                statusBar.hoveredLink = link
+                                                statusBar.externalHoveredLink = link
                                         }
 
                                         Menu {
@@ -1330,7 +1330,7 @@ Rectangle {
 
             Text {
                 id: statusBar
-                property string hoveredLink: ""
+                property string externalHoveredLink: ""
                 anchors.top: textInputView.bottom
                 anchors.bottom: parent.bottom
                 anchors.right: parent.right
@@ -1340,12 +1340,12 @@ Rectangle {
                 horizontalAlignment: Qt.AlignRight
                 verticalAlignment: Qt.AlignVCenter
                 color: theme.mutedTextColor
-                visible: currentChat.tokenSpeed !== "" || hoveredLink !== ""
+                visible: currentChat.tokenSpeed !== "" || externalHoveredLink !== ""
                 elide: Text.ElideRight
                 wrapMode: Text.WordWrap
                 text: {
-                    if (hoveredLink !== "")
-                        return hoveredLink
+                    if (externalHoveredLink !== "")
+                        return externalHoveredLink
 
                     const segments = [currentChat.tokenSpeed];
                     const device = currentChat.device;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c1782a506b85bef2aad9e50e6b607f47b2b559e1  | 
|--------|--------|

### Summary:
Renamed `hoveredLink` to `externalHoveredLink` in `gpt4all-chat/qml/ChatView.qml` to avoid a conflict.

**Key points**:
- Renamed `hoveredLink` to `externalHoveredLink` in `gpt4all-chat/qml/ChatView.qml`.
- Updated `statusBar` property name to `externalHoveredLink`.
- Modified `onLinkHovered` function in `TextArea` to use `externalHoveredLink`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->