### PR TITLE
Fix response generation broken by themeable syntax highlighting

### DIFF
--- a/gpt4all-chat/chatmodel.h
+++ b/gpt4all-chat/chatmodel.h
@@ -188,6 +188,11 @@ public:
         }
     }
 
+    Q_INVOKABLE void forceUpdate(int index)
+    {
+        emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole});
+    }
+
     Q_INVOKABLE void updateValue(int index, const QString &value)
     {
         if (index < 0 || index >= m_chatItems.size()) return;

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -966,7 +966,7 @@ Rectangle {
                                             textProcessor.codeColors.headerColor       = theme.codeHeaderColor
                                             textProcessor.codeColors.backgroundColor   = theme.codeBackgroundColor
                                             textProcessor.textDocument                 = textDocument
-                                            myTextArea.text = value
+                                            chatModel.forceUpdate(index); // called to trigger a reprocessing of the text
                                         }
 
                                         Component.onCompleted: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8b1fbfb74c6a6b4f95e8849cfce5dbac4a944b32  | 
|--------|--------|

### Summary:
Fixes response generation issue by adding `forceUpdate` method in `ChatModel` and invoking it in `ChatView.qml` to handle theme changes.

**Key points**:
- Added `forceUpdate` method in `gpt4all-chat/chatmodel.h` to trigger `dataChanged` signal for `ValueRole`.
- Modified `gpt4all-chat/qml/ChatView.qml` to call `chatModel.forceUpdate(index)` for reprocessing text when theme changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->