### PR TITLE
Fix up the loading default model to display the actual name as per Vi…

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -631,13 +631,24 @@ Rectangle {
                         }
 
                         MyButton {
+                            id: loadDefaultModelButton
                             visible: ModelList.installedModels.count !== 0
                             anchors.top: modelInstalledLabel.bottom
                             anchors.topMargin: 50
                             anchors.horizontalCenter: modelInstalledLabel.horizontalCenter
                             rightPadding: 60
                             leftPadding: 60
-                            text: qsTr("Load default model  \u2192");
+                            property string defaultModel
+                            function updateDefaultModel() {
+                                var i = comboBox.find(MySettings.userDefaultModel)
+                                if (i !== -1) {
+                                    defaultModel = comboBox.valueAt(i);
+                                } else {
+                                    defaultModel = comboBox.valueAt(0);
+                                }
+                            }
+
+                            text: qsTr("Load \u00B7 ") + defaultModel + qsTr(" (default) \u2192");
                             onClicked: {
                                 var i = comboBox.find(MySettings.userDefaultModel)
                                 if (i !== -1) {
@@ -645,6 +656,20 @@ Rectangle {
                                 } else {
                                     comboBox.changeModel(0);
                                 }
+                            }
+
+                            // This requires a bit of work because apparently the combobox valueAt
+                            // function only works after the combobox component is loaded so we have
+                            // to use our own component loaded to make this work along with a signal
+                            // from MySettings for when the setting for user default model changes
+                            Connections {
+                                target: MySettings
+                                function onUserDefaultModelChanged() {
+                                    loadDefaultModelButton.updateDefaultModel()
+                                }
+                            }
+                            Component.onCompleted: {
+                                loadDefaultModelButton.updateDefaultModel()
                             }
                             Accessible.role: Accessible.Button
                             Accessible.name: qsTr("Load the default model")

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -638,7 +638,7 @@ Rectangle {
                             anchors.horizontalCenter: modelInstalledLabel.horizontalCenter
                             rightPadding: 60
                             leftPadding: 60
-                            property string defaultModel
+                            property string defaultModel: ""
                             function updateDefaultModel() {
                                 var i = comboBox.find(MySettings.userDefaultModel)
                                 if (i !== -1) {


### PR DESCRIPTION
…ncent.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a2fd0e430b46f508c8cb537cb303710de75ac07a  | 
|--------|--------|

### Summary:
Updated `loadDefaultModelButton` in `gpt4all-chat/qml/ChatView.qml` to dynamically display the actual default model name.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/ChatView.qml`
- **Component**: `loadDefaultModelButton`
- **New Property**: `defaultModel` to store the default model name.
- **New Function**: `updateDefaultModel` to update `defaultModel` based on `MySettings.userDefaultModel`.
- **Text Update**: Button text now shows `Load \u00B7 {defaultModel} (default) \u2192`.
- **Connections**: Added `Connections` to update the default model when `MySettings.userDefaultModel` changes.
- **Component.onCompleted**: Calls `updateDefaultModel` to set initial value.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->