### PR TITLE
Update gpt4all.py to fix grammar

### DIFF
--- a/gpt4all-bindings/python/gpt4all/gpt4all.py
+++ b/gpt4all-bindings/python/gpt4all/gpt4all.py
@@ -502,7 +502,7 @@ class GPT4All:
         Generate outputs from any GPT4All model.
 
         Args:
-            prompt: The prompt for the model the complete.
+            prompt: The prompt for the model to complete.
             max_tokens: The maximum number of tokens to generate.
             temp: The model temperature. Larger values increase creativity but decrease factuality.
             top_k: Randomly sample from the top_k most likely tokens at each generation step. Set this to 1 for greedy decoding.


### PR DESCRIPTION
## Describe your changes
Changed line 505 of this file to read "prompt: The prompt for the model to complete."
There was a grammatical error in the documentation. It was, "prompt: The prompt for the model the complete." This commit fixes it.

## Issue ticket number and link
#2524

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] ~If it is a core feature, I have added thorough tests.~ NOT NEEDED
- [X] I have added thorough documentation for my code.
- [X] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [X] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
![old](https://github.com/nomic-ai/gpt4all/assets/128327411/59faf975-7620-4c37-a993-f3d44308d51b)
Old documentation 

![new](https://github.com/nomic-ai/gpt4all/assets/128327411/067149fe-10a0-488b-bb21-a3fe42047429)
New documentation

### Steps to Reproduce
Open documentation and go to Python Reference under Python SDK. The grammar fix will be under `generate`.

## Notes
Compilation succeeded for the python bindings.

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 63176877e42f1d76e33c5eef4c6026253c75360f  | 
|--------|--------|

### Summary:
Fixed grammatical error in the docstring of the `generate` function in `gpt4all-bindings/python/gpt4all/gpt4all.py`.

**Key points**:
- **File**: `gpt4all-bindings/python/gpt4all/gpt4all.py`
- **Class**: `GPT4All`
- **Function**: `generate`
- **Change**: Fixed grammatical error in the docstring of the `generate` function. Changed "prompt: The prompt for the model the complete." to "prompt: The prompt for the model to complete."


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->