### PR TITLE
Fix placement of our thumbs down dialog and datalake opt-in dialog.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -987,11 +987,8 @@ Rectangle {
 
                                     ThumbsDownDialog {
                                         id: thumbsDownDialog
-                                        property point globalPoint: mapFromItem(window,
-                                                                                window.width / 2 - width / 2,
-                                                                                window.height / 2 - height / 2)
-                                        x: globalPoint.x
-                                        y: globalPoint.y
+                                        x: Math.round((parent.width - width) / 2)
+                                        y: Math.round((parent.height - height) / 2)
                                         width: 640
                                         height: 300
                                         property string text: value

--- a/gpt4all-chat/qml/MyDialog.qml
+++ b/gpt4all-chat/qml/MyDialog.qml
@@ -7,6 +7,7 @@ import QtQuick.Layouts
 
 Dialog {
     id: myDialog
+    parent: Overlay.overlay
     property alias closeButtonVisible: myCloseButton.visible
     background: Rectangle {
         width: parent.width


### PR DESCRIPTION
Currently the thumbs down dialog and the datalake opt-in dialog are misplaced. This PR uses https://doc.qt.io/qt-6/qml-qtquick-controls-overlay.html to fix.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e821d1d35b54eb36e81161da0f7defc5a3b5ad75  | 
|--------|--------|

### Summary:
Fixes the placement of `ThumbsDownDialog` and `MyDialog` by updating their positioning logic.

**Key points**:
- Updated `ThumbsDownDialog` positioning in `gpt4all-chat/qml/ChatView.qml` to center using `parent` dimensions.
- Set `parent` of `Dialog` to `Overlay.overlay` in `gpt4all-chat/qml/MyDialog.qml` for correct placement.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->