### PR TITLE
Fix scrolling of the chat view at expense of some more memory usage.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -776,6 +776,7 @@ Rectangle {
                             Layout.alignment: Qt.AlignHCenter
                             spacing: 25
                             model: chatModel
+                            cacheBuffer: listView.contentHeight
 
                             ScrollBar.vertical: ScrollBar {
                                 policy: ScrollBar.AsNeeded

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -776,7 +776,7 @@ Rectangle {
                             Layout.alignment: Qt.AlignHCenter
                             spacing: 25
                             model: chatModel
-                            cacheBuffer: listView.contentHeight
+                            cacheBuffer: Math.max(0, listView.contentHeight)
 
                             ScrollBar.vertical: ScrollBar {
                                 policy: ScrollBar.AsNeeded


### PR DESCRIPTION
This is using https://doc.qt.io/qt-6/qml-qtquick-listview.html#cacheBuffer-prop to actually be able to scroll the chatview. I'm at a loss for how Qt developers thought *not* using this would be acceptable in nearly any circumstance? Why wasn't this the default??

Before:

![Peek 2024-07-04 11-55](https://github.com/nomic-ai/gpt4all/assets/10168/aa384328-8b99-4c84-b37a-3feb52b29f84)

After:

![Peek 2024-07-04 11-56](https://github.com/nomic-ai/gpt4all/assets/10168/ea56ecea-70b2-4342-86d7-c63b1c582885)