### PR TITLE
GPT4All Chat server API: add errors 405 Method Not Allowed

### DIFF
--- a/gpt4all-chat/server.cpp
+++ b/gpt4all-chat/server.cpp
@@ -147,6 +147,53 @@ void Server::start()
         }
     );
 
+    // Respond with code 405 to wrong HTTP methods:
+    m_server->route("/v1/models",  QHttpServerRequest::Method::Post,
+        [](const QHttpServerRequest &request) {
+            if (!MySettings::globalInstance()->serverChat())
+                return QHttpServerResponse(QHttpServerResponder::StatusCode::Unauthorized);
+            return QHttpServerResponse(
+                QJsonDocument::fromJson("{\"error\": {\"message\": \"Not allowed to POST on /v1/models."
+                    " (HINT: Perhaps you meant to use a different HTTP method?)\","
+                    " \"type\": \"invalid_request_error\", \"param\": null, \"code\": null}}").object(),
+                QHttpServerResponder::StatusCode::MethodNotAllowed);
+        }
+    );
+
+    m_server->route("/v1/models/<arg>", QHttpServerRequest::Method::Post,
+        [](const QString &model, const QHttpServerRequest &request) {
+            if (!MySettings::globalInstance()->serverChat())
+                return QHttpServerResponse(QHttpServerResponder::StatusCode::Unauthorized);
+            return QHttpServerResponse(
+                QJsonDocument::fromJson("{\"error\": {\"message\": \"Not allowed to POST on /v1/models/*."
+                    " (HINT: Perhaps you meant to use a different HTTP method?)\","
+                    " \"type\": \"invalid_request_error\", \"param\": null, \"code\": null}}").object(),
+                QHttpServerResponder::StatusCode::MethodNotAllowed);
+        }
+    );
+
+    m_server->route("/v1/completions", QHttpServerRequest::Method::Get,
+        [](const QHttpServerRequest &request) {
+            if (!MySettings::globalInstance()->serverChat())
+                return QHttpServerResponse(QHttpServerResponder::StatusCode::Unauthorized);
+            return QHttpServerResponse(
+                QJsonDocument::fromJson("{\"error\": {\"message\": \"Only POST requests are accepted.\","
+                    " \"type\": \"invalid_request_error\", \"param\": null, \"code\": \"method_not_supported\"}}").object(),
+                QHttpServerResponder::StatusCode::MethodNotAllowed);
+        }
+    );
+
+    m_server->route("/v1/chat/completions", QHttpServerRequest::Method::Get,
+        [](const QHttpServerRequest &request) {
+            if (!MySettings::globalInstance()->serverChat())
+                return QHttpServerResponse(QHttpServerResponder::StatusCode::Unauthorized);
+            return QHttpServerResponse(
+                QJsonDocument::fromJson("{\"error\": {\"message\": \"Only POST requests are accepted.\","
+                    " \"type\": \"invalid_request_error\", \"param\": null, \"code\": \"method_not_supported\"}}").object(),
+                QHttpServerResponder::StatusCode::MethodNotAllowed);
+        }
+    );
+
     m_server->afterRequest([] (QHttpServerResponse &&resp) {
         resp.addHeader("Access-Control-Allow-Origin", "*");
         return std::move(resp);


### PR DESCRIPTION
Add a HTTP status code 405 Method Not Allowed for each of the four handlers when the wrong method (GET/POST) is used. This mimics the OpenAI API response.

## Describe your changes

## Issue ticket number and link
- Should I open one?
- [Mentioned in Discord](https://discord.com/channels/1076964370942267462/1096848919473946694/1260014267030044732).

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
```bash
$ curl -vX POST http://localhost:4891/v1/models
* Host localhost:4891 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4891...
*   Trying 127.0.0.1:4891...
* Connected to localhost (127.0.0.1) port 4891
> POST /v1/models HTTP/1.1
> Host: localhost:4891
> User-Agent: curl/8.8.0
> Accept: */*
>
< HTTP/1.1 405 Method Not Allowed
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Content-Length: 172
<
{"error":{"code":null,"message":"Not allowed to POST on /v1/models. (HINT: Perhaps you meant to use a different HTTP method?)","param":null,"type":"invalid_request_error"}}
```

```bash
$ curl -vX POST http://localhost:4891/v1/models/foo
* Host localhost:4891 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4891...
*   Trying 127.0.0.1:4891...
* Connected to localhost (127.0.0.1) port 4891
> POST /v1/models/foo HTTP/1.1
> Host: localhost:4891
> User-Agent: curl/8.8.0
> Accept: */*
>
< HTTP/1.1 405 Method Not Allowed
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Content-Length: 174
<
{"error":{"code":null,"message":"Not allowed to POST on /v1/models/*. (HINT: Perhaps you meant to use a different HTTP method?)","param":null,"type":"invalid_request_error"}}
```

```bash
$ curl -vX GET http://localhost:4891/v1/completions
Note: Unnecessary use of -X or --request, GET is already inferred.
* Host localhost:4891 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4891...
*   Trying 127.0.0.1:4891...
* Connected to localhost (127.0.0.1) port 4891
> GET /v1/completions HTTP/1.1
> Host: localhost:4891
> User-Agent: curl/8.8.0
> Accept: */*
>
< HTTP/1.1 405 Method Not Allowed
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Content-Length: 130
<
{"error":{"code":"method_not_supported","message":"Only POST requests are accepted.","param":null,"type":"invalid_request_error"}}
```

```bash
$ curl -vX GET http://localhost:4891/v1/chat/completions
Note: Unnecessary use of -X or --request, GET is already inferred.
* Host localhost:4891 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:4891...
*   Trying 127.0.0.1:4891...
* Connected to localhost (127.0.0.1) port 4891
> GET /v1/chat/completions HTTP/1.1
> Host: localhost:4891
> User-Agent: curl/8.8.0
> Accept: */*
>
< HTTP/1.1 405 Method Not Allowed
< Access-Control-Allow-Origin: *
< Content-Type: application/json
< Content-Length: 130
<
{"error":{"code":"method_not_supported","message":"Only POST requests are accepted.","param":null,"type":"invalid_request_error"}}
```

### Steps to Reproduce
Run the cURL commands with local API server active.

## Notes
Works for me here, but I have no idea if this the correct way to do it, esp. with regards to leaking things. Please have a look,