### PR TITLE
Fix the erase search button to use the new icon.

### DIFF
--- a/gpt4all-chat/qml/AddModelView.qml
+++ b/gpt4all-chat/qml/AddModelView.qml
@@ -144,11 +144,7 @@ Rectangle {
                             backgroundColor: theme.textColor
                             backgroundColorHovered: theme.iconBackgroundDark
                             visible: discoverField.text !== ""
-                            contentItem: Text {
-                                color: clearDiscoverButton.hovered ? theme.iconBackgroundDark : theme.textColor
-                                text: "\u2715"
-                                font.pixelSize: theme.fontSizeLarge
-                            }
+                            source: "qrc:/gpt4all/icons/close.svg"
                             onClicked: {
                                 discoverField.text = ""
                                 discoverField.sendDiscovery() // should clear results


### PR DESCRIPTION
Before
![image](https://github.com/nomic-ai/gpt4all/assets/10168/e768af47-80e4-4a5d-b49b-c92300a4d0e7)

After
![image](https://github.com/nomic-ai/gpt4all/assets/10168/c5d888a5-36b3-487b-a5bc-d245b3157a5d)

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9e2a9b000182bb7a19b01a303e3313da8a54fb0c  | 
|--------|--------|

### Summary:
Replaced the text-based clear button with an SVG icon in `gpt4all-chat/qml/AddModelView.qml` for improved UI consistency.

**Key points**:
- Updated `clearDiscoverButton` in `gpt4all-chat/qml/AddModelView.qml` to use an SVG icon instead of text.
- Replaced text content `\u2715` with `source: "qrc:/gpt4all/icons/close.svg"`.
- Ensures the clear button uses the new icon for better UI consistency.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->