### PR TITLE
Make the stop generation button visible during model response.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1612,7 +1612,7 @@ Rectangle {
                                               }
                                           }
                     function sendMessage() {
-                        if (textInput.text === "")
+                        if (textInput.text === "" || currentChat.responseInProgress || currentChat.isRecalc)
                             return
 
                         currentChat.stopGenerating()

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1678,10 +1678,37 @@ Rectangle {
                 anchors.right: textInputView.right
                 anchors.verticalCenter: textInputView.verticalCenter
                 anchors.rightMargin: 15
-                imageWidth: theme.fontSizeLargest
-                imageHeight: theme.fontSizeLargest
                 visible: currentChat.responseInProgress && !currentChat.isServer
-                source: "qrc:/gpt4all/icons/stop_generating.svg"
+
+                background: Item {
+                    anchors.fill: parent
+                    Image {
+                        id: stopImage
+                        anchors.centerIn: parent
+                        visible: false
+                        fillMode: Image.PreserveAspectFit
+                        mipmap: true
+                        sourceSize.width: theme.fontSizeLargest
+                        sourceSize.height: theme.fontSizeLargest
+                        source: "qrc:/gpt4all/icons/stop_generating.svg"
+                    }
+                    Rectangle {
+                        anchors.centerIn: stopImage
+                        width: theme.fontSizeLargest + 8
+                        height: theme.fontSizeLargest + 8
+                        color: theme.viewBackground
+                        border.pixelAligned: false
+                        border.color: theme.controlBorder
+                        border.width: 1
+                        radius: width / 2
+                    }
+                    ColorOverlay {
+                        anchors.fill: stopImage
+                        source: stopImage
+                        color: stopButton.hovered ? stopButton.backgroundColorHovered : stopButton.backgroundColor
+                    }
+                }
+
                 Accessible.name: qsTr("Stop generating")
                 Accessible.description: qsTr("Stop the current response generation")
                 ToolTip.visible: stopButton.hovered

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1350,7 +1350,7 @@ Rectangle {
                 property bool isHovered: {
                     return conversationTrayButton.isHovered ||
                         resetContextButton.hovered || copyChatButton.hovered ||
-                        regenerateButton.hovered || stopButton.hovered
+                        regenerateButton.hovered
                 }
 
                 state: conversationTrayContent.isHovered ? "expanded" : "collapsed"
@@ -1461,23 +1461,6 @@ Rectangle {
                         }
                         ToolTip.visible: regenerateButton.hovered
                         ToolTip.text: qsTr("Redo last chat response")
-                    }
-                    MyToolButton {
-                        id: stopButton
-                        Layout.preferredWidth: 40
-                        Layout.preferredHeight: 40
-                        source: "qrc:/gpt4all/icons/stop_generating.svg"
-                        imageWidth: 20
-                        imageHeight: 20
-                        visible: currentChat.responseInProgress
-                        onClicked: {
-                            var index = Math.max(0, chatModel.count - 1);
-                            var listElement = chatModel.get(index);
-                            listElement.stopped = true
-                            currentChat.stopGenerating()
-                        }
-                        ToolTip.visible: stopButton.hovered
-                        ToolTip.text: qsTr("Stop the current response generation")
                     }
                 }
             }
@@ -1687,20 +1670,46 @@ Rectangle {
                 }
             }
 
+
             MyToolButton {
-                id: sendButton
-                backgroundColor: theme.sendButtonBackground
-                backgroundColorHovered: theme.sendButtonBackgroundHovered
+                id: stopButton
+                backgroundColor: theme.conversationInputButtonBackground
+                backgroundColorHovered: theme.conversationInputButtonBackgroundHovered
                 anchors.right: textInputView.right
                 anchors.verticalCenter: textInputView.verticalCenter
                 anchors.rightMargin: 15
                 imageWidth: theme.fontSizeLargest
                 imageHeight: theme.fontSizeLargest
-                visible: !currentChat.isServer && ModelList.selectableModels.count !== 0
-                enabled: !currentChat.responseInProgress
+                visible: currentChat.responseInProgress && !currentChat.isServer
+                source: "qrc:/gpt4all/icons/stop_generating.svg"
+                Accessible.name: qsTr("Stop generating")
+                Accessible.description: qsTr("Stop the current response generation")
+                ToolTip.visible: stopButton.hovered
+                ToolTip.text: Accessible.description
+
+                onClicked: {
+                    var index = Math.max(0, chatModel.count - 1);
+                    var listElement = chatModel.get(index);
+                    listElement.stopped = true
+                    currentChat.stopGenerating()
+                }
+            }
+
+            MyToolButton {
+                id: sendButton
+                backgroundColor: theme.conversationInputButtonBackground
+                backgroundColorHovered: theme.conversationInputButtonBackgroundHovered
+                anchors.right: textInputView.right
+                anchors.verticalCenter: textInputView.verticalCenter
+                anchors.rightMargin: 15
+                imageWidth: theme.fontSizeLargest
+                imageHeight: theme.fontSizeLargest
+                visible: !currentChat.responseInProgress && !currentChat.isServer && ModelList.selectableModels.count !== 0
                 source: "qrc:/gpt4all/icons/send_message.svg"
                 Accessible.name: qsTr("Send message")
                 Accessible.description: qsTr("Sends the message/prompt contained in textfield to the model")
+                ToolTip.visible: sendButton.hovered
+                ToolTip.text: Accessible.description
 
                 onClicked: {
                     textInput.sendMessage()

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -511,7 +511,7 @@ QtObject {
         }
     }
 
-    property color sendButtonBackground: {
+    property color conversationInputButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return accentColor;
@@ -522,7 +522,7 @@ QtObject {
         }
     }
 
-    property color sendButtonBackgroundHovered: {
+    property color conversationInputButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return blue0;


### PR DESCRIPTION
This ensures that it is always clear when the response is still being generated and it also makes it easier to stop generation. Seems like a decent solution?
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4fdab841788160d72aadf56699292a88773694dd  | 
|--------|--------|

### Summary:
Moved the stop generation button to a more prominent location and ensured its visibility during response generation in `gpt4all-chat/qml/ChatView.qml`, with theme property updates in `gpt4all-chat/qml/Theme.qml`.

**Key points**:
- **Modified** `gpt4all-chat/qml/ChatView.qml` to move the `stopButton` outside the conversation tray and make it always visible during response generation.
- **Updated** `stopButton` visibility conditions to `currentChat.responseInProgress && !currentChat.isServer`.
- **Renamed** theme properties in `gpt4all-chat/qml/Theme.qml`:
  - `sendButtonBackground` to `conversationInputButtonBackground`
  - `sendButtonBackgroundHovered` to `conversationInputButtonBackgroundHovered`.
- **Ensured** `stopButton` is more accessible and easier to use during response generation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->