### PR TITLE
Fix property binding loop warning.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1164,7 +1164,7 @@ Rectangle {
                                     states: [
                                         State {
                                             name: "expanded"
-                                            PropertyChanges { target: sourcesLayout; Layout.preferredHeight: childrenRect.height }
+                                            PropertyChanges { target: sourcesLayout; Layout.preferredHeight: flow.height }
                                         },
                                         State {
                                             name: "collapsed"
@@ -1186,6 +1186,7 @@ Rectangle {
                                     ]
 
                                     Flow {
+                                        id: flow
                                         Layout.fillWidth: true
                                         spacing: 10
                                         visible: consolidatedSources.length !== 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8b29294cf536df038ae470f1ff38a3bfa6c38693  | 
|--------|--------|

### Summary:
Fixed property binding loop warning in `gpt4all-chat/qml/ChatView.qml` by changing `Layout.preferredHeight` binding from `childrenRect.height` to `flow.height`.

**Key points**:
- **File Modified**: `gpt4all-chat/qml/ChatView.qml`
- **Issue Fixed**: Property binding loop warning.
- **Modification**: Changed `Layout.preferredHeight` binding from `childrenRect.height` to `flow.height` in `sourcesLayout` state changes.
- **Specific Lines**: Updated in lines 1167 and 1188.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->