### PR TITLE
chat: fix documentation links

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -61,7 +61,7 @@ Rectangle {
                      + "<li>Check the model file is complete in the download folder"
                      + "<li>You can find the download folder in the settings dialog"
                      + "<li>If you've sideloaded the model ensure the file is not corrupt by checking md5sum"
-                     + "<li>Read more about what models are supported in our <a href=\"https://docs.gpt4all.io/gpt4all_chat.html\">documentation</a> for the gui"
+                     + "<li>Read more about what models are supported in our <a href=\"https://docs.gpt4all.io/\">documentation</a> for the gui"
                      + "<li>Check out our <a href=\"https://discord.gg/4M2QFmTt2k\">discord channel</a> for help")
     }
 

--- a/gpt4all-chat/qml/HomeView.qml
+++ b/gpt4all-chat/qml/HomeView.qml
@@ -224,7 +224,7 @@ Rectangle {
                     MyFancyLink {
                         text: qsTr("Documentation")
                         imageSource: "qrc:/gpt4all/icons/info.svg"
-                        onClicked: { Qt.openUrlExternally("https://docs.gpt4all.io/gpt4all_chat.html") }
+                        onClicked: { Qt.openUrlExternally("https://docs.gpt4all.io/") }
                     }
 
                     MyFancyLink {

--- a/gpt4all-chat/qml/LocalDocsSettings.qml
+++ b/gpt4all-chat/qml/LocalDocsSettings.qml
@@ -247,7 +247,7 @@ MySettingsTab {
             color: theme.textErrorColor
             wrapMode: Text.WordWrap
             text: qsTr("Warning: Advanced usage only.")
-            helpText: qsTr("Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model's context window. More info <a href=\"https://docs.gpt4all.io/gpt4all_chat.html#localdocs-beta-plugin-chat-with-your-data\">here.</a>")
+            helpText: qsTr("Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model's context window. More info <a href=\"https://docs.gpt4all.io/gpt4all_desktop/localdocs.html\">here</a>.")
             onLinkActivated: function(link) { Qt.openUrlExternally(link) }
         }
 


### PR DESCRIPTION
Now that the documentation has been overhauled, we need to point to the new locations. Right now these all go to the homepage of the docs, which is OK for the plain ones but not so great for the LocalDocs one. In the future, we should add a more in-depth explanation of LocalDocs to the new docs.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f9e56200fb0b01be7c8e6a329a135c5226e7e151  | 
|--------|--------|

### Summary:
Updated documentation links in `ChatView.qml`, `HomeView.qml`, and `LocalDocsSettings.qml` to point to the new locations after the documentation overhaul.

**Key points**:
- **Updated documentation links** in `gpt4all-chat/qml/ChatView.qml`, `gpt4all-chat/qml/HomeView.qml`, and `gpt4all-chat/qml/LocalDocsSettings.qml`.
- Changed links to point to the new documentation homepage `https://docs.gpt4all.io/`.
- Updated `LocalDocs` link to `https://docs.gpt4all.io/gpt4all_desktop/localdocs.html` in `LocalDocsSettings.qml`.
- Ensures users are directed to the correct documentation pages after the overhaul.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->