### PR TITLE
modellist: work around filtered item models getting out of sync

### DIFF
--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -980,6 +980,12 @@ void ModelList::updateData(const QString &id, const QVector<QPair<int, QVariant>
         }
     }
     emit dataChanged(createIndex(index, 0), createIndex(index, 0));
+
+    // FIXME(jared): for some reason these don't update correctly when the source model changes, so we explicitly invalidate them
+    m_selectableModels->invalidate();
+    m_installedModels->invalidate();
+    m_downloadableModels->invalidate();
+
     emit userDefaultModelListChanged();
 }
 


### PR DESCRIPTION
I have yet to understand exactly why, but since #2086 the "Clone" button on the models page sometimes results in the entire settings page being replaced with blank values instead of a cloned model.

I now know that when the "Clone" button is clicked, the id returned fromModelList::clone is not found in the combo box for selection, which leads to index=-1 -> selected value=undefined -> default-constructed `ModelInfo()` when values are accessed.

This stems from the fact that m_selectableModels doesn't contain the newly added model by the end of ModelList::clone. For whatever reason, the initial ModelList::addModel call *does* fire an InstalledModels::filterAcceptsRow check on the cloned model, but the ModelList::updateModel call to set its data (which *does* call ModelList::dataChanged) does not. So m_selectableModels incorrectly thinks the cloned model is not yet "installed."

This PR works around that by explicitly invalidating all of the filter models at the end of ModelList::updateData. In the future, we should figure out why the dataChanged signal does not result in the expected update of the child models.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f3f598a2aa9b8fd20bf045c99f77a03bee6db943  | 
|--------|--------|

### Summary:
Fixes issue with 'Clone' button resulting in blank values by invalidating filter models in `ModelList::updateData`.

**Key points**:
- **Issue**: 'Clone' button on models page sometimes results in blank values on settings page.
- **Root Cause**: `m_selectableModels` does not contain the newly added model by the end of `ModelList::clone`.
- **Fix**: Explicitly invalidate filter models (`m_selectableModels`, `m_installedModels`, `m_downloadableModels`) at the end of `ModelList::updateData`.
- **Files Affected**: `gpt4all-chat/modellist.cpp`.
- **Functions Affected**: `ModelList::updateData`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->