### PR TITLE
Fix for reload button hovering

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -298,9 +298,11 @@ Rectangle {
                             id: contentRow
                             anchors.centerIn: parent
                             spacing: 0
+                            Layout.maximumWidth: 550
                             RowLayout {
                                 id: miniButtonsRow
                                 clip: true
+                                Layout.maximumWidth: 550
                                 Behavior on Layout.preferredWidth {
                                     NumberAnimation {
                                         duration: 300
@@ -309,7 +311,7 @@ Rectangle {
                                 }
 
                                 Layout.preferredWidth: {
-                                    if (!comboBox.hovered)
+                                    if (!(comboBox.hovered || reloadButton.hovered || ejectButton.hovered))
                                         return 0
                                     return (reloadButton.visible ? reloadButton.width : 0) + (ejectButton.visible ? ejectButton.width : 0)
                                 }
@@ -350,6 +352,7 @@ Rectangle {
                             }
 
                             Text {
+                                Layout.maximumWidth: 520
                                 id: comboBoxText
                                 leftPadding: 10
                                 rightPadding: 10


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6ecea58cd5ab4fd478ff0196bc7ec1d59f7bb02b  | 
|--------|--------|

### Summary:
Fixes hover behavior for the reload button and adjusts layout widths in `gpt4all-chat/qml/ChatView.qml`.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/ChatView.qml`
- **Components Affected**: `RowLayout`, `Text`
- **Changes**:
  - Added `Layout.maximumWidth: 550` to `contentRow` and `miniButtonsRow`.
  - Updated `Layout.preferredWidth` condition to include `reloadButton.hovered` and `ejectButton.hovered`.
  - Added `Layout.maximumWidth: 520` to `comboBoxText`.
- **Behavior**: Ensures proper handling of button hover states and adjusts layout width accordingly.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->