### PR TITLE
[WIP] Improve LocalDocs view's error mesage

### DIFF
--- a/gpt4all-chat/qml/LocalDocsView.qml
+++ b/gpt4all-chat/qml/LocalDocsView.qml
@@ -83,10 +83,14 @@ Rectangle {
             Text {
                 anchors.centerIn: parent
                 horizontalAlignment: Qt.AlignHCenter
-                text: qsTr("ERROR: The LocalDocs database is not valid.")
+                text: qsTr("<h3>ERROR: The LocalDocs database cannot be accessed or is not valid.</h3><br>"
+                      + "<i>This is unexpected. Note: You will need to restart each time after you try any of the following suggested fixes.</i>"
+                      + "<ul><li>First of all, make sure that the folder set as <b>Download Path</b> exists on the file system.</li>"
+                      + "<li>Check ownership as well as read and write permissions of the <b>Download Path</b>.</li>"
+                      + "<li>If there is a file named 'localdocs_v2.db', check ownership and read/write permissions of this file, too.</li>"
+                      + "<li>If the problem cannot be solved this way and there are any 'localdocs_v*.db' files present, you can try "
+                      + "backing them up and removing them as a last resort. You will have to recreate your collections, however.</li></ul>");
                 color: theme.textErrorColor
-                font.bold: true
-                font.pixelSize: theme.fontSizeLargest
             }
         }
 


### PR DESCRIPTION
- LocalDocsView.qml: better message and suggested fixes
- **Draft!** Will probably close it and do it properly later. But I need to write some things down now.
- See notes below, there are some additional considerations.

## Describe your changes
- Here's a first idea to change the **content** of the message. Doesn't look good yet (prepare to be disappointed).

## Issue ticket number and link
- Regarding: #2516

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Not yet.

### Steps to Reproduce
For people who run into edge cases. E.g. set *Download Path* to a non-existent directory, relaunch, then switch to LocalDocs view.

## Notes
Things to be wary of:
- As far as I understand, SQLite can write several temporary files for bookkeeping not only next to the DB (*Download Path*),
but also in a system temp folder and potentially even the current working directory. All of these could cause permission problems in rare cases. See SQLite docs: [Temporary Files Used By SQLite](https://www.sqlite.org/tempfiles.html)

- When something goes wrong with `QSqlDatabase::open()`, at least there's a connection error returned from the Qt DB API, which is then logged. Unfortunately, it might just be an SQLite error code + general message. Codes in SQLite docs which I think correspond to this: [Primary Result Code List](https://www.sqlite.org/rescode.html#primary_result_code_list)
  - Not sure if this should be exposed in some way other than the log.
  - The log should also at least include the DB's file name or path (as mentioned on discord).

- Unclear what happens when people try to mount and use remote file systems, i.e. the *Download Path* is on a shared folder. I think SQLite has some expectations regarding file system capabilities, which might not fulfilled in such a scenario.