### PR TITLE
AddCollectionView: fix label colors

### DIFF
--- a/gpt4all-chat/qml/AddCollectionView.qml
+++ b/gpt4all-chat/qml/AddCollectionView.qml
@@ -106,6 +106,7 @@ Rectangle {
                 text: qsTr("Name")
                 font.bold: true
                 font.pixelSize: theme.fontSizeLarger
+                color: theme.settingsTitleTextColor
             }
 
             MyTextField {
@@ -138,6 +139,7 @@ Rectangle {
                 text: qsTr("Folder")
                 font.bold: true
                 font.pixelSize: theme.fontSizeLarger
+                color: theme.settingsTitleTextColor
             }
 
             RowLayout {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5a7c803ea21f8ab5b2d0362aa6ac513586b057ee  | 
|--------|--------|

### Summary:
Set `theme.settingsTitleTextColor` for 'Name' and 'Folder' labels in `AddCollectionView.qml`.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/AddCollectionView.qml`
- **Labels Updated**: 'Name' and 'Folder' labels
- **Color Set**: `theme.settingsTitleTextColor` for both labels
- **Lines Added**: `color: theme.settingsTitleTextColor` to the respective `Label` elements


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->