### PR TITLE
backend: fix a crash on inputs greater than n_ctx

### DIFF
--- a/gpt4all-backend/llmodel.h
+++ b/gpt4all-backend/llmodel.h
@@ -248,7 +248,7 @@ protected:
         return true;
     }
 
-    void decodePrompt(std::function<bool(int32_t)> promptCallback,
+    bool decodePrompt(std::function<bool(int32_t)> promptCallback,
                       std::function<bool(int32_t, const std::string&)> responseCallback,
                       std::function<bool(bool)> recalculateCallback,
                       PromptContext &promptCtx,


### PR DESCRIPTION
This fixes a regression in commit 4fc4d94b ("fix chat-style prompt templates (#1970)"), which moved some return statements into a new function (LLModel::decodePrompt) without making them return from the parent as well.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3409b98c0d20ea5e7fe4958342a837ce8f84f332  | 
|--------|--------|

### Summary:
Fixes crash on inputs greater than `n_ctx` by updating `LLModel::decodePrompt` to return a boolean and handle errors appropriately.

**Key points**:
- **Modified** `gpt4all-backend/llmodel.h`:
  - Changed `LLModel::decodePrompt` return type from `void` to `bool`.
- **Updated** `gpt4all-backend/llmodel_shared.cpp`:
  - Updated `LLModel::prompt` to handle `decodePrompt` return value and exit on error.
  - Modified `LLModel::decodePrompt` to return `false` on errors and `true` on success.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->