### PR TITLE
This bottom padding while doing text generation is no not necessary

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1328,7 +1328,7 @@ Rectangle {
                             footer: Item {
                                 id: bottomPadding
                                 width: parent.width
-                                height: 60
+                                height: 0
                             }
                         }
                     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d62ea317dd97a176dc8b6a87b3088a4bbc2b8852  | 
|--------|--------|

### Summary:
Reduced bottom padding height from 60 to 0 in `gpt4all-chat/qml/ChatView.qml` to remove unnecessary space during text generation.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/ChatView.qml`
- **Change**: Reduced `height` of `bottomPadding` from `60` to `0`.
- **Effect**: Removes unnecessary bottom padding during text generation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->