### PR TITLE
Update theme for menus

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -402,7 +402,7 @@ Rectangle {
                     }
                     delegate: ItemDelegate {
                         id: comboItemDelegate
-                        width: comboItemPopup.width
+                        width: comboItemPopup.width -20
                         contentItem: Text {
                             text: name
                             color: theme.textColor
@@ -411,6 +411,10 @@ Rectangle {
                             verticalAlignment: Text.AlignVCenter
                         }
                         background: Rectangle {
+                            //color: theme.menuBackgroundColor//theme.controlBorder
+                            //border.color: theme.controlBorder
+                            //border.width: 1
+                            radius: 10
                             color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
                         }
                         highlighted: comboBox.highlightedIndex === index
@@ -445,7 +449,10 @@ Rectangle {
                         }
 
                         background: Rectangle {
-                            color: theme.menuFrameColor
+                            //color: theme.menuBackgroundColor//theme.controlBorder
+                            border.color: theme.menuBorderColor
+                            border.width: 1
+                            color: theme.menuBackgroundColor
                             radius: 10
                         }
                     }

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -411,7 +411,7 @@ Rectangle {
                             verticalAlignment: Text.AlignVCenter
                         }
                         background: Rectangle {
-                            color: highlighted ? theme.lightContrast : theme.darkContrast
+                            color: highlighted ? theme.chatViewModelListHighlightColor : theme.chatViewModelListBgColor
                         }
                         highlighted: comboBox.highlightedIndex === index
                     }
@@ -445,7 +445,7 @@ Rectangle {
                         }
 
                         background: Rectangle {
-                            color: theme.controlBackground
+                            color: theme.chatViewModelListFrameColor
                             radius: 10
                         }
                     }

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -881,9 +881,7 @@ Rectangle {
                                         color: {
                                             if (!currentChat.isServer)
                                                 return theme.textColor
-                                            if (name === qsTr("Response: "))
-                                                return theme.white
-                                            return theme.black
+                                            return theme.white
                                         }
                                         wrapMode: Text.WordWrap
                                         textFormat: TextEdit.PlainText

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -411,9 +411,6 @@ Rectangle {
                             verticalAlignment: Text.AlignVCenter
                         }
                         background: Rectangle {
-                            //color: theme.menuBackgroundColor//theme.controlBorder
-                            //border.color: theme.controlBorder
-                            //border.width: 1
                             radius: 10
                             color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
                         }
@@ -449,7 +446,6 @@ Rectangle {
                         }
 
                         background: Rectangle {
-                            //color: theme.menuBackgroundColor//theme.controlBorder
                             border.color: theme.menuBorderColor
                             border.width: 1
                             color: theme.menuBackgroundColor

--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -411,7 +411,7 @@ Rectangle {
                             verticalAlignment: Text.AlignVCenter
                         }
                         background: Rectangle {
-                            color: highlighted ? theme.chatViewModelListHighlightColor : theme.chatViewModelListBgColor
+                            color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
                         }
                         highlighted: comboBox.highlightedIndex === index
                     }
@@ -445,7 +445,7 @@ Rectangle {
                         }
 
                         background: Rectangle {
-                            color: theme.chatViewModelListFrameColor
+                            color: theme.menuFrameColor
                             radius: 10
                         }
                     }

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -62,7 +62,7 @@ MySettingsTab {
                     elide: Text.ElideRight
                 }
                 delegate: ItemDelegate {
-                    width: comboBox.width
+                    width: comboBox.width -20
                     contentItem: Text {
                         text: name
                         color: theme.textColor
@@ -71,7 +71,8 @@ MySettingsTab {
                         verticalAlignment: Text.AlignVCenter
                     }
                     background: Rectangle {
-                        color: highlighted ? theme.lightContrast : theme.darkContrast
+                        radius: 10
+                        color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
                     }
                     highlighted: comboBox.highlightedIndex === index
                 }

--- a/gpt4all-chat/qml/MyComboBox.qml
+++ b/gpt4all-chat/qml/MyComboBox.qml
@@ -54,7 +54,7 @@ ComboBox {
             verticalAlignment: Text.AlignVCenter
         }
         background: Rectangle {
-            color: highlighted ? theme.lightContrast : theme.darkContrast
+            color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
         }
         highlighted: comboBox.highlightedIndex === index
     }
@@ -84,7 +84,7 @@ ComboBox {
         }
 
         background: Rectangle {
-            color: theme.controlBackground
+            color: theme.menuFrameColor
             radius: 10
         }
     }

--- a/gpt4all-chat/qml/MyComboBox.qml
+++ b/gpt4all-chat/qml/MyComboBox.qml
@@ -45,7 +45,7 @@ ComboBox {
         }
     }
     delegate: ItemDelegate {
-        width: comboBox.width
+        width: comboBox.width -20
         contentItem: Text {
             text: modelData
             color: theme.textColor
@@ -54,6 +54,7 @@ ComboBox {
             verticalAlignment: Text.AlignVCenter
         }
         background: Rectangle {
+            radius: 10
             color: highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
         }
         highlighted: comboBox.highlightedIndex === index
@@ -84,7 +85,9 @@ ComboBox {
         }
 
         background: Rectangle {
-            color: theme.menuFrameColor
+            color: theme.menuBackgroundColor//theme.controlBorder
+            border.color: theme.menuBorderColor //theme.controlBorder
+            border.width: 1
             radius: 10
         }
     }

--- a/gpt4all-chat/qml/MyMenu.qml
+++ b/gpt4all-chat/qml/MyMenu.qml
@@ -14,7 +14,7 @@ Menu {
     background: Rectangle {
         implicitWidth: 220
         implicitHeight: 40
-        color: theme.controlBackground
+        color: theme.contextMenuFrameColor
         radius: 10
     }
 

--- a/gpt4all-chat/qml/MyMenu.qml
+++ b/gpt4all-chat/qml/MyMenu.qml
@@ -14,7 +14,9 @@ Menu {
     background: Rectangle {
         implicitWidth: 220
         implicitHeight: 40
-        color: theme.menuFrameColor
+        color: theme.menuBackgroundColor
+        border.color: theme.menuBorderColor
+        border.width: 1
         radius: 10
     }
 

--- a/gpt4all-chat/qml/MyMenu.qml
+++ b/gpt4all-chat/qml/MyMenu.qml
@@ -14,7 +14,7 @@ Menu {
     background: Rectangle {
         implicitWidth: 220
         implicitHeight: 40
-        color: theme.contextMenuFrameColor
+        color: theme.menuFrameColor
         radius: 10
     }
 

--- a/gpt4all-chat/qml/MyMenuItem.qml
+++ b/gpt4all-chat/qml/MyMenuItem.qml
@@ -6,6 +6,8 @@ import QtQuick.Controls.Basic
 MenuItem {
     id: item
     background: Rectangle {
+        radius: 10
+        width: parent.width -20
         color: item.highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
     }
 

--- a/gpt4all-chat/qml/MyMenuItem.qml
+++ b/gpt4all-chat/qml/MyMenuItem.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls.Basic
 MenuItem {
     id: item
     background: Rectangle {
-        color: item.highlighted ? theme.lightContrast : theme.darkContrast
+        color: item.highlighted ? theme.contextMenuHighlightColor : theme.contextMenuBgColor
     }
 
     contentItem: Text {

--- a/gpt4all-chat/qml/MyMenuItem.qml
+++ b/gpt4all-chat/qml/MyMenuItem.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls.Basic
 MenuItem {
     id: item
     background: Rectangle {
-        color: item.highlighted ? theme.contextMenuHighlightColor : theme.contextMenuBgColor
+        color: item.highlighted ? theme.menuHighlightColor : theme.menuBackgroundColor
     }
 
     contentItem: Text {

--- a/gpt4all-chat/qml/SettingsView.qml
+++ b/gpt4all-chat/qml/SettingsView.qml
@@ -13,7 +13,7 @@ import mysettings
 
 Rectangle {
     id: settingsDialog
-    color: theme.viewBackground//theme.yellow400//theme.blue500//
+    color: theme.viewBackground
 
     property alias pageToDisplay: listView.currentIndex
 
@@ -80,7 +80,7 @@ Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 width: 220
-                color: theme.viewBackground//theme.yellow400// left settings selection area
+                color: theme.viewBackground
                 radius: 10
 
                 ScrollView {

--- a/gpt4all-chat/qml/SettingsView.qml
+++ b/gpt4all-chat/qml/SettingsView.qml
@@ -13,7 +13,7 @@ import mysettings
 
 Rectangle {
     id: settingsDialog
-    color: theme.viewBackground
+    color: theme.viewBackground//theme.yellow400//theme.blue500//
 
     property alias pageToDisplay: listView.currentIndex
 
@@ -80,7 +80,7 @@ Rectangle {
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
                 width: 220
-                color: theme.viewBackground
+                color: theme.viewBackground//theme.yellow400// left settings selection area
                 radius: 10
 
                 ScrollView {
@@ -137,19 +137,58 @@ Rectangle {
 
                 MySettingsStack {
                     tabs: [
-                        Component { ApplicationSettings { } }
+                        Component {
+                            Rectangle {
+                                id: stackAppSettings
+                                color: theme.conversationBackground
+                                border.color: theme.controlBorder
+                                border.width: 1
+                                radius: 10
+
+                                ApplicationSettings {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                }
+                            }
+                        }
                     ]
                 }
 
                 MySettingsStack {
                     tabs: [
-                        Component { ModelSettings { } }
+                        Component {
+                            Rectangle {
+                                id: stackModelSettings
+                                color: theme.conversationBackground
+                                border.color: theme.controlBorder
+                                border.width: 1
+                                radius: 10
+
+                                ModelSettings {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                }
+                            }
+                        }
                     ]
                 }
 
                 MySettingsStack {
                     tabs: [
-                        Component { LocalDocsSettings { } }
+                        Component {
+                            Rectangle {
+                                id: stackLocalDocSettings
+                                color: theme.conversationBackground
+                                border.color: theme.controlBorder
+                                border.width: 1
+                                radius: 10
+
+                                LocalDocsSettings {
+                                    anchors.fill: parent
+                                    anchors.margins: 10
+                                }
+                            }
+                        }
                     ]
                 }
             }

--- a/gpt4all-chat/qml/SettingsView.qml
+++ b/gpt4all-chat/qml/SettingsView.qml
@@ -137,58 +137,19 @@ Rectangle {
 
                 MySettingsStack {
                     tabs: [
-                        Component {
-                            Rectangle {
-                                id: stackAppSettings
-                                color: theme.conversationBackground
-                                border.color: theme.controlBorder
-                                border.width: 1
-                                radius: 10
-
-                                ApplicationSettings {
-                                    anchors.fill: parent
-                                    anchors.margins: 10
-                                }
-                            }
-                        }
+                        Component { ApplicationSettings { } }
                     ]
                 }
 
                 MySettingsStack {
                     tabs: [
-                        Component {
-                            Rectangle {
-                                id: stackModelSettings
-                                color: theme.conversationBackground
-                                border.color: theme.controlBorder
-                                border.width: 1
-                                radius: 10
-
-                                ModelSettings {
-                                    anchors.fill: parent
-                                    anchors.margins: 10
-                                }
-                            }
-                        }
+                        Component { ModelSettings { } }
                     ]
                 }
 
                 MySettingsStack {
                     tabs: [
-                        Component {
-                            Rectangle {
-                                id: stackLocalDocSettings
-                                color: theme.conversationBackground
-                                border.color: theme.controlBorder
-                                border.width: 1
-                                radius: 10
-
-                                LocalDocsSettings {
-                                    anchors.fill: parent
-                                    anchors.margins: 10
-                                }
-                            }
-                        }
+                        Component { LocalDocsSettings { } }
                     ]
                 }
             }

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -1164,25 +1164,14 @@ QtObject {
         }
     }
 
-    property color menuFrameColor: {
+    property color menuBackgroundColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return blue700
             case "Dark":
                 return darkgray200
             default:
-                return gray200
-        }
-    }
-
-    property color menuBackgroundColor: {
-        switch (MySettings.chatTheme) {
-            case "LegacyDark":
-                return blue600
-            case "Dark":
-                return darkgray100
-            default:
-                return gray100
+                return gray50
         }
     }
 
@@ -1194,6 +1183,17 @@ QtObject {
                 return darkgray0
             default:
                 return green100
+        }
+    }
+
+    property color menuBorderColor: {
+        switch (MySettings.chatTheme) {
+            case "LegacyDark":
+                return blue400
+            case "Dark":
+                return gray800
+            default:
+                return gray300
         }
     }
 

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -1164,7 +1164,7 @@ QtObject {
         }
     }
 
-    property color chatViewModelListFrameColor: {
+    property color menuFrameColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return blue700
@@ -1175,7 +1175,7 @@ QtObject {
         }
     }
 
-    property color chatViewModelListBgColor: {
+    property color menuBackgroundColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return blue600
@@ -1186,7 +1186,7 @@ QtObject {
         }
     }
 
-    property color chatViewModelListHighlightColor: {
+    property color menuHighlightColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return blue400
@@ -1195,17 +1195,6 @@ QtObject {
             default:
                 return green100
         }
-    }
-    property color contextMenuFrameColor: {
-        return chatViewModelListFrameColor
-    }
-
-    property color contextMenuBgColor: {
-        return chatViewModelListBgColor
-    }
-
-    property color contextMenuHighlightColor: {
-        return chatViewModelListHighlightColor
     }
 
     property real fontScale: MySettings.fontSize === "Small"  ? 1 :

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -1164,6 +1164,50 @@ QtObject {
         }
     }
 
+    property color chatViewModelListFrameColor: {
+        switch (MySettings.chatTheme) {
+            case "LegacyDark":
+                return blue700
+            case "Dark":
+                return darkgray200
+            default:
+                return gray200
+        }
+    }
+
+    property color chatViewModelListBgColor: {
+        switch (MySettings.chatTheme) {
+            case "LegacyDark":
+                return blue600
+            case "Dark":
+                return darkgray100
+            default:
+                return gray100
+        }
+    }
+
+    property color chatViewModelListHighlightColor: {
+        switch (MySettings.chatTheme) {
+            case "LegacyDark":
+                return blue400
+            case "Dark":
+                return darkgray0
+            default:
+                return green100
+        }
+    }
+    property color contextMenuFrameColor: {
+        return chatViewModelListFrameColor
+    }
+
+    property color contextMenuBgColor: {
+        return chatViewModelListBgColor
+    }
+
+    property color contextMenuHighlightColor: {
+        return chatViewModelListHighlightColor
+    }
+
     property real fontScale: MySettings.fontSize === "Small"  ? 1 :
                              MySettings.fontSize === "Medium" ? 1.3 :
                                                   /* "Large" */ 1.8

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -128,6 +128,10 @@ QtObject {
         }
     }
 
+ /*
+  These nolonger apply to anything (remove this?)
+  Replaced by menuHighlightColor & menuBackgroundColor now using different colors.
+
     property color darkContrast: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
@@ -149,7 +153,7 @@ QtObject {
                 return gray0
         }
     }
-
+*/
     property color controlBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
@@ -219,6 +223,8 @@ QtObject {
                 return gray50
         }
     }
+/*
+  These nolonger apply to anything (remove this?)
 
     property color containerForeground: {
         switch (MySettings.chatTheme) {
@@ -230,7 +236,7 @@ QtObject {
                 return gray300
         }
     }
-
+*/
     property color containerBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":

--- a/gpt4all-chat/qml/Theme.qml
+++ b/gpt4all-chat/qml/Theme.qml
@@ -120,82 +120,82 @@ QtObject {
     property color accentColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue200;
+                return blue200
             case "Dark":
-                return yellow300;
+                return yellow300
             default:
-                return yellow300;
+                return yellow300
         }
     }
 
     property color darkContrast: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray300;
+                return darkgray300
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color lightContrast: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue400;
+                return blue400
             case "Dark":
-                return darkgray0;
+                return darkgray0
             default:
-                return gray0;
+                return gray0
         }
     }
 
     property color controlBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue800;
+                return blue800
             case "Dark":
-                return darkgray0;
+                return darkgray0
             default:
-                return gray300;
+                return gray300
         }
     }
 
     property color controlBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray300;
+                return darkgray300
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color disabledControlBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray200;
+                return darkgray200
             default:
-                return gray200;
+                return gray200
         }
     }
 
     property color dividerColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray200;
+                return darkgray200
             default:
-                return grayRed0;
+                return grayRed0
         }
     }
 
     property color conversationDivider: {
-        return dividerColor;
+        return dividerColor
     }
 
     property color settingsDivider: {
@@ -203,489 +203,489 @@ QtObject {
             case "LegacyDark":
                 return dividerColor
             case "Dark":
-                return darkgray400;
+                return darkgray400
             default:
-                return grayRed500;
+                return grayRed500
         }
     }
 
     property color viewBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue600;
+                return blue600
             case "Dark":
-                return darkgray100;
+                return darkgray100
             default:
-                return gray50;
+                return gray50
         }
     }
 
     property color containerForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray300;
+                return darkgray300
             default:
-                return gray300;
+                return gray300
         }
     }
 
     property color containerBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue900;
+                return blue900
             case "Dark":
-                return darkgray200;
+                return darkgray200
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color viewBarBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray400;
+                return darkgray400
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color progressForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return accentColor;
+                return accentColor
             default:
-                return green600;
+                return green600
         }
     }
 
     property color progressBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue900;
+                return blue900
             case "Dark":
-                return green600;
+                return green600
             default:
-                return green100;
+                return green100
         }
     }
 
     property color altProgressForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return progressForeground;
+                return progressForeground
             default:
-                return "#fcf0c9";
+                return "#fcf0c9"
         }
     }
 
     property color altProgressBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return progressBackground;
+                return progressBackground
             default:
-                return "#fff9d2";
+                return "#fff9d2"
         }
     }
 
     property color altProgressText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return textColor;
+                return textColor
             default:
-                return "#d16f0e";
+                return "#d16f0e"
         }
     }
 
     property color checkboxBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return gray200;
+                return gray200
             default:
-                return gray600;
+                return gray600
         }
     }
 
     property color checkboxForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return green300;
+                return green300
             default:
-                return green600;
+                return green600
         }
     }
 
     property color buttonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue950;
+                return blue950
             case "Dark":
-                return darkgray300;
+                return darkgray300
             default:
-                return green600;
+                return green600
         }
     }
 
     property color buttonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue900;
+                return blue900
             case "Dark":
-                return darkgray400;
+                return darkgray400
             default:
-                return green500;
+                return green500
         }
     }
 
     property color lightButtonText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return textColor;
+                return textColor
             case "Dark":
-                return textColor;
+                return textColor
             default:
-                return green600;
+                return green600
         }
     }
 
     property color lightButtonMutedText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return mutedTextColor;
+                return mutedTextColor
             case "Dark":
-                return mutedTextColor;
+                return mutedTextColor
             default:
-                return green300;
+                return green300
         }
     }
 
     property color lightButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackground;
+                return buttonBackground
             case "Dark":
-                return buttonBackground;
+                return buttonBackground
             default:
-                return green100;
+                return green100
         }
     }
 
     property color lightButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             case "Dark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             default:
-                return green200;
+                return green200
         }
     }
 
     property color darkButtonText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return textColor;
+                return textColor
             case "Dark":
-                return textColor;
+                return textColor
             default:
-                return red600;
+                return red600
         }
     }
 
     property color darkButtonMutedText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return mutedTextColor;
+                return mutedTextColor
             case "Dark":
-                return mutedTextColor;
+                return mutedTextColor
             default:
-                return red300;
+                return red300
         }
     }
 
     property color darkButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackground;
+                return buttonBackground
             case "Dark":
-                return buttonBackground;
+                return buttonBackground
             default:
-                return red200;
+                return red200
         }
     }
 
     property color darkButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             case "Dark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             default:
-                return red300;
+                return red300
         }
     }
 
     property color lighterButtonForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return textColor;
+                return textColor
             case "Dark":
-                return textColor;
+                return textColor
             default:
-                return green600;
+                return green600
         }
     }
 
     property color lighterButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackground;
+                return buttonBackground
             case "Dark":
-                return buttonBackground;
+                return buttonBackground
             default:
-                return green100;
+                return green100
         }
     }
 
     property color lighterButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             case "Dark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             default:
-                return green50;
+                return green50
         }
     }
 
     property color lighterButtonBackgroundHoveredRed: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             case "Dark":
-                return buttonBackgroundHovered;
+                return buttonBackgroundHovered
             default:
-                return red50;
+                return red50
         }
     }
 
     property color sourcesBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return lighterButtonBackground;
+                return lighterButtonBackground
             case "Dark":
-                return lighterButtonBackground;
+                return lighterButtonBackground
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color sourcesBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return lighterButtonBackgroundHovered;
+                return lighterButtonBackgroundHovered
             case "Dark":
-                return lighterButtonBackgroundHovered;
+                return lighterButtonBackgroundHovered
             default:
-                return gray200;
+                return gray200
         }
     }
 
     property color buttonBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return controlBorder;
+                return controlBorder
             default:
-                return yellow200;
+                return yellow200
         }
     }
 
     property color sendButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return accentColor;
+                return accentColor
             default:
-                return black;
+                return black
         }
     }
 
     property color sendButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue0;
+                return blue0
             case "Dark":
-                return darkwhite;
+                return darkwhite
             default:
-                return accentColor;
+                return accentColor
         }
     }
 
     property color selectedBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue700;
+                return blue700
             case "Dark":
-                return darkgray200;
+                return darkgray200
             default:
-                return gray0;
+                return gray0
         }
     }
 
     property color conversationButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue500;
+                return blue500
             case "Dark":
-                return darkgray100;
+                return darkgray100
             default:
-                return gray0;
+                return gray0
         }
     }
    property color conversationBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue500;
+                return blue500
             case "Dark":
-                return darkgray50;
+                return darkgray50
             default:
-                return white;
+                return white
         }
     }
 
     property color conversationProgress: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return green400;
+                return green400
             default:
-                return green400;
+                return green400
         }
     }
 
     property color conversationButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue400;
+                return blue400
             case "Dark":
-                return darkgray0;
+                return darkgray0
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color conversationButtonBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return yellow200;
+                return yellow200
             default:
-                return yellow200;
+                return yellow200
         }
     }
 
     property color conversationHeader: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return green400;
+                return green400
             default:
-                return green500;
+                return green500
         }
     }
 
     property color collectionsButtonText: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return black;
+                return black
             case "Dark":
-                return black;
+                return black
             default:
-                return white;
+                return white
         }
     }
 
     property color collectionsButtonProgress: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
                 return darkgray400
             default:
-                return green400;
+                return green400
         }
     }
 
     property color collectionsButtonForeground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return green300;
+                return green300
             default:
-                return green600;
+                return green600
         }
     }
 
     property color collectionsButtonBackground: {
         switch (MySettings.chatTheme) {
             default:
-                return lighterButtonBackground;
+                return lighterButtonBackground
         }
     }
 
     property color collectionsButtonBackgroundHovered: {
         switch (MySettings.chatTheme) {
             default:
-                return lighterButtonBackgroundHovered;
+                return lighterButtonBackgroundHovered
         }
     }
 
     property color welcomeButtonBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBackground;
+                return buttonBackground
             case "Dark":
-                return buttonBackground;
+                return buttonBackground
             default:
-                return lighterButtonBackground;
+                return lighterButtonBackground
         }
     }
 
     property color welcomeButtonBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return buttonBorder;
+                return buttonBorder
             case "Dark":
-                return buttonBorder;
+                return buttonBorder
             default:
-                return green300;
+                return green300
         }
     }
 
     property color welcomeButtonBorderHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple200;
+                return purple200
             case "Dark":
-                return darkgray100;
+                return darkgray100
             default:
-                return green400;
+                return green400
         }
     }
 
@@ -696,7 +696,7 @@ QtObject {
             case "Dark":
                 return textColor
             default:
-                return green700;
+                return green700
         }
     }
 
@@ -707,7 +707,7 @@ QtObject {
             case "Dark":
                 return gray400
             default:
-                return green800;
+                return green800
         }
     }
 
@@ -718,7 +718,7 @@ QtObject {
             case "Dark":
                 return textColor
             default:
-                return grayRed900;
+                return grayRed900
         }
     }
 
@@ -729,95 +729,95 @@ QtObject {
             case "Dark":
                 return mutedTextColor
             default:
-                return textColor;
+                return textColor
         }
     }
 
     property color iconBackgroundDark: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue200;
+                return blue200
             case "Dark":
-                return green400;
+                return green400
             default:
-                return black;
+                return black
         }
     }
 
     property color iconBackgroundLight: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue200;
+                return blue200
             case "Dark":
-                return darkwhite;
+                return darkwhite
             default:
-                return gray500;
+                return gray500
         }
     }
 
     property color iconBackgroundHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue0;
+                return blue0
             case "Dark":
-                return gray400;
+                return gray400
             default:
-                return accentColor;
+                return accentColor
         }
     }
 
     property color iconBackgroundViewBar: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return iconBackgroundLight;
+                return iconBackgroundLight
             case "Dark":
-                return iconBackgroundLight;
+                return iconBackgroundLight
             default:
-                return green500;
+                return green500
         }
     }
 
     property color iconBackgroundViewBarToggled: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return iconBackgroundLight;
+                return iconBackgroundLight
             case "Dark":
-                return darkgray50;
+                return darkgray50
             default:
-                return green200;
+                return green200
         }
     }
 
     property color iconBackgroundViewBarHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return iconBackgroundHovered;
+                return iconBackgroundHovered
             case "Dark":
-                return iconBackgroundHovered;
+                return iconBackgroundHovered
             default:
-                return green600;
+                return green600
         }
     }
 
     property color slugBackground: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue600;
+                return blue600
             case "Dark":
-                return darkgray300;
+                return darkgray300
             default:
-                return gray100;
+                return gray100
         }
     }
 
     property color textColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue0;
+                return blue0
             case "Dark":
-                return darkwhite;
+                return darkwhite
             default:
-                return black;
+                return black
         }
     }
 
@@ -825,7 +825,7 @@ QtObject {
     property color mutedLighterTextColor: {
         switch (MySettings.chatTheme) {
             default:
-                return gray300;
+                return gray300
         }
     }
 
@@ -833,7 +833,7 @@ QtObject {
     property color mutedLightTextColor: {
         switch (MySettings.chatTheme) {
             default:
-                return gray400;
+                return gray400
         }
     }
 
@@ -841,11 +841,11 @@ QtObject {
     property color mutedTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue200;
+                return blue200
             case "Dark":
-                return gray400;
+                return gray400
             default:
-                return gray500;
+                return gray500
         }
     }
 
@@ -853,11 +853,11 @@ QtObject {
     property color mutedDarkTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return mutedTextColor;
+                return mutedTextColor
             case "Dark":
-                return mutedTextColor;
+                return mutedTextColor
             default:
-                return grayRed500;
+                return grayRed500
         }
     }
 
@@ -865,97 +865,97 @@ QtObject {
     property color mutedDarkTextColorHovered: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue400;
+                return blue400
             default:
-                return grayRed900;
+                return grayRed900
         }
     }
 
     property color oppositeTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return white;
+                return white
             case "Dark":
-                return darkwhite;
+                return darkwhite
             default:
-                return white;
+                return white
         }
     }
 
     property color oppositeMutedTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return white;
+                return white
             case "Dark":
-                return darkwhite;
+                return darkwhite
             default:
-                return white;
+                return white
         }
     }
 
     property color textAccent: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return accentColor;
+                return accentColor
             default:
-                return accentColor;
+                return accentColor
         }
     }
 
     property color textErrorColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return red400;
+                return red400
             case "Dark":
-                return red400;
+                return red400
             default:
-                return red400;
+                return red400
         }
     }
 
     property color settingsTitleTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue100;
+                return blue100
             case "Dark":
-                return green200;
+                return green200
             default:
-                return black;
+                return black
         }
     }
 
     property color titleTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return green300;
+                return green300
             default:
-                return green700;
+                return green700
         }
     }
 
     property color titleTextColor2: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return darkwhite;
+                return darkwhite
             case "Dark":
-                return green200;
+                return green200
             default:
-                return green700;
+                return green700
         }
     }
 
     property color titleInfoTextColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue200;
+                return blue200
             case "Dark":
-                return gray400;
+                return gray400
             default:
-                return gray600;
+                return gray600
         }
     }
 
@@ -966,102 +966,102 @@ QtObject {
             case "Dark":
                 return yellow25
             default:
-                return grayRed900;
+                return grayRed900
         }
     }
 
     property color styledTextColor2: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue0;
+                return blue0
             case "Dark":
                 return yellow50
             default:
-                return green500;
+                return green500
         }
     }
 
     property color chatDrawerSectionHeader: {
-            switch (MySettings.chatTheme) {
+        switch (MySettings.chatTheme) {
             case "LegacyDark":
                 return purple50
             case "Dark":
                 return yellow0
             default:
-                return grayRed800;
+                return grayRed800
         }
     }
 
     property color dialogBorder: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return accentColor;
+                return accentColor
             case "Dark":
-                return darkgray0;
+                return darkgray0
             default:
-                return darkgray0;
+                return darkgray0
         }
     }
 
     property color linkColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return yellow600;
+                return yellow600
             case "Dark":
-                return yellow600;
+                return yellow600
             default:
-                return yellow600;
+                return yellow600
         }
     }
 
     property color mainHeader: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue900;
+                return blue900
             case "Dark":
-                return green600;
+                return green600
             default:
-                return green600;
+                return green600
         }
     }
 
     property color mainComboBackground: {
         switch (MySettings.chatTheme) {
             default:
-                return "transparent";
+                return "transparent"
         }
     }
 
     property color sendGlow: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue1000;
+                return blue1000
             case "Dark":
-                return green950;
+                return green950
             default:
-                return green300;
+                return green300
         }
     }
 
     property color userColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return blue800;
+                return blue800
             case "Dark":
-                return green700;
+                return green700
             default:
-                return green700;
+                return green700
         }
     }
 
     property color assistantColor: {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
-                return purple400;
+                return purple400
             case "Dark":
-                return accentColor;
+                return accentColor
             default:
-                return accentColor;
+                return accentColor
         }
     }
 
@@ -1070,7 +1070,7 @@ QtObject {
             case "LegacyDark":
             case "Dark":
             default:
-                return textColor;
+                return textColor
         }
     }
 
@@ -1078,9 +1078,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return "#2e95d3"; // blue
+                return "#2e95d3" // blue
             default:
-                return "#195273"; // dark blue
+                return "#195273" // dark blue
         }
     }
 
@@ -1088,9 +1088,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return"#f22c3d"; // red
+                return"#f22c3d" // red
             default:
-                return"#7d1721"; // dark red
+                return"#7d1721" // dark red
         }
     }
 
@@ -1098,9 +1098,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return "#e9950c"; // orange
+                return "#e9950c" // orange
             default:
-                return "#815207"; // dark orange
+                return "#815207" // dark orange
         }
     }
 
@@ -1108,9 +1108,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return "#808080"; // gray
+                return "#808080" // gray
             default:
-                return "#474747"; // dark gray
+                return "#474747" // dark gray
         }
     }
 
@@ -1118,9 +1118,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return "#00a37d"; // green
+                return "#00a37d" // green
             default:
-                return "#004a39"; // dark green
+                return "#004a39" // dark green
         }
     }
 
@@ -1128,9 +1128,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return "#df3079"; // fuchsia
+                return "#df3079" // fuchsia
             default:
-                return "#761942"; // dark fuchsia
+                return "#761942" // dark fuchsia
         }
     }
 
@@ -1138,9 +1138,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return containerBackground;
+                return containerBackground
             default:
-                return green50;
+                return green50
         }
     }
 
@@ -1148,9 +1148,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return controlBackground;
+                return controlBackground
             default:
-                return gray100;
+                return gray100
         }
     }
 
@@ -1158,9 +1158,9 @@ QtObject {
         switch (MySettings.chatTheme) {
             case "LegacyDark":
             case "Dark":
-                return controlBackground;
+                return controlBackground
             default:
-                return gray100;
+                return gray100
         }
     }
 


### PR DESCRIPTION
## Describe your changes
Menu theme colors adjusted to produce softer look while maintaining current scheme.

To achieve this:
Assigned property names for each color by the object to which they apply. (Ideally easy to understand without needing to trace)
- "menuBorderColor" (the color for the border of the comboBox & context menus)
- "menuBackgroundColor" (the color for the background of the comboBox & context menus)
- "menuHighlightColor" (the color for the highlight of the comboBox & context menus)

Other:
- The previous color properties no longer apply to other separate objects and were commented out with notes. (To be removed?)
- Fix for server text color in chatview. (tested)

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
<!-- Screenshots or video of new or updated code changes !-->

### Steps to Reproduce
<!-- Steps to reproduce demo !-->

## Notes
<!-- Any other relevant information to include about PR !-->

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2a9ef8e696791ccb8729134ad2609903f33712cd  | 
|--------|--------|

### Summary:
Updated theme colors for menus and context menus with new color properties for a softer look in `gpt4all-chat/qml/ChatView.qml`, `gpt4all-chat/qml/MyMenu.qml`, and `gpt4all-chat/qml/MyMenuItem.qml`.

**Key points**:
- Updated theme colors for menus in `gpt4all-chat/qml/ChatView.qml`, `gpt4all-chat/qml/MyMenu.qml`, and `gpt4all-chat/qml/MyMenuItem.qml`.
- Introduced new color properties in `gpt4all-chat/qml/Theme.qml`:
  - `chatViewModelListFrameColor`
  - `chatViewModelListBgColor`
  - `chatViewModelListHighlightColor`
  - `contextMenuFrameColor`
  - `contextMenuBgColor`
  - `contextMenuHighlightColor`
- Applied new color properties to relevant UI components for a softer look while maintaining the current scheme.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->