### PR TITLE
This is unnecessary and was a mistake to include.

### DIFF
--- a/gpt4all-chat/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/chatviewtextprocessor.cpp
@@ -899,8 +899,6 @@ void ChatViewTextProcessor::handleTextChanged()
     QTextCursor cursor(doc);
     QString invisibleCharacter = QString(QChar(0xFEFF));
     cursor.insertText(invisibleCharacter, QTextCharFormat());
-
-    m_syntaxHighlighter->rehighlight();
     m_isProcessingText = false;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f6480bfa43e2220e455abc8b29c6fae469cad292  | 
|--------|--------|

### Summary:
Removed redundant `m_syntaxHighlighter->rehighlight()` call in `ChatViewTextProcessor::handleTextChanged` function.

**Key points**:
- Removed `m_syntaxHighlighter->rehighlight()` call in `gpt4all-chat/chatviewtextprocessor.cpp` within `ChatViewTextProcessor::handleTextChanged` function.
- Ensures `m_isProcessingText` is set to `false` without rehighlighting.
- Likely fixes redundant or problematic rehighlighting behavior.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->