### PR TITLE
Add documentation link to HomeView.qml

### DIFF
--- a/gpt4all-chat/qml/HomeView.qml
+++ b/gpt4all-chat/qml/HomeView.qml
@@ -222,6 +222,12 @@ Rectangle {
                     }
 
                     MyFancyLink {
+                        text: qsTr("Documentation")
+                        imageSource: "qrc:/gpt4all/icons/info.svg"
+                        onClicked: { Qt.openUrlExternally("https://docs.gpt4all.io/gpt4all_chat.html") }
+                    }
+
+                    MyFancyLink {
                         text: qsTr("Discord")
                         imageSource: "qrc:/gpt4all/icons/discord.svg"
                         onClicked: { Qt.openUrlExternally("https://discord.gg/4M2QFmTt2k") }


### PR DESCRIPTION
Additionally link to the documentation at https://docs.gpt4all.io/gpt4all_chat.html

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/ef6256ab-432a-4000-8641-bed621df83c1)
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/ce03a22a-87eb-49eb-8212-966827a882f3)
![image](https://github.com/nomic-ai/gpt4all/assets/134004613/5a40a532-fc82-4d09-850b-9b750c1e568e)

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
Just a suggestion to put it there like that. Feel free, to copy, adjust, and reject the PR.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f77f9b8197e730091b61d178ced66be90775959b  | 
|--------|--------|

### Summary:
Added a documentation link to `gpt4all-chat/qml/HomeView.qml`.

**Key points**:
- Added a new `MyFancyLink` component to `gpt4all-chat/qml/HomeView.qml`.
- The new link points to the documentation at `https://docs.gpt4all.io/gpt4all_chat.html`.
- The link is labeled 'Documentation' and uses the `info.svg` icon.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->