### PR TITLE
Fix folder dialog on linux so that we can select the folder properly.

### DIFF
--- a/gpt4all-chat/qml/AddCollectionView.qml
+++ b/gpt4all-chat/qml/AddCollectionView.qml
@@ -96,7 +96,7 @@ Rectangle {
 
             function openFolderDialog(currentFolder, onAccepted) {
                 folderDialog.currentFolder = currentFolder;
-                folderDialog.accepted.connect(function() { onAccepted(folderDialog.currentFolder); });
+                folderDialog.accepted.connect(function() { onAccepted(folderDialog.selectedFolder); });
                 folderDialog.open();
             }
 

--- a/gpt4all-chat/qml/MySettingsStack.qml
+++ b/gpt4all-chat/qml/MySettingsStack.qml
@@ -68,7 +68,7 @@ Item {
 
     function openFolderDialog(currentFolder, onAccepted) {
         folderDialog.currentFolder = currentFolder;
-        folderDialog.accepted.connect(function() { onAccepted(folderDialog.currentFolder); });
+        folderDialog.accepted.connect(function() { onAccepted(folderDialog.selectedFolder); });
         folderDialog.open();
     }
 


### PR DESCRIPTION
OMG, I can't believe I am just **NOW** figuring this out.

Apparently, on Linux you have to select the folder not enter it. NOTE: THIS MUST BE TESTED ON WINDOWS AND MAC TO MAKE SURE IT STILL WORKS!