### PR TITLE
Add Spanish (MX) Translation

### DIFF
--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -1,0 +1,3711 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+    <context>
+        <name>AddCollectionView</name>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="45" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="45" />
+            <source>← Existing Collections</source>
+            <translation>← Colecciones existentes</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="68" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="68" />
+            <source>Add Document Collection</source>
+            <translation>Agregar colección de documentos</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="78" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="78" />
+            <source>Add a folder containing plain text files, PDFs, or Markdown. Configure
+                additional extensions in Settings.</source>
+            <translation>Agregue una carpeta que contenga archivos de texto plano, PDFs o Markdown.
+                Configure extensiones adicionales en Configuración.</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="94" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="94" />
+            <source>Please choose a directory</source>
+            <translation>Por favor, elija un directorio</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="106" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="106" />
+            <source>Name</source>
+            <translation>Nombre</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="121" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="121" />
+            <source>Collection name...</source>
+            <translation>Nombre de la colección...</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="123" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="123" />
+            <source>Name of the collection to add (Required)</source>
+            <translation>Nombre de la colección a agregar (Requerido)</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="139" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="139" />
+            <source>Folder</source>
+            <translation>Carpeta</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="156" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="156" />
+            <source>Folder path...</source>
+            <translation>Ruta de la carpeta...</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="159" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="159" />
+            <source>Folder path to documents (Required)</source>
+            <translation>Ruta de la carpeta de documentos (Requerido)</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="171" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="171" />
+            <source>Browse</source>
+            <translation>Explorar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddCollectionView.qml" line="184" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
+                line="184" />
+            <source>Create Collection</source>
+            <translation>Crear colección</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddModelView</name>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="51" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="51" />
+            <source>← Existing Models</source>
+            <translation>← Modelos existentes</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="71" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="71" />
+            <source>Explore Models</source>
+            <translation>Explorar modelos</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="88" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="88" />
+            <source>Discover and download models by keyword search...</source>
+            <translation>Descubre y descarga modelos mediante búsqueda por palabras clave...</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="91" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="91" />
+            <source>Text field for discovering and filtering downloadable models</source>
+            <translation>Campo de texto para descubrir y filtrar modelos descargables</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="167" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="167" />
+            <source>Initiate model discovery and filtering</source>
+            <translation>Iniciar descubrimiento y filtrado de modelos</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="168" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="168" />
+            <source>Triggers discovery and filtering of models</source>
+            <translation>Activa el descubrimiento y filtrado de modelos</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="186" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="186" />
+            <source>Default</source>
+            <translation>Predeterminado</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="186" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="186" />
+            <source>Likes</source>
+            <translation>Me gusta</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="186" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="186" />
+            <source>Downloads</source>
+            <translation>Descargas</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="186" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="186" />
+            <source>Recent</source>
+            <translation>Reciente</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="206" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="206" />
+            <source>Asc</source>
+            <translation>Asc</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="206" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="206" />
+            <source>Desc</source>
+            <translation>Desc</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="234" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="234" />
+            <source>None</source>
+            <translation>Ninguno</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="97" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="97" />
+            <source>Searching · %1</source>
+            <translation>Buscando · %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="193" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="193" />
+            <source>Sort by: %1</source>
+            <translation>Ordenar por: %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="218" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="218" />
+            <source>Sort dir: %1</source>
+            <translation>Dirección de ordenamiento: %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="254" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="254" />
+            <source>Limit: %1</source>
+            <translation>Límite: %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="287" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="287" />
+            <source>Network error: could not retrieve %1</source>
+            <translation>Error de red: no se pudo recuperar %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="297" />
+            <location filename="../qml/AddModelView.qml" line="560" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="297" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="560" />
+            <source>Busy indicator</source>
+            <translation>Indicador de ocupado</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="298" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="298" />
+            <source>Displayed when the models request is ongoing</source>
+            <translation>Se muestra cuando la solicitud de modelos está en curso</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="338" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="338" />
+            <source>Model file</source>
+            <translation>Archivo del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="339" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="339" />
+            <source>Model file to be downloaded</source>
+            <translation>Archivo del modelo a descargar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="362" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="362" />
+            <source>Description</source>
+            <translation>Descripción</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="363" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="363" />
+            <source>File description</source>
+            <translation>Descripción del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="396" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="396" />
+            <source>Cancel</source>
+            <translation>Cancelar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="396" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="396" />
+            <source>Resume</source>
+            <translation>Reanudar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="396" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="396" />
+            <source>Download</source>
+            <translation>Descargar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="404" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="404" />
+            <source>Stop/restart/start the download</source>
+            <translation>Detener/reiniciar/iniciar la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="416" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="416" />
+            <source>Remove</source>
+            <translation>Eliminar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="423" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="423" />
+            <source>Remove model from filesystem</source>
+            <translation>Eliminar modelo del sistema de archivos</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="437" />
+            <location filename="../qml/AddModelView.qml" line="446" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="437" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="446" />
+            <source>Install</source>
+            <translation>Instalar</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="447" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="447" />
+            <source>Install online model</source>
+            <translation>Instalar modelo en línea</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="476" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="476" />
+            <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
+                hardware. Model requires more memory (%1 GB) than your system has available
+                (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+            <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
+                para su hardware. El modelo requiere más memoria (%1 GB) de la que su sistema tiene
+                disponible
+                (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="628" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="628" />
+            <source>%1 GB</source>
+            <translation>%1 GB</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="628" />
+            <location filename="../qml/AddModelView.qml" line="650" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="628" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="650" />
+            <source>?</source>
+            <translation>?</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="463" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="463" />
+            <source>Describes an error that occurred when downloading</source>
+            <translation>Describe un error que ocurrió durante la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="457" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="457" />
+            <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+                href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+            <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+                href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="482" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="482" />
+            <source>Error for incompatible hardware</source>
+            <translation>Error por hardware incompatible</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="520" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="520" />
+            <source>Download progressBar</source>
+            <translation>Barra de progreso de descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="521" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="521" />
+            <source>Shows the progress made in the download</source>
+            <translation>Muestra el progreso realizado en la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="531" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="531" />
+            <source>Download speed</source>
+            <translation>Velocidad de descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="532" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="532" />
+            <source>Download speed in bytes/kilobytes/megabytes per second</source>
+            <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="549" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="549" />
+            <source>Calculating...</source>
+            <translation>Calculando...</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="553" />
+            <location filename="../qml/AddModelView.qml" line="582" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="553" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="582" />
+            <source>Whether the file hash is being calculated</source>
+            <translation>Si se está calculando el hash del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="561" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="561" />
+            <source>Displayed when the file hash is being calculated</source>
+            <translation>Se muestra cuando se está calculando el hash del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="579" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="579" />
+            <source>enter $API_KEY</source>
+            <translation>ingrese $API_KEY</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="601" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="601" />
+            <source>File size</source>
+            <translation>Tamaño del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="623" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="623" />
+            <source>RAM required</source>
+            <translation>RAM requerida</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="645" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="645" />
+            <source>Parameters</source>
+            <translation>Parámetros</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="667" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="667" />
+            <source>Quant</source>
+            <translation>Cuantificación</translation>
+        </message>
+        <message>
+            <location filename="../qml/AddModelView.qml" line="689" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
+                line="689" />
+            <source>Type</source>
+            <translation>Tipo</translation>
+        </message>
+    </context>
+    <context>
+        <name>ApplicationSettings</name>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="16" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="16" />
+            <source>Application</source>
+            <translation>Aplicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="25" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="25" />
+            <source>Network dialog</source>
+            <translation>Diálogo de red</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="26" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="26" />
+            <source>opt-in to share feedback/conversations</source>
+            <translation>optar por compartir comentarios/conversaciones</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="37" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="37" />
+            <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
+                to check for updates!&lt;br&gt;&lt;br&gt;
+                Did you install this application using the online installer? If so,&lt;br&gt;
+                the MaintenanceTool executable should be located one directory&lt;br&gt;
+                above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
+                If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have
+                to&lt;br&gt;
+                reinstall.</source>
+            <translation>ERROR: El sistema de actualización no pudo encontrar la herramienta de
+                mantenimiento utilizada&lt;br&gt;
+                para buscar actualizaciones&lt;br&gt;&lt;br&gt;
+                ¿Instaló esta aplicación utilizando el instalador en línea? Si es así,&lt;br&gt;
+                el ejecutable de la herramienta de mantenimiento debería estar ubicado un
+                directorio&lt;br&gt;
+                por encima de donde reside esta aplicación en su sistema de
+                archivos.&lt;br&gt;&lt;br&gt;
+                Si no puede iniciarlo manualmente, me temo que tendrá que&lt;br&gt;
+                reinstalar.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="48" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="48" />
+            <source>Error dialog</source>
+            <translation>Diálogo de error</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="72" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="72" />
+            <source>Application Settings</source>
+            <translation>Configuración de la aplicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="85" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="85" />
+            <source>General</source>
+            <translation>General</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="97" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="97" />
+            <source>Theme</source>
+            <translation>Tema</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="98" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="98" />
+            <source>The application color scheme.</source>
+            <translation>El esquema de colores de la aplicación.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="110" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="110" />
+            <source>Dark</source>
+            <translation>Oscuro</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="110" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="110" />
+            <source>Light</source>
+            <translation>Claro</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="110" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="110" />
+            <source>LegacyDark</source>
+            <translation>Oscuro legado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="131" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="131" />
+            <source>Font Size</source>
+            <translation>Tamaño de fuente</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="132" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="132" />
+            <source>The size of text in the application.</source>
+            <translation>El tamaño del texto en la aplicación.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="165" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="165" />
+            <source>Device</source>
+            <translation>Dispositivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="166" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="166" />
+            <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or
+                Metal.</source>
+            <translation>El dispositivo de cómputo utilizado para la generación de texto.
+                &quot;Auto&quot; utiliza Vulkan o Metal.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="199" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="199" />
+            <source>Default Model</source>
+            <translation>Modelo predeterminado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="200" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="200" />
+            <source>The preferred model for new chats. Also used as the local server fallback.</source>
+            <translation>El modelo preferido para nuevos chats. También se utiliza como respaldo del
+                servidor local.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="232" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="232" />
+            <source>Suggestion Mode</source>
+            <translation>Modo de sugerencia</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="233" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="233" />
+            <source>Generate suggested follow-up questions at the end of responses.</source>
+            <translation>Generar preguntas de seguimiento sugeridas al final de las respuestas.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="244" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="244" />
+            <source>When chatting with LocalDocs</source>
+            <translation>Al chatear con LocalDocs</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="244" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="244" />
+            <source>Whenever possible</source>
+            <translation>Siempre que sea posible</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="244" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="244" />
+            <source>Never</source>
+            <translation>Nunca</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="256" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="256" />
+            <source>Download Path</source>
+            <translation>Ruta de descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="257" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="257" />
+            <source>Where to store local models and the LocalDocs database.</source>
+            <translation>Dónde almacenar los modelos locales y la base de datos de LocalDocs.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="286" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="286" />
+            <source>Browse</source>
+            <translation>Explorar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="287" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="287" />
+            <source>Choose where to save model files</source>
+            <translation>Elegir dónde guardar los archivos del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="298" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="298" />
+            <source>Enable Datalake</source>
+            <translation>Habilitar Datalake</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="299" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="299" />
+            <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
+            <translation>Enviar chats y comentarios al Datalake de código abierto de GPT4All.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="332" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="332" />
+            <source>Advanced</source>
+            <translation>Avanzado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="344" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="344" />
+            <source>CPU Threads</source>
+            <translation>Hilos de CPU</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="345" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="345" />
+            <source>The number of CPU threads used for inference and embedding.</source>
+            <translation>El número de hilos de CPU utilizados para inferencia e incrustación.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="376" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="376" />
+            <source>Save Chat Context</source>
+            <translation>Guardar contexto del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="377" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="377" />
+            <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB
+                per chat.</source>
+            <translation>Guardar el estado del modelo de chat en el disco para una carga más rápida.
+                ADVERTENCIA: Usa ~2GB por chat.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="393" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="393" />
+            <source>Enable Local Server</source>
+            <translation>Habilitar servidor local</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="394" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="394" />
+            <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
+                resource usage.</source>
+            <translation>Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
+                en un mayor uso de recursos.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="410" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="410" />
+            <source>API Server Port</source>
+            <translation>Puerto del servidor API</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="411" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="411" />
+            <source>The port to use for the local server. Requires restart.</source>
+            <translation>El puerto a utilizar para el servidor local. Requiere reinicio.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="463" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="463" />
+            <source>Check For Updates</source>
+            <translation>Buscar actualizaciones</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="464" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="464" />
+            <source>Manually check for an update to GPT4All.</source>
+            <translation>Buscar manualmente una actualización para GPT4All.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ApplicationSettings.qml" line="473" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
+                line="473" />
+            <source>Updates</source>
+            <translation>Actualizaciones</translation>
+        </message>
+    </context>
+    <context>
+        <name>Chat</name>
+        <message>
+            <location filename="../chat.h" line="72" />
+            <location filename="../chat.cpp" line="25" />
+            <source>New Chat</source>
+            <translation>Nuevo chat</translation>
+        </message>
+        <message>
+            <location filename="../chat.cpp" line="38" />
+            <source>Server Chat</source>
+            <translation>Chat del servidor</translation>
+        </message>
+    </context>
+    <context>
+        <name>ChatDrawer</name>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="37" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="37" />
+            <source>Drawer</source>
+            <translation>Cajón</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="38" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="38" />
+            <source>Main navigation drawer</source>
+            <translation>Cajón de navegación principal</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="49" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="49" />
+            <source>＋ New Chat</source>
+            <translation>＋ Nuevo chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="50" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="50" />
+            <source>Create a new chat</source>
+            <translation>Crear un nuevo chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="199" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="199" />
+            <source>Select the current chat or edit the chat when in edit mode</source>
+            <translation>Seleccionar el chat actual o editar el chat cuando esté en modo de edición</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="216" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="216" />
+            <source>Edit chat name</source>
+            <translation>Editar nombre del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="229" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="229" />
+            <source>Save chat name</source>
+            <translation>Guardar nombre del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="246" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="246" />
+            <source>Delete chat</source>
+            <translation>Eliminar chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="283" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="283" />
+            <source>Confirm chat deletion</source>
+            <translation>Confirmar eliminación del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="305" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="305" />
+            <source>Cancel chat deletion</source>
+            <translation>Cancelar eliminación del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="317" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="317" />
+            <source>List of chats</source>
+            <translation>Lista de chats</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatDrawer.qml" line="318" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
+                line="318" />
+            <source>List of chats in the drawer dialog</source>
+            <translation>Lista de chats en el diálogo del cajón</translation>
+        </message>
+    </context>
+    <context>
+        <name>ChatListModel</name>
+        <message>
+            <location filename="../chatlistmodel.h" line="86" />
+            <source>TODAY</source>
+            <translation>HOY</translation>
+        </message>
+        <message>
+            <location filename="../chatlistmodel.h" line="88" />
+            <source>THIS WEEK</source>
+            <translation>ESTA SEMANA</translation>
+        </message>
+        <message>
+            <location filename="../chatlistmodel.h" line="90" />
+            <source>THIS MONTH</source>
+            <translation>ESTE MES</translation>
+        </message>
+        <message>
+            <location filename="../chatlistmodel.h" line="92" />
+            <source>LAST SIX MONTHS</source>
+            <translation>ÚLTIMOS SEIS MESES</translation>
+        </message>
+        <message>
+            <location filename="../chatlistmodel.h" line="94" />
+            <source>THIS YEAR</source>
+            <translation>ESTE AÑO</translation>
+        </message>
+        <message>
+            <location filename="../chatlistmodel.h" line="96" />
+            <source>LAST YEAR</source>
+            <translation>AÑO PASADO</translation>
+        </message>
+    </context>
+    <context>
+        <name>ChatView</name>
+        <message>
+            <location filename="../qml/ChatView.qml" line="77" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="77" />
+            <source>&lt;h3&gt;Warning&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+            <translation>&lt;h3&gt;Advertencia&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="86" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="86" />
+            <source>Switch model dialog</source>
+            <translation>Diálogo para cambiar de modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="87" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="87" />
+            <source>Warn the user if they switch models, then context will be erased</source>
+            <translation>Advertir al usuario si cambia de modelo, entonces se borrará el contexto</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="94" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="94" />
+            <source>Conversation copied to clipboard.</source>
+            <translation>Conversación copiada al portapapeles.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="101" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="101" />
+            <source>Code copied to clipboard.</source>
+            <translation>Código copiado al portapapeles.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="231" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="231" />
+            <source>Chat panel</source>
+            <translation>Panel de chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="232" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="232" />
+            <source>Chat panel with options</source>
+            <translation>Panel de chat con opciones</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="339" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="339" />
+            <source>Reload the currently loaded model</source>
+            <translation>Recargar el modelo actualmente cargado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="353" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="353" />
+            <source>Eject the currently loaded model</source>
+            <translation>Expulsar el modelo actualmente cargado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="365" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="365" />
+            <source>No model installed.</source>
+            <translation>No hay modelo instalado.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="367" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="367" />
+            <source>Model loading error.</source>
+            <translation>Error al cargar el modelo.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="369" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="369" />
+            <source>Waiting for model...</source>
+            <translation>Esperando al modelo...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="371" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="371" />
+            <source>Switching context...</source>
+            <translation>Cambiando contexto...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="373" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="373" />
+            <source>Choose a model...</source>
+            <translation>Elige un modelo...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="375" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="375" />
+            <source>Not found: %1</source>
+            <translation>No encontrado: %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="463" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="463" />
+            <source>The top item is the current model</source>
+            <translation>El elemento superior es el modelo actual</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="549" />
+            <location filename="../qml/ChatView.qml" line="1307" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="549" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1307" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="567" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="567" />
+            <source>Add documents</source>
+            <translation>Agregar documentos</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="568" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="568" />
+            <source>add collections of documents to the chat</source>
+            <translation>agregar colecciones de documentos al chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="732" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="732" />
+            <source>Load the default model</source>
+            <translation>Cargar el modelo predeterminado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="733" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="733" />
+            <source>Loads the default model which can be changed in settings</source>
+            <translation>Carga el modelo predeterminado que se puede cambiar en la configuración</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="744" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="744" />
+            <source>No Model Installed</source>
+            <translation>No hay modelo instalado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="753" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="753" />
+            <source>GPT4All requires that you install at least one
+                model to get started</source>
+            <translation>GPT4All requiere que instales al menos un
+                modelo para comenzar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="765" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="765" />
+            <source>Install a Model</source>
+            <translation>Instalar un modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="770" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="770" />
+            <source>Shows the add model view</source>
+            <translation>Muestra la vista de agregar modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="795" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="795" />
+            <source>Conversation with the model</source>
+            <translation>Conversación con el modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="796" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="796" />
+            <source>prompt / response pairs from the conversation</source>
+            <translation>pares de pregunta / respuesta de la conversación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="848" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="848" />
+            <source>GPT4All</source>
+            <translation>GPT4All</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="848" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="848" />
+            <source>You</source>
+            <translation>Tú</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="870" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="870" />
+            <source>recalculating context ...</source>
+            <translation>recalculando contexto ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="872" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="872" />
+            <source>response stopped ...</source>
+            <translation>respuesta detenida ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="875" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="875" />
+            <source>processing ...</source>
+            <translation>procesando ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="876" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="876" />
+            <source>generating response ...</source>
+            <translation>generando respuesta ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="877" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="877" />
+            <source>generating questions ...</source>
+            <translation>generando preguntas ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="943" />
+            <location filename="../qml/ChatView.qml" line="1899" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="943" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1899" />
+            <source>Copy</source>
+            <translation>Copiar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="949" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="949" />
+            <source>Copy Message</source>
+            <translation>Copiar mensaje</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="959" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="959" />
+            <source>Disable markdown</source>
+            <translation>Desactivar markdown</translation>
+        </message>
+        <message>
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="959" />
+            <source>Enable markdown</source>
+            <translation>Activar markdown</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1049" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1049" />
+            <source>Thumbs up</source>
+            <translation>Me gusta</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1050" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1050" />
+            <source>Gives a thumbs up to the response</source>
+            <translation>Da un me gusta a la respuesta</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1083" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1083" />
+            <source>Thumbs down</source>
+            <translation>No me gusta</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1084" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1084" />
+            <source>Opens thumbs down dialog</source>
+            <translation>Abre el diálogo de no me gusta</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1139" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1139" />
+            <source>%1 Sources</source>
+            <translation>%1 Fuentes</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1383" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1383" />
+            <source>Suggested follow-ups</source>
+            <translation>Seguimientos sugeridos</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1659" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1659" />
+            <source>Erase and reset chat session</source>
+            <translation>Borrar y reiniciar sesión de chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1680" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1680" />
+            <source>Copy chat session to clipboard</source>
+            <translation>Copiar sesión de chat al portapapeles</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1706" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1706" />
+            <source>Redo last chat response</source>
+            <translation>Rehacer última respuesta del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1955" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1955" />
+            <source>Stop generating</source>
+            <translation>Detener generación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1956" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1956" />
+            <source>Stop the current response generation</source>
+            <translation>Detener la generación de la respuesta actual</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1771" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1771" />
+            <source>Reloads the model</source>
+            <translation>Recarga el modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="58" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="58" />
+            <source>&lt;h3&gt;Encountered an error loading
+                model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model
+                loading failures can happen for a variety of reasons, but the most common causes
+                include a bad file format, an incomplete or corrupted download, the wrong file type,
+                not enough system RAM or an incompatible model type. Here are some suggestions for
+                resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a
+                compatible format and type&lt;li&gt;Check the model file is complete in the download
+                folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If
+                you&apos;ve sideloaded the model ensure the file is not corrupt by checking
+                md5sum&lt;li&gt;Read more about what models are supported in our &lt;a
+                href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the
+                gui&lt;li&gt;Check out our &lt;a
+                href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
+            <translation>&lt;h3&gt;Se encontró un error al cargar el
+                modelo:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Los
+                fallos de carga de modelos pueden ocurrir por varias razones, pero las causas más
+                comunes incluyen un formato de archivo incorrecto, una descarga incompleta o
+                corrupta, un tipo de archivo equivocado, insuficiente RAM del sistema o un tipo de
+                modelo incompatible. Aquí hay algunas sugerencias para resolver el
+                problema:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Asegúrese de que el archivo del modelo tenga
+                un formato y tipo compatible&lt;li&gt;Verifique que el archivo del modelo esté
+                completo en la carpeta de descargas&lt;li&gt;Puede encontrar la carpeta de descargas
+                en el diálogo de configuración&lt;li&gt;Si ha cargado el modelo manualmente,
+                asegúrese de que el archivo no esté corrupto verificando el md5sum&lt;li&gt;Lea más
+                sobre qué modelos son compatibles en nuestra &lt;a
+                href=&quot;https://docs.gpt4all.io/&quot;&gt;documentación&lt;/a&gt; para la
+                interfaz gráfica&lt;li&gt;Consulte nuestro &lt;a
+                href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canal de Discord&lt;/a&gt; para
+                obtener ayuda</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="377" />
+            <location filename="../qml/ChatView.qml" line="1769" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="377" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1769" />
+            <source>Reload · %1</source>
+            <translation>Recargar · %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="379" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="379" />
+            <source>Loading · %1</source>
+            <translation>Cargando · %1</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="708" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="708" />
+            <source>Load · %1 (default) →</source>
+            <translation>Cargar · %1 (predeterminado) →</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="873" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="873" />
+            <source>retrieving localdocs: %1 ...</source>
+            <translation>recuperando documentos locales: %1 ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="874" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="874" />
+            <source>searching localdocs: %1 ...</source>
+            <translation>buscando en documentos locales: %1 ...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1845" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1845" />
+            <source>Send a message...</source>
+            <translation>Enviar un mensaje...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1845" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1845" />
+            <source>Load a model to continue...</source>
+            <translation>Carga un modelo para continuar...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1848" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1848" />
+            <source>Send messages/prompts to the model</source>
+            <translation>Enviar mensajes/indicaciones al modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1893" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1893" />
+            <source>Cut</source>
+            <translation>Cortar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1905" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1905" />
+            <source>Paste</source>
+            <translation>Pegar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1909" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1909" />
+            <source>Select All</source>
+            <translation>Seleccionar todo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1979" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1979" />
+            <source>Send message</source>
+            <translation>Enviar mensaje</translation>
+        </message>
+        <message>
+            <location filename="../qml/ChatView.qml" line="1980" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
+                line="1980" />
+            <source>Sends the message/prompt contained in textfield to the model</source>
+            <translation>Envía el mensaje/indicación contenido en el campo de texto al modelo</translation>
+        </message>
+    </context>
+    <context>
+        <name>CollectionsDrawer</name>
+        <message>
+            <location filename="../qml/CollectionsDrawer.qml" line="72" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="72" />
+            <source>Warning: searching collections while indexing can return incomplete results</source>
+            <translation>Advertencia: buscar en colecciones mientras se indexan puede devolver
+                resultados incompletos</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../qml/CollectionsDrawer.qml" line="89" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="89" />
+            <source>%n file(s)</source>
+            <translation>
+                <numerusform>%n archivo</numerusform>
+                <numerusform>%n archivos</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../qml/CollectionsDrawer.qml" line="89" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="89" />
+            <source>%n word(s)</source>
+            <translation>
+                <numerusform>%n palabra</numerusform>
+                <numerusform>%n palabras</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../qml/CollectionsDrawer.qml" line="105" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="105" />
+            <source>Updating</source>
+            <translation>Actualizando</translation>
+        </message>
+        <message>
+            <location filename="../qml/CollectionsDrawer.qml" line="130" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="130" />
+            <source>＋ Add Docs</source>
+            <translation>＋ Agregar documentos</translation>
+        </message>
+        <message>
+            <location filename="../qml/CollectionsDrawer.qml" line="139" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
+                line="139" />
+            <source>Select a collection to make it available to the chat model.</source>
+            <translation>Seleccione una colección para hacerla disponible al modelo de chat.</translation>
+        </message>
+    </context>
+    <context>
+        <name>HomeView</name>
+        <message>
+            <location filename="../qml/HomeView.qml" line="49" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="49" />
+            <source>Welcome to GPT4All</source>
+            <translation>Bienvenido a GPT4All</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="56" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="56" />
+            <source>The privacy-first LLM chat application</source>
+            <translation>La aplicación de chat LLM que prioriza la privacidad</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="66" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="66" />
+            <source>Start chatting</source>
+            <translation>Comenzar a chatear</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="81" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="81" />
+            <source>Start Chatting</source>
+            <translation>Iniciar chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="82" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="82" />
+            <source>Chat with any LLM</source>
+            <translation>Chatear con cualquier LLM</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="92" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="92" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="93" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="93" />
+            <source>Chat with your local files</source>
+            <translation>Chatear con tus archivos locales</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="103" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="103" />
+            <source>Find Models</source>
+            <translation>Buscar modelos</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="104" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="104" />
+            <source>Explore and download models</source>
+            <translation>Explorar y descargar modelos</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="190" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="190" />
+            <source>Latest news</source>
+            <translation>Últimas noticias</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="191" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="191" />
+            <source>Latest news from GPT4All</source>
+            <translation>Últimas noticias de GPT4All</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="222" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="222" />
+            <source>Release Notes</source>
+            <translation>Notas de la versión</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="228" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="228" />
+            <source>Documentation</source>
+            <translation>Documentación</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="234" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="234" />
+            <source>Discord</source>
+            <translation>Discord</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="240" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="240" />
+            <source>X (Twitter)</source>
+            <translation>X (Twitter)</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="246" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="246" />
+            <source>Github</source>
+            <translation>Github</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="257" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="257" />
+            <source>GPT4All.io</source>
+            <translation>GPT4All.io</translation>
+        </message>
+        <message>
+            <location filename="../qml/HomeView.qml" line="282" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
+                line="282" />
+            <source>Subscribe to Newsletter</source>
+            <translation>Suscribirse al boletín</translation>
+        </message>
+    </context>
+    <context>
+        <name>LocalDocsSettings</name>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="19" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="19" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="29" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="29" />
+            <source>LocalDocs Settings</source>
+            <translation>Configuración de DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="38" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="38" />
+            <source>Indexing</source>
+            <translation>Indexación</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="51" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="51" />
+            <source>Allowed File Extensions</source>
+            <translation>Extensiones de archivo permitidas</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="52" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="52" />
+            <source>Comma-separated list. LocalDocs will only attempt to process files with these
+                extensions.</source>
+            <translation>Lista separada por comas. DocumentosLocales solo intentará procesar
+                archivos con estas extensiones.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="100" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="100" />
+            <source>Embedding</source>
+            <translation>Incrustación</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="112" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="112" />
+            <source>Use Nomic Embed API</source>
+            <translation>Usar API de incrustación Nomic</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="113" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="113" />
+            <source>Embed documents using the fast Nomic API instead of a private local model.
+                Requires restart.</source>
+            <translation>Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
+                local privado. Requiere reinicio.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="130" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="130" />
+            <source>Nomic API Key</source>
+            <translation>Clave API de Nomic</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="131" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="131" />
+            <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a
+                href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;.
+                Requires restart.</source>
+            <translation>Clave API para usar con Nomic Embed. Obtén una en la &lt;a
+                href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;página de claves API&lt;/a&gt;
+                de Atlas. Requiere reinicio.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="165" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="165" />
+            <source>Embeddings Device</source>
+            <translation>Dispositivo de incrustaciones</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="166" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="166" />
+            <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires
+                restart.</source>
+            <translation>El dispositivo de cómputo utilizado para las incrustaciones.
+                &quot;Auto&quot; usa la CPU. Requiere reinicio.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="202" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="202" />
+            <source>Display</source>
+            <translation>Visualización</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="215" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="215" />
+            <source>Show Sources</source>
+            <translation>Mostrar fuentes</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="216" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="216" />
+            <source>Display the sources used for each response.</source>
+            <translation>Mostrar las fuentes utilizadas para cada respuesta.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="233" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="233" />
+            <source>Advanced</source>
+            <translation>Avanzado</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="249" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="249" />
+            <source>Warning: Advanced usage only.</source>
+            <translation>Advertencia: Solo para uso avanzado.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="250" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="250" />
+            <source>
+                Values too large may cause localdocs failure, extremely slow responses or
+                failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to
+                the model&apos;s context window. More info &lt;a
+                href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
+            <translation>
+                Valores demasiado grandes pueden causar fallos en documentos locales,
+                respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N
+                caracteres x N fragmentos} se agregan a la ventana de contexto del modelo. Más
+                información &lt;a
+                href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="258" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="258" />
+            <source>Document snippet size (characters)</source>
+            <translation>Tamaño del fragmento de documento (caracteres)</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="259" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="259" />
+            <source>Number of characters per document snippet. Larger numbers increase likelihood of
+                factual responses, but also result in slower generation.</source>
+            <translation>Número de caracteres por fragmento de documento. Números más grandes
+                aumentan la probabilidad de respuestas fácticas, pero también resultan en una
+                generación más lenta.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="284" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="284" />
+            <source>Max document snippets per prompt</source>
+            <translation>Máximo de fragmentos de documento por indicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsSettings.qml" line="285" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
+                line="285" />
+            <source>Max best N matches of retrieved document snippets to add to the context for
+                prompt. Larger numbers increase likelihood of factual responses, but also result in
+                slower generation.</source>
+            <translation>Máximo de los mejores N coincidencias de fragmentos de documento
+                recuperados para agregar al contexto de la indicación. Números más grandes aumentan
+                la probabilidad de respuestas fácticas, pero también resultan en una generación más
+                lenta.</translation>
+        </message>
+    </context>
+    <context>
+        <name>LocalDocsView</name>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="52" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="52" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="58" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="58" />
+            <source>Chat with your local files</source>
+            <translation>Chatea con tus archivos locales</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="71" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="71" />
+            <source>＋ Add Collection</source>
+            <translation>＋ Agregar colección</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="86" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="86" />
+            <source>ERROR: The LocalDocs database is not valid.</source>
+            <translation>ERROR: La base de datos de DocumentosLocales no es válida.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="104" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="104" />
+            <source>No Collections Installed</source>
+            <translation>No hay colecciones instaladas</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="113" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="113" />
+            <source>Install a collection of local documents to get started using this feature</source>
+            <translation>Instala una colección de documentos locales para comenzar a usar esta
+                función</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="124" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="124" />
+            <source>＋ Add Doc Collection</source>
+            <translation>＋ Agregar colección de documentos</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="129" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="129" />
+            <source>Shows the add model view</source>
+            <translation>Muestra la vista de agregar modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="226" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="226" />
+            <source>Indexing progressBar</source>
+            <translation>Barra de progreso de indexación</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="227" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="227" />
+            <source>Shows the progress made in the indexing</source>
+            <translation>Muestra el progreso realizado en la indexación</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="252" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="252" />
+            <source>ERROR</source>
+            <translation>ERROR</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="256" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="256" />
+            <source>INDEXING</source>
+            <translation>INDEXANDO</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="260" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="260" />
+            <source>EMBEDDING</source>
+            <translation>INCRUSTANDO</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="263" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="263" />
+            <source>REQUIRES UPDATE</source>
+            <translation>REQUIERE ACTUALIZACIÓN</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="266" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="266" />
+            <source>READY</source>
+            <translation>LISTO</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="268" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="268" />
+            <source>INSTALLING</source>
+            <translation>INSTALANDO</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="295" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="295" />
+            <source>Indexing in progress</source>
+            <translation>Indexación en progreso</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="298" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="298" />
+            <source>Embedding in progress</source>
+            <translation>Incrustación en progreso</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="301" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="301" />
+            <source>This collection requires an update after version change</source>
+            <translation>Esta colección requiere una actualización después del cambio de versión</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="304" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="304" />
+            <source>Automatically reindexes upon changes to the folder</source>
+            <translation>Reindexación automática al cambiar la carpeta</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="306" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="306" />
+            <source>Installation in progress</source>
+            <translation>Instalación en progreso</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="320" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="320" />
+            <source>%</source>
+            <translation>%</translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../qml/LocalDocsView.qml" line="332" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="332" />
+            <source>%n file(s)</source>
+            <translation>
+                <numerusform>%n archivo</numerusform>
+                <numerusform>%n archivos</numerusform>
+            </translation>
+        </message>
+        <message numerus="yes">
+            <location filename="../qml/LocalDocsView.qml" line="332" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="332" />
+            <source>%n word(s)</source>
+            <translation>
+                <numerusform>%n palabra</numerusform>
+                <numerusform>%n palabras</numerusform>
+            </translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="403" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="403" />
+            <source>Remove</source>
+            <translation>Eliminar</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="415" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="415" />
+            <source>Rebuild</source>
+            <translation>Reconstruir</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="418" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="418" />
+            <source>Reindex this folder from scratch. This is slow and usually not needed.</source>
+            <translation>Reindexar esta carpeta desde cero. Esto es lento y generalmente no es
+                necesario.</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="425" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="425" />
+            <source>Update</source>
+            <translation>Actualizar</translation>
+        </message>
+        <message>
+            <location filename="../qml/LocalDocsView.qml" line="428" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
+                line="428" />
+            <source>Update the collection to the new version. This is a slow operation.</source>
+            <translation>Actualizar la colección a la nueva versión. Esta es una operación lenta.</translation>
+        </message>
+    </context>
+    <context>
+        <name>ModelList</name>
+        <message>
+            <location filename="../modellist.cpp" line="1537" />
+            <source>
+                &lt;ul&gt;&lt;li&gt;Requires personal OpenAI API
+                key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
+                OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
+                disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
+                OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
+                href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
+            <translation>
+                &lt;ul&gt;&lt;li&gt;Requiere clave API personal de
+                OpenAI.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a
+                OpenAI!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el
+                disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con
+                OpenAI&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a
+                href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aquí.&lt;/a&gt;&lt;/li&gt;</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1556" />
+            <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
+                %1</source>
+            <translation>&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
+                OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1584" />
+            <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt; %1 %2</source>
+            <translation>&lt;strong&gt;Modelo ChatGPT GPT-4 de OpenAI&lt;/strong&gt;&lt;br&gt; %1 %2</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1615" />
+            <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt; %1</source>
+            <translation>&lt;strong&gt;Modelo Mistral Tiny&lt;/strong&gt;&lt;br&gt; %1</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1640" />
+            <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt; %1</source>
+            <translation>&lt;strong&gt;Modelo Mistral Small&lt;/strong&gt;&lt;br&gt; %1</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1666" />
+            <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt; %1</source>
+            <translation>&lt;strong&gt;Modelo Mistral Medium&lt;/strong&gt;&lt;br&gt; %1</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1569" />
+            <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does
+                not guarantee API key access. Contact OpenAI for more info.</source>
+            <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Aunque pague a OpenAI por ChatGPT-4, esto no
+                garantiza el acceso a la clave API. Contacte a OpenAI para más información.</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="1596" />
+            <source>
+                &lt;ul&gt;&lt;li&gt;Requires personal Mistral API
+                key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
+                Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
+                disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
+                Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
+                href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
+            <translation>
+                &lt;ul&gt;&lt;li&gt;Requiere clave API personal de
+                Mistral.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a
+                Mistral!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el
+                disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con
+                Mistral&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a
+                href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aquí&lt;/a&gt;.&lt;/li&gt;</translation>
+        </message>
+        <message>
+            <location filename="../modellist.cpp" line="2081" />
+            <source>&lt;strong&gt;Created by
+                %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model
+                has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found
+                &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
+            <translation>&lt;strong&gt;Creado por
+                %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicado el %2.&lt;li&gt;Este
+                modelo tiene %3 me gusta.&lt;li&gt;Este modelo tiene %4 descargas.&lt;li&gt;Puede
+                encontrar más información &lt;a
+                href=&quot;https://huggingface.co/%5&quot;&gt;aquí.&lt;/a&gt;&lt;/ul&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>ModelSettings</name>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="14" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="14" />
+            <source>Model</source>
+            <translation>Modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="33" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="33" />
+            <source>Model Settings</source>
+            <translation>Configuración del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="83" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="83" />
+            <source>Clone</source>
+            <translation>Clonar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="93" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="93" />
+            <source>Remove</source>
+            <translation>Eliminar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="107" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="107" />
+            <source>Name</source>
+            <translation>Nombre</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="140" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="140" />
+            <source>Model File</source>
+            <translation>Archivo del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="158" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="158" />
+            <source>System Prompt</source>
+            <translation>Indicación del sistema</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="159" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="159" />
+            <source>Prefixed at the beginning of every conversation. Must contain the appropriate
+                framing tokens.</source>
+            <translation>Prefijado al inicio de cada conversación. Debe contener los tokens de
+                encuadre apropiados.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="205" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="205" />
+            <source>Prompt Template</source>
+            <translation>Plantilla de indicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="206" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="206" />
+            <source>The template that wraps every prompt.</source>
+            <translation>La plantilla que envuelve cada indicación.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="210" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="210" />
+            <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s
+                input.</source>
+            <translation>Debe contener la cadena &quot;%1&quot; para ser reemplazada con la entrada
+                del usuario.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="255" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="255" />
+            <source>Chat Name Prompt</source>
+            <translation>Indicación para el nombre del chat</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="256" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="256" />
+            <source>Prompt used to automatically generate chat names.</source>
+            <translation>Indicación utilizada para generar automáticamente nombres de chat.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="283" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="283" />
+            <source>Suggested FollowUp Prompt</source>
+            <translation>Indicación de seguimiento sugerida</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="284" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="284" />
+            <source>Prompt used to generate suggested follow-up questions.</source>
+            <translation>Indicación utilizada para generar preguntas de seguimiento sugeridas.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="322" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="322" />
+            <source>Context Length</source>
+            <translation>Longitud del contexto</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="323" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="323" />
+            <source>Number of input and output tokens the model sees.</source>
+            <translation>Número de tokens de entrada y salida que el modelo ve.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="344" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="344" />
+            <source>Maximum combined prompt/response tokens before information is lost.
+                Using more context than the model was trained on will yield poor results.
+                NOTE: Does not take effect until you reload the model.</source>
+            <translation>Máximo de tokens combinados de indicación/respuesta antes de que se pierda
+                información.
+                Usar más contexto del que se utilizó para entrenar el modelo producirá resultados
+                pobres.
+                NOTA: No tiene efecto hasta que recargues el modelo.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="382" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="382" />
+            <source>Temperature</source>
+            <translation>Temperatura</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="383" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="383" />
+            <source>Randomness of model output. Higher -&gt; more variation.</source>
+            <translation>Aleatoriedad de la salida del modelo. Mayor -&gt; más variación.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="394" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="394" />
+            <source>Temperature increases the chances of choosing less likely tokens.
+                NOTE: Higher temperature gives more creative but less predictable outputs.</source>
+            <translation>La temperatura aumenta las probabilidades de elegir tokens menos probables.
+                NOTA: Una temperatura más alta da resultados más creativos pero menos predecibles.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="428" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="428" />
+            <source>Top-P</source>
+            <translation>Top-P</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="429" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="429" />
+            <source>Nucleus Sampling factor. Lower -&gt; more predicatable.</source>
+            <translation>Factor de muestreo de núcleo. Menor -&gt; más predecible.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="439" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="439" />
+            <source>Only the most likely tokens up to a total probability of top_p can be chosen.
+                NOTE: Prevents choosing highly unlikely tokens.</source>
+            <translation>Solo se pueden elegir los tokens más probables hasta una probabilidad total
+                de top_p.
+                NOTA: Evita elegir tokens altamente improbables.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="473" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="473" />
+            <source>Min-P</source>
+            <translation>Min-P</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="474" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="474" />
+            <source>Minimum token probability. Higher -&gt; more predictable.</source>
+            <translation>Probabilidad mínima del token. Mayor -&gt; más predecible.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="484" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="484" />
+            <source>Sets the minimum relative probability for a token to be considered.</source>
+            <translation>Establece la probabilidad relativa mínima para que un token sea
+                considerado.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="520" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="520" />
+            <source>Top-K</source>
+            <translation>Top-K</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="521" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="521" />
+            <source>Size of selection pool for tokens.</source>
+            <translation>Tamaño del grupo de selección para tokens.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="532" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="532" />
+            <source>Only the top K most likely tokens will be chosen from.</source>
+            <translation>Solo se elegirán los K tokens más probables.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="567" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="567" />
+            <source>Max Length</source>
+            <translation>Longitud máxima</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="568" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="568" />
+            <source>Maximum response length, in tokens.</source>
+            <translation>Longitud máxima de respuesta, en tokens.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="613" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="613" />
+            <source>Prompt Batch Size</source>
+            <translation>Tamaño del lote de indicaciones</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="614" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="614" />
+            <source>The batch size used for prompt processing.</source>
+            <translation>El tamaño del lote utilizado para el procesamiento de indicaciones.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="625" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="625" />
+            <source>Amount of prompt tokens to process at once.
+                NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
+            <translation>Cantidad de tokens de indicación para procesar a la vez.
+                NOTA: Valores más altos pueden acelerar la lectura de indicaciones pero usarán más
+                RAM.</translation>
+        </message>
+        <message>
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="660" />
+            <source>Repeat Penalty</source>
+            <translation>Penalización por repetición</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="661" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="661" />
+            <source>Repetition penalty factor. Set to 1 to disable.</source>
+            <translation>Factor de penalización por repetición. Establecer a 1 para desactivar.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="705" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="705" />
+            <source>Repeat Penalty Tokens</source>
+            <translation>Tokens de penalización por repetición</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="706" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="706" />
+            <source>Number of previous tokens used for penalty.</source>
+            <translation>Número de tokens anteriores utilizados para la penalización.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="751" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="751" />
+            <source>GPU Layers</source>
+            <translation>Capas de GPU</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="752" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="752" />
+            <source>Number of model layers to load into VRAM.</source>
+            <translation>Número de capas del modelo a cargar en la VRAM.</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelSettings.qml" line="763" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
+                line="763" />
+            <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of
+                VRAM while loading this model.
+                Lower values increase CPU load and RAM usage, and make inference slower.
+                NOTE: Does not take effect until you reload the model.</source>
+            <translation>Cuántas capas del modelo cargar en la VRAM. Disminuye esto si GPT4All se
+                queda sin VRAM al cargar este modelo.
+                Valores más bajos aumentan la carga de CPU y el uso de RAM, y hacen la inferencia
+                más lenta.
+                NOTA: No tiene efecto hasta que recargues el modelo.</translation>
+        </message>
+    </context>
+    <context>
+        <name>ModelsView</name>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="36" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="36" />
+            <source>No Models Installed</source>
+            <translation>No hay modelos instalados</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="45" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="45" />
+            <source>Install a model to get started using GPT4All</source>
+            <translation>Instala un modelo para empezar a usar GPT4All</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="56" />
+            <location filename="../qml/ModelsView.qml" line="98" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="56" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="98" />
+            <source>＋ Add Model</source>
+            <translation>＋ Agregar modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="61" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="61" />
+            <source>Shows the add model view</source>
+            <translation>Muestra la vista de agregar modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="79" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="79" />
+            <source>Installed Models</source>
+            <translation>Modelos instalados</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="85" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="85" />
+            <source>Locally installed chat models</source>
+            <translation>Modelos de chat instalados localmente</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="143" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="143" />
+            <source>Model file</source>
+            <translation>Archivo del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="144" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="144" />
+            <source>Model file to be downloaded</source>
+            <translation>Archivo del modelo a descargar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="166" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="166" />
+            <source>Description</source>
+            <translation>Descripción</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="167" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="167" />
+            <source>File description</source>
+            <translation>Descripción del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="192" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="192" />
+            <source>Cancel</source>
+            <translation>Cancelar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="192" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="192" />
+            <source>Resume</source>
+            <translation>Reanudar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="200" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="200" />
+            <source>Stop/restart/start the download</source>
+            <translation>Detener/reiniciar/iniciar la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="212" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="212" />
+            <source>Remove</source>
+            <translation>Eliminar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="219" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="219" />
+            <source>Remove model from filesystem</source>
+            <translation>Eliminar modelo del sistema de archivos</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="233" />
+            <location filename="../qml/ModelsView.qml" line="242" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="233" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="242" />
+            <source>Install</source>
+            <translation>Instalar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="243" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="243" />
+            <source>Install online model</source>
+            <translation>Instalar modelo en línea</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="253" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="253" />
+            <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+                href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+            <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+                href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="272" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="272" />
+            <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
+                hardware. Model requires more memory (%1 GB) than your system has available
+                (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+            <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
+                para su hardware. El modelo requiere más memoria (%1 GB) de la que su sistema tiene
+                disponible (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="424" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="424" />
+            <source>%1 GB</source>
+            <translation>%1 GB</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="424" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="424" />
+            <source>?</source>
+            <translation>?</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="259" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="259" />
+            <source>Describes an error that occurred when downloading</source>
+            <translation>Describe un error que ocurrió durante la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="278" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="278" />
+            <source>Error for incompatible hardware</source>
+            <translation>Error por hardware incompatible</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="316" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="316" />
+            <source>Download progressBar</source>
+            <translation>Barra de progreso de descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="317" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="317" />
+            <source>Shows the progress made in the download</source>
+            <translation>Muestra el progreso realizado en la descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="327" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="327" />
+            <source>Download speed</source>
+            <translation>Velocidad de descarga</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="328" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="328" />
+            <source>Download speed in bytes/kilobytes/megabytes per second</source>
+            <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="345" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="345" />
+            <source>Calculating...</source>
+            <translation>Calculando...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="349" />
+            <location filename="../qml/ModelsView.qml" line="378" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="349" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="378" />
+            <source>Whether the file hash is being calculated</source>
+            <translation>Si se está calculando el hash del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="356" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="356" />
+            <source>Busy indicator</source>
+            <translation>Indicador de ocupado</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="357" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="357" />
+            <source>Displayed when the file hash is being calculated</source>
+            <translation>Se muestra cuando se está calculando el hash del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="375" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="375" />
+            <source>enter $API_KEY</source>
+            <translation>ingrese $API_KEY</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="397" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="397" />
+            <source>File size</source>
+            <translation>Tamaño del archivo</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="419" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="419" />
+            <source>RAM required</source>
+            <translation>RAM requerida</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="441" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="441" />
+            <source>Parameters</source>
+            <translation>Parámetros</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="463" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="463" />
+            <source>Quant</source>
+            <translation>Cuantificación</translation>
+        </message>
+        <message>
+            <location filename="../qml/ModelsView.qml" line="485" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
+                line="485" />
+            <source>Type</source>
+            <translation>Tipo</translation>
+        </message>
+    </context>
+    <context>
+        <name>MyFancyLink</name>
+        <message>
+            <location filename="../qml/MyFancyLink.qml" line="42" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml"
+                line="42" />
+            <source>Fancy link</source>
+            <translation>Enlace elegante</translation>
+        </message>
+        <message>
+            <location filename="../qml/MyFancyLink.qml" line="43" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml"
+                line="43" />
+            <source>A stylized link</source>
+            <translation>Un enlace estilizado</translation>
+        </message>
+    </context>
+    <context>
+        <name>MySettingsStack</name>
+        <message>
+            <location filename="../qml/MySettingsStack.qml" line="66" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsStack.qml"
+                line="66" />
+            <source>Please choose a directory</source>
+            <translation>Por favor, elija un directorio</translation>
+        </message>
+    </context>
+    <context>
+        <name>MySettingsTab</name>
+        <message>
+            <location filename="../qml/MySettingsTab.qml" line="62" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml"
+                line="62" />
+            <source>Restore Defaults</source>
+            <translation>Restaurar valores predeterminados</translation>
+        </message>
+        <message>
+            <location filename="../qml/MySettingsTab.qml" line="66" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml"
+                line="66" />
+            <source>Restores settings dialog to a default state</source>
+            <translation>Restaura el diálogo de configuración a su estado predeterminado</translation>
+        </message>
+    </context>
+    <context>
+        <name>NetworkDialog</name>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="39" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="39" />
+            <source>Contribute data to the GPT4All Opensource Datalake.</source>
+            <translation>Contribuir datos al Datalake de código abierto de GPT4All.</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="55" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="55" />
+            <source>By enabling this feature, you will be able to participate in the democratic
+                process of training a large language model by contributing data for future model
+                improvements.
+
+                When a GPT4All model responds to you and you have opted-in, your conversation will
+                be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its
+                response. If you dislike a response, you can suggest an alternative response. This
+                data will be collected and aggregated in the GPT4All Datalake.
+
+                NOTE: By turning on this feature, you will be sending your data to the GPT4All Open
+                Source Datalake. You should have no expectation of chat privacy when this feature is
+                enabled. You should; however, have an expectation of an optional attribution if you
+                wish. Your chat data will be openly available for anyone to download and will be
+                used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
+                attribution information attached to your data and you will be credited as a
+                contributor to any GPT4All model release that uses your data!</source>
+            <translation>Al habilitar esta función, podrá participar en el proceso democrático de
+                entrenamiento de un modelo de lenguaje grande contribuyendo con datos para futuras
+                mejoras del modelo.
+
+                Cuando un modelo GPT4All le responda y usted haya aceptado, su conversación se
+                enviará al Datalake de código abierto de GPT4All. Además, puede dar me gusta/no me
+                gusta a su respuesta. Si no le gusta una respuesta, puede sugerir una alternativa.
+                Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
+
+                NOTA: Al activar esta función, enviará sus datos al Datalake de código abierto de
+                GPT4All. No debe esperar privacidad en el chat cuando esta función esté habilitada.
+                Sin embargo, puede esperar una atribución opcional si lo desea. Sus datos de chat
+                estarán disponibles abiertamente para que cualquiera los descargue y serán
+                utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará
+                toda la información de atribución adjunta a sus datos y se le acreditará como
+                contribuyente en cualquier lanzamiento de modelo GPT4All que utilice sus datos.</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="63" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="63" />
+            <source>Terms for opt-in</source>
+            <translation>Términos para optar por participar</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="64" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="64" />
+            <source>Describes what will happen when you opt-in</source>
+            <translation>Describe lo que sucederá cuando opte por participar</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="72" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="72" />
+            <source>Please provide a name for attribution (optional)</source>
+            <translation>Por favor, proporcione un nombre para la atribución (opcional)</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="74" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="74" />
+            <source>Attribution (optional)</source>
+            <translation>Atribución (opcional)</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="75" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="75" />
+            <source>Provide attribution</source>
+            <translation>Proporcionar atribución</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="88" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="88" />
+            <source>Enable</source>
+            <translation>Habilitar</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="89" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="89" />
+            <source>Enable opt-in</source>
+            <translation>Habilitar participación</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="93" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="93" />
+            <source>Cancel</source>
+            <translation>Cancelar</translation>
+        </message>
+        <message>
+            <location filename="../qml/NetworkDialog.qml" line="94" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
+                line="94" />
+            <source>Cancel opt-in</source>
+            <translation>Cancelar participación</translation>
+        </message>
+    </context>
+    <context>
+        <name>NewVersionDialog</name>
+        <message>
+            <location filename="../qml/NewVersionDialog.qml" line="34" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
+                line="34" />
+            <source>New version is available</source>
+            <translation>Nueva versión disponible</translation>
+        </message>
+        <message>
+            <location filename="../qml/NewVersionDialog.qml" line="46" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
+                line="46" />
+            <source>Update</source>
+            <translation>Actualizar</translation>
+        </message>
+        <message>
+            <location filename="../qml/NewVersionDialog.qml" line="48" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
+                line="48" />
+            <source>Update to new version</source>
+            <translation>Actualizar a nueva versión</translation>
+        </message>
+    </context>
+    <context>
+        <name>PopupDialog</name>
+        <message>
+            <location filename="../qml/PopupDialog.qml" line="38" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
+                line="38" />
+            <source>Reveals a shortlived help balloon</source>
+            <translation>Muestra un globo de ayuda de corta duración</translation>
+        </message>
+        <message>
+            <location filename="../qml/PopupDialog.qml" line="48" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
+                line="48" />
+            <source>Busy indicator</source>
+            <translation>Indicador de ocupado</translation>
+        </message>
+        <message>
+            <location filename="../qml/PopupDialog.qml" line="49" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
+                line="49" />
+            <source>Displayed when the popup is showing busy</source>
+            <translation>Se muestra cuando la ventana emergente está ocupada</translation>
+        </message>
+    </context>
+    <context>
+        <name>SettingsView</name>
+        <message>
+            <location filename="../qml/SettingsView.qml" line="22" />
+            <location filename="../qml/SettingsView.qml" line="61" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="22" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="61" />
+            <source>Settings</source>
+            <translation>Configuración</translation>
+        </message>
+        <message>
+            <location filename="../qml/SettingsView.qml" line="23" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="23" />
+            <source>Contains various application settings</source>
+            <translation>Contiene varias configuraciones de la aplicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/SettingsView.qml" line="29" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="29" />
+            <source>Application</source>
+            <translation>Aplicación</translation>
+        </message>
+        <message>
+            <location filename="../qml/SettingsView.qml" line="32" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="32" />
+            <source>Model</source>
+            <translation>Modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/SettingsView.qml" line="35" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
+                line="35" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+    </context>
+    <context>
+        <name>StartupDialog</name>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="50" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="50" />
+            <source>Welcome!</source>
+            <translation>¡Bienvenido!</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="67" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="67" />
+            <source>### Release notes
+                %1### Contributors
+                %2</source>
+            <translation>### Notas de la versión
+                %1### Contribuidores
+                %2</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="71" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="71" />
+            <source>Release notes</source>
+            <translation>Notas de la versión</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="72" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="72" />
+            <source>Release notes for this version</source>
+            <translation>Notas de la versión para esta versión</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="87" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="87" />
+            <source>### Opt-ins for anonymous usage analytics and datalake
+                By enabling these features, you will be able to participate in the democratic
+                process of training a
+                large language model by contributing data for future model improvements.
+
+                When a GPT4All model responds to you and you have opted-in, your conversation will
+                be sent to the GPT4All
+                Open Source Datalake. Additionally, you can like/dislike its response. If you
+                dislike a response, you
+                can suggest an alternative response. This data will be collected and aggregated in
+                the GPT4All Datalake.
+
+                NOTE: By turning on this feature, you will be sending your data to the GPT4All Open
+                Source Datalake.
+                You should have no expectation of chat privacy when this feature is enabled. You
+                should; however, have
+                an expectation of an optional attribution if you wish. Your chat data will be openly
+                available for anyone
+                to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI
+                will retain all
+                attribution information attached to your data and you will be credited as a
+                contributor to any GPT4All
+                model release that uses your data!</source>
+            <translation>### Aceptación para análisis de uso anónimo y datalake
+                Al habilitar estas funciones, podrá participar en el proceso democrático de entrenar
+                un
+                modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo.
+                Cuando un modelo GPT4All le responda y usted haya aceptado, su conversación se
+                enviará al
+                Datalake de código abierto de GPT4All. Además, puede dar me gusta/no me gusta a su
+                respuesta. Si no le gusta una respuesta,
+                puede sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake
+                de GPT4All.
+
+                NOTA: Al activar esta función, enviará sus datos al Datalake de código abierto de
+                GPT4All.
+                No debe esperar privacidad en el chat cuando esta función esté habilitada. Sin
+                embargo, puede
+                esperar una atribución opcional si lo desea. Sus datos de chat estarán disponibles
+                abiertamente para que cualquiera
+                los descargue y serán utilizados por Nomic AI para mejorar futuros modelos de
+                GPT4All. Nomic AI conservará toda la
+                información de atribución adjunta a sus datos y se le acreditará como contribuyente
+                en cualquier lanzamiento de modelo GPT4All
+                que utilice sus datos.</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="106" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="106" />
+            <source>Terms for opt-in</source>
+            <translation>Términos para aceptar</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="107" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="107" />
+            <source>Describes what will happen when you opt-in</source>
+            <translation>Describe lo que sucederá cuando acepte</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="124" />
+            <location filename="../qml/StartupDialog.qml" line="150" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="124" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="150" />
+            <source>Opt-in for anonymous usage statistics</source>
+            <translation>Aceptar estadísticas de uso anónimas</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="147" />
+            <location filename="../qml/StartupDialog.qml" line="262" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="147" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="262" />
+            <source>Yes</source>
+            <translation>Sí</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="151" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="151" />
+            <source>Allow opt-in for anonymous usage statistics</source>
+            <translation>Permitir aceptación de estadísticas de uso anónimas</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="189" />
+            <location filename="../qml/StartupDialog.qml" line="304" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="189" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="304" />
+            <source>No</source>
+            <translation>No</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="192" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="192" />
+            <source>Opt-out for anonymous usage statistics</source>
+            <translation>Rechazar estadísticas de uso anónimas</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="193" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="193" />
+            <source>Allow opt-out for anonymous usage statistics</source>
+            <translation>Permitir rechazo de estadísticas de uso anónimas</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="238" />
+            <location filename="../qml/StartupDialog.qml" line="265" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="238" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="265" />
+            <source>Opt-in for network</source>
+            <translation>Aceptar para la red</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="239" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="239" />
+            <source>Allow opt-in for network</source>
+            <translation>Permitir aceptación para la red</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="266" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="266" />
+            <source>Allow opt-in anonymous sharing of chats to the GPT4All Datalake</source>
+            <translation>Permitir compartir anónimamente los chats con el Datalake de GPT4All</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="307" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="307" />
+            <source>Opt-out for network</source>
+            <translation>Rechazar para la red</translation>
+        </message>
+        <message>
+            <location filename="../qml/StartupDialog.qml" line="308" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
+                line="308" />
+            <source>Allow opt-out anonymous sharing of chats to the GPT4All Datalake</source>
+            <translation>Permitir rechazar el compartir anónimo de chats con el Datalake de GPT4All</translation>
+        </message>
+    </context>
+    <context>
+        <name>SwitchModelDialog</name>
+        <message>
+            <location filename="../qml/SwitchModelDialog.qml" line="22" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
+                line="22" />
+            <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
+                conversation. Do you wish to continue?</source>
+            <translation>&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
+                actual. ¿Desea continuar?</translation>
+        </message>
+        <message>
+            <location filename="../qml/SwitchModelDialog.qml" line="33" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
+                line="33" />
+            <source>Continue</source>
+            <translation>Continuar</translation>
+        </message>
+        <message>
+            <location filename="../qml/SwitchModelDialog.qml" line="34" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
+                line="34" />
+            <source>Continue with model loading</source>
+            <translation>Continuar con la carga del modelo</translation>
+        </message>
+        <message>
+            <location filename="../qml/SwitchModelDialog.qml" line="38" />
+            <location filename="../qml/SwitchModelDialog.qml" line="39" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
+                line="38" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
+                line="39" />
+            <source>Cancel</source>
+            <translation>Cancelar</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThumbsDownDialog</name>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="39" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="39" />
+            <source>Please edit the text below to provide a better response. (optional)</source>
+            <translation>Por favor, edite el texto a continuación para proporcionar una mejor
+                respuesta. (opcional)</translation>
+        </message>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="54" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="54" />
+            <source>Please provide a better response...</source>
+            <translation>Por favor, proporcione una mejor respuesta...</translation>
+        </message>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="64" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="64" />
+            <source>Submit</source>
+            <translation>Enviar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="65" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="65" />
+            <source>Submits the user&apos;s response</source>
+            <translation>Envía la respuesta del usuario</translation>
+        </message>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="69" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="69" />
+            <source>Cancel</source>
+            <translation>Cancelar</translation>
+        </message>
+        <message>
+            <location filename="../qml/ThumbsDownDialog.qml" line="70" />
+            <location
+                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
+                line="70" />
+            <source>Closes the response dialog</source>
+            <translation>Cierra el diálogo de respuesta</translation>
+        </message>
+    </context>
+    <context>
+        <name>main</name>
+        <message>
+            <location filename="../main.qml" line="111" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="111" />
+            <source>
+                &lt;h3&gt;Encountered an error starting
+                up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware
+                detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet
+                the minimal requirements to run this program. In particular, it does not support AVX
+                intrinsics which this program requires to successfully run a modern large language
+                model. The only solution at this time is to upgrade your hardware to a more modern
+                CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a
+                href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+            <translation>
+                &lt;h3&gt;Se encontró un error al
+                iniciar:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatible
+                detectado.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Desafortunadamente, su CPU no cumple
+                con los requisitos mínimos para ejecutar este programa. En particular, no soporta
+                las instrucciones AVX que este programa requiere para ejecutar con éxito un modelo
+                de lenguaje grande moderno. La única solución en este momento es actualizar su
+                hardware a una CPU más moderna.&lt;br&gt;&lt;br&gt;Vea aquí para más información:
+                &lt;a
+                href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="23" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="23" />
+            <source>GPT4All v%1</source>
+            <translation>GPT4All v%1</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="127" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="127" />
+            <source>&lt;h3&gt;Encountered an error starting
+                up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings
+                file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the
+                program from accessing the settings file. This could be caused by incorrect
+                permissions in the local app config directory where the settings file is located.
+                Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord
+                channel&lt;/a&gt; for help.</source>
+            <translation>&lt;h3&gt;Se encontró un error al
+                iniciar:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;No se puede acceder al archivo de
+                configuración.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Desafortunadamente, algo está
+                impidiendo que el programa acceda al archivo de configuración. Esto podría ser
+                causado por permisos incorrectos en el directorio de configuración local de la
+                aplicación donde se encuentra el archivo de configuración. Consulte nuestro &lt;a
+                href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canal de Discord&lt;/a&gt; para
+                obtener ayuda.</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="155" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="155" />
+            <source>Connection to datalake failed.</source>
+            <translation>La conexión al datalake falló.</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="166" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="166" />
+            <source>Saving chats.</source>
+            <translation>Guardando chats.</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="177" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="177" />
+            <source>Network dialog</source>
+            <translation>Diálogo de red</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="178" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="178" />
+            <source>opt-in to share feedback/conversations</source>
+            <translation>optar por compartir comentarios/conversaciones</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="231" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="231" />
+            <source>Home view</source>
+            <translation>Vista de inicio</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="232" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="232" />
+            <source>Home view of application</source>
+            <translation>Vista de inicio de la aplicación</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="240" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="240" />
+            <source>Home</source>
+            <translation>Inicio</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="266" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="266" />
+            <source>Chat view</source>
+            <translation>Vista de chat</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="267" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="267" />
+            <source>Chat view to interact with models</source>
+            <translation>Vista de chat para interactuar con modelos</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="275" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="275" />
+            <source>Chats</source>
+            <translation>Chats</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="300" />
+            <location filename="../main.qml" line="309" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="300" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="309" />
+            <source>Models</source>
+            <translation>Modelos</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="301" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="301" />
+            <source>Models view for installed models</source>
+            <translation>Vista de modelos para modelos instalados</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="334" />
+            <location filename="../main.qml" line="343" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="334" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="343" />
+            <source>LocalDocs</source>
+            <translation>DocumentosLocales</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="335" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="335" />
+            <source>LocalDocs view to configure and use local docs</source>
+            <translation>Vista de DocumentosLocales para configurar y usar documentos locales</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="368" />
+            <location filename="../main.qml" line="377" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="368" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="377" />
+            <source>Settings</source>
+            <translation>Configuración</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="369" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="369" />
+            <source>Settings view for application configuration</source>
+            <translation>Vista de configuración para la configuración de la aplicación</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="422" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="422" />
+            <source>The datalake is enabled</source>
+            <translation>El datalake está habilitado</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="424" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="424" />
+            <source>Using a network model</source>
+            <translation>Usando un modelo de red</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="426" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="426" />
+            <source>Server mode is enabled</source>
+            <translation>El modo servidor está habilitado</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="640" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="640" />
+            <source>Installed models</source>
+            <translation>Modelos instalados</translation>
+        </message>
+        <message>
+            <location filename="../main.qml" line="641" />
+            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
+                line="641" />
+            <source>View of installed models</source>
+            <translation>Vista de modelos instalados</translation>
+        </message>
+    </context>
+</TS>


### PR DESCRIPTION
## Describe your changes
Take 2: Added the signed off by message to clean commit as requested.

Added Spanish language per [the instructions](https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-chat/contributing_translations.md). 

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [X] I have performed a self-review of my code.

## Demo
Behold, The Linguist!
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/9f813cbe-c185-4e57-90d2-f9f0a17742eb">
### Steps to Reproduce
You can open this file in Qt Linguist to verify the file will work. Linguist should auto detect it as the following:
Language: Spanish (Spain)
Country/Region: Mexico

## Notes
This initial effort was aimed at Mexican (LATAM) Spanish as that is what I know, but it can also serve as a jumping off point for other Spanish-speaking countries as needed. My Spanish is also not perfect, but it will be easier for people correct any mistakes I may have made from this point forward.