### PR TITLE
 Fixes for issue #2519.

### DIFF
--- a/gpt4all-chat/chatmodel.h
+++ b/gpt4all-chat/chatmodel.h
@@ -188,11 +188,6 @@ public:
         }
     }
 
-    Q_INVOKABLE void forceUpdate(int index)
-    {
-        emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole});
-    }
-
     Q_INVOKABLE void updateValue(int index, const QString &value)
     {
         if (index < 0 || index >= m_chatItems.size()) return;
@@ -201,6 +196,7 @@ public:
         if (item.value != value) {
             item.value = value;
             emit dataChanged(createIndex(index, 0), createIndex(index, 0), {ValueRole});
+            emit valueChanged(index, value);
         }
     }
 
@@ -468,6 +464,7 @@ public:
 
 Q_SIGNALS:
     void countChanged();
+    void valueChanged(int index, const QString &value);
 
 private:
 

--- a/gpt4all-chat/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/chatviewtextprocessor.cpp
@@ -885,12 +885,17 @@ void ChatViewTextProcessor::handleTextChanged()
     if (!m_quickTextDocument || !m_shouldProcessText)
         return;
 
+    // Force full layout of the text document to work around a bug in Qt
+    // TODO(jared): report the Qt bug and link to the report here
+    QTextDocument* doc = m_quickTextDocument->textDocument();
+    (void)doc->documentLayout()->documentSize();
+
     handleCodeBlocks();
     handleMarkdown();
 
     // We insert an invisible char at the end to make sure the document goes back to the default
     // text format
-    QTextCursor cursor(m_quickTextDocument->textDocument());
+    QTextCursor cursor(doc);
     QString invisibleCharacter = QString(QChar(0xFEFF));
     cursor.insertText(invisibleCharacter, QTextCharFormat());
 }

--- a/gpt4all-chat/chatviewtextprocessor.h
+++ b/gpt4all-chat/chatviewtextprocessor.h
@@ -96,6 +96,7 @@ public:
     QQuickTextDocument* textDocument() const;
     void setTextDocument(QQuickTextDocument* textDocument);
 
+    Q_INVOKABLE void setValue(const QString &value);
     Q_INVOKABLE bool tryCopyAtPosition(int position) const;
 
     bool shouldProcessText() const;
@@ -119,12 +120,11 @@ private Q_SLOTS:
     void handleMarkdown();
 
 private:
-    QQuickTextDocument *m_textDocument;
+    QQuickTextDocument *m_quickTextDocument;
     SyntaxHighlighter *m_syntaxHighlighter;
     QVector<ContextLink> m_links;
     QVector<CodeCopy> m_copies;
     bool m_shouldProcessText = false;
-    bool m_isProcessingText = false;
     qreal m_fontPixelSize;
 };
 

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -872,7 +872,6 @@ Rectangle {
                                     Layout.fillWidth: true
                                     TextArea {
                                         id: myTextArea
-                                        text: value
                                         Layout.fillWidth: true
                                         padding: 0
                                         color: {
@@ -967,11 +966,16 @@ Rectangle {
                                             textProcessor.codeColors.headerColor       = theme.codeHeaderColor
                                             textProcessor.codeColors.backgroundColor   = theme.codeBackgroundColor
                                             textProcessor.textDocument                 = textDocument
-                                            chatModel.forceUpdate(index); // called to trigger a reprocessing of the text
+                                            textProcessor.setValue(value);
                                         }
 
                                         Component.onCompleted: {
                                             resetChatViewTextProcessor();
+                                            chatModel.valueChanged.connect(function(i, value) {
+                                                if (index === i)
+                                                    textProcessor.setValue(value);
+                                                }
+                                            );
                                         }
 
                                         Connections {

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -945,7 +945,7 @@ Rectangle {
                                                 height: enabled ? implicitHeight : 0
                                                 onTriggered: {
                                                     textProcessor.shouldProcessText = !textProcessor.shouldProcessText;
-                                                    textProcessor.setValue(value)
+                                                    textProcessor.setValue(value);
                                                 }
                                             }
                                         }

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -945,7 +945,7 @@ Rectangle {
                                                 height: enabled ? implicitHeight : 0
                                                 onTriggered: {
                                                     textProcessor.shouldProcessText = !textProcessor.shouldProcessText;
-                                                    myTextArea.text = value
+                                                    textProcessor.setValue(value)
                                                 }
                                             }
                                         }

--- a/gpt4all-chat/qml/HomeView.qml
+++ b/gpt4all-chat/qml/HomeView.qml
@@ -272,7 +272,7 @@ Rectangle {
         color: theme.conversationBackground
         width: subscribeLink.width
         RowLayout {
-            anchors.fill: parent
+            anchors.centerIn: parent
             MyFancyLink {
                 id: subscribeLink
                 Layout.alignment: Qt.AlignCenter


### PR DESCRIPTION
Send text directly into the text document from the chat view rather than using a signal to post process the text. This is still not ideal in that we want to move to preprocessing the text in the future and to do so by streaming the content in rather than replacing it all at the same time, but it does fix a hang that we experience with an infinite recursive loop of text changed signals in the markdown processing.

This fixes issue #2519.
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 124d8be686c469c20d394d09cd445d3dd7d8b9ae  | 
|--------|--------|

### Summary:
Fixes issue #2519 by sending text directly to the text document in the chat view, avoiding infinite recursive loops during markdown processing.

**Key points**:
- Fixes issue #2519 by sending text directly to the text document in the chat view, avoiding infinite recursive loops during markdown processing.
- Removed `forceUpdate` method from `gpt4all-chat/chatmodel.h`.
- Added `valueChanged` signal in `ChatModel` class in `gpt4all-chat/chatmodel.h`.
- Modified `updateValue` method in `ChatModel` to emit `valueChanged` signal.
- Replaced `m_textDocument` with `m_quickTextDocument` in `ChatViewTextProcessor` class in `gpt4all-chat/chatviewtextprocessor.cpp` and `gpt4all-chat/chatviewtextprocessor.h`.
- Added `setValue` method to `ChatViewTextProcessor` class to set plain text directly.
- Updated `gpt4all-chat/qml/ChatView.qml` to use `textProcessor.setValue(value)` instead of `chatModel.forceUpdate(index)`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->