### PR TITLE
MacOS Build Online: no offline on

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -207,7 +207,7 @@ jobs:
               -DBUILD_UNIVERSAL=ON \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=12.6 \
               -DMACDEPLOYQT=~/Qt/6.5.1/macos/bin/macdeployqt \
-              -DGPT4ALL_OFFLINE_INSTALLER=ON \
+              -DGPT4ALL_OFFLINE_INSTALLER=OFF \
               -DGPT4ALL_SIGN_INSTALL=ON \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH:PATH=~/Qt/6.5.1/macos/lib/cmake/Qt6 \


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 046b20b587e183ec02b85a617aaba64cb3e8afb7  | 
|--------|--------|

### Summary:
Switched macOS online installer build configuration from offline to online in `.circleci/continue_config.yml`.

**Key points**:
- Updated `.circleci/continue_config.yml`.
- Changed `-DGPT4ALL_OFFLINE_INSTALLER` from `ON` to `OFF` in `build-online-chat-installer-macos` job.
- Affects macOS online installer builds only.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->