### PR TITLE
Feature: dynamic changes of language and locale at runtime issue #2644

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(GPT4ALL_TRANSLATIONS OFF "Build with translations")
 option(GPT4ALL_LOCALHOST OFF "Build installer for localhost repo")
 option(GPT4ALL_OFFLINE_INSTALLER "Build an offline installer" OFF)
 option(GPT4ALL_SIGN_INSTALL "Sign installed binaries and installers (requires signing identities)" OFF)
@@ -226,9 +227,14 @@ qt_add_qml_module(chat
       icons/you.svg
 )
 
-qt_add_translations(chat
-    TS_FILES ${CMAKE_SOURCE_DIR}/translations/gpt4all_en.ts
-)
+if (GPT4ALL_TRANSLATIONS)
+    qt_add_translations(chat
+        TS_FILES
+        ${CMAKE_SOURCE_DIR}/translations/gpt4all_en.ts
+        ${CMAKE_SOURCE_DIR}/translations/gpt4all_es_MX.ts
+        ${CMAKE_SOURCE_DIR}/translations/gpt4all_zh_CN.ts
+    )
+endif()
 
 set_target_properties(chat PROPERTIES
     WIN32_EXECUTABLE TRUE

--- a/gpt4all-chat/main.cpp
+++ b/gpt4all-chat/main.cpp
@@ -33,12 +33,17 @@ int main(int argc, char *argv[])
 
     QGuiApplication app(argc, argv);
 
-    QTranslator translator;
-    bool success = translator.load(":/i18n/gpt4all_en.qm");
-    Q_ASSERT(success);
-    app.installTranslator(&translator);
+    // Set the local and language translation before the qml engine has even been started. This will
+    // use the default system locale unless the user has explicitly set it to use a different one.
+    MySettings::globalInstance()->setLanguageAndLocale();
 
     QQmlApplicationEngine engine;
+
+    // Add a connection here from MySettings::languageAndLocaleChanged signal to a lambda slot where I can call
+    // engine.uiLanguage property
+    QObject::connect(MySettings::globalInstance(), &MySettings::languageAndLocaleChanged, [&engine]() {
+        engine.setUiLanguage(MySettings::globalInstance()->languageAndLocale());
+    });
 
     QString llmodelSearchPaths = QCoreApplication::applicationDirPath();
     const QString libDir = QCoreApplication::applicationDirPath() + "/../lib/";

--- a/gpt4all-chat/mysettings.h
+++ b/gpt4all-chat/mysettings.h
@@ -33,8 +33,11 @@ class MySettings : public QObject
     Q_PROPERTY(bool serverChat READ serverChat WRITE setServerChat NOTIFY serverChatChanged)
     Q_PROPERTY(QString modelPath READ modelPath WRITE setModelPath NOTIFY modelPathChanged)
     Q_PROPERTY(QString userDefaultModel READ userDefaultModel WRITE setUserDefaultModel NOTIFY userDefaultModelChanged)
+    // FIXME: This should be changed to an enum to allow translations to work
     Q_PROPERTY(QString chatTheme READ chatTheme WRITE setChatTheme NOTIFY chatThemeChanged)
+    // FIXME: This should be changed to an enum to allow translations to work
     Q_PROPERTY(QString fontSize READ fontSize WRITE setFontSize NOTIFY fontSizeChanged)
+    Q_PROPERTY(QString languageAndLocale READ languageAndLocale WRITE setLanguageAndLocale NOTIFY languageAndLocaleChanged)
     Q_PROPERTY(bool forceMetal READ forceMetal WRITE setForceMetal NOTIFY forceMetalChanged)
     Q_PROPERTY(QString lastVersionStarted READ lastVersionStarted WRITE setLastVersionStarted NOTIFY lastVersionStartedChanged)
     Q_PROPERTY(int localDocsChunkSize READ localDocsChunkSize WRITE setLocalDocsChunkSize NOTIFY localDocsChunkSizeChanged)
@@ -52,6 +55,7 @@ class MySettings : public QObject
     Q_PROPERTY(QStringList embeddingsDeviceList MEMBER m_embeddingsDeviceList CONSTANT)
     Q_PROPERTY(int networkPort READ networkPort WRITE setNetworkPort NOTIFY networkPortChanged)
     Q_PROPERTY(SuggestionMode suggestionMode READ suggestionMode WRITE setSuggestionMode NOTIFY suggestionModeChanged)
+    Q_PROPERTY(QStringList uiLanguages MEMBER m_uiLanguages CONSTANT)
 
 public:
     static MySettings *globalInstance();
@@ -142,6 +146,9 @@ public:
     SuggestionMode suggestionMode() const;
     void setSuggestionMode(SuggestionMode mode);
 
+    QString languageAndLocale() const;
+    void setLanguageAndLocale(const QString &bcp47Name = QString()); // called on startup with QString()
+
     // Release/Download settings
     QString lastVersionStarted() const;
     void setLastVersionStarted(const QString &value);
@@ -215,12 +222,15 @@ Q_SIGNALS:
     void attemptModelLoadChanged();
     void deviceChanged();
     void suggestionModeChanged();
+    void languageAndLocaleChanged();
 
 private:
     QSettings m_settings;
     bool m_forceMetal;
     const QStringList m_deviceList;
     const QStringList m_embeddingsDeviceList;
+    const QStringList m_uiLanguages;
+    QTranslator *m_translator = nullptr;
 
 private:
     explicit MySettings();
@@ -232,6 +242,7 @@ private:
     QVariant getModelSetting(const QString &name, const ModelInfo &info) const;
     void setModelSetting(const QString &name, const ModelInfo &info, const QVariant &value, bool force,
                          bool signal = false);
+    QString filePathForLocale(const QLocale &locale);
 };
 
 #endif // MYSETTINGS_H

--- a/gpt4all-chat/qml/ApplicationSettings.qml
+++ b/gpt4all-chat/qml/ApplicationSettings.qml
@@ -161,15 +161,45 @@ MySettingsTab {
             }
         }
         MySettingsLabel {
-            id: deviceLabel
-            text: qsTr("Device")
-            helpText: qsTr('The compute device used for text generation. "Auto" uses Vulkan or Metal.')
+            id: languageLabel
+            visible: MySettings.uiLanguages.length > 1
+            text: qsTr("Language and Locale")
+            helpText: qsTr("The language and locale you wish to use.")
             Layout.row: 4
             Layout.column: 0
         }
         MyComboBox {
-            id: deviceBox
+            id: languageBox
+            visible: MySettings.uiLanguages.length > 1
             Layout.row: 4
+            Layout.column: 2
+            Layout.minimumWidth: 200
+            Layout.maximumWidth: 200
+            Layout.fillWidth: false
+            Layout.alignment: Qt.AlignRight
+            model: MySettings.uiLanguages
+            Accessible.name: fontLabel.text
+            Accessible.description: fontLabel.helpText
+            function updateModel() {
+                languageBox.currentIndex = languageBox.indexOfValue(MySettings.languageAndLocale);
+            }
+            Component.onCompleted: {
+                languageBox.updateModel()
+            }
+            onActivated: {
+                MySettings.languageAndLocale = languageBox.currentText
+            }
+        }
+        MySettingsLabel {
+            id: deviceLabel
+            text: qsTr("Device")
+            helpText: qsTr('The compute device used for text generation. "Auto" uses Vulkan or Metal.')
+            Layout.row: 5
+            Layout.column: 0
+        }
+        MyComboBox {
+            id: deviceBox
+            Layout.row: 5
             Layout.column: 2
             Layout.minimumWidth: 400
             Layout.maximumWidth: 400
@@ -198,12 +228,12 @@ MySettingsTab {
             id: defaultModelLabel
             text: qsTr("Default Model")
             helpText: qsTr("The preferred model for new chats. Also used as the local server fallback.")
-            Layout.row: 5
+            Layout.row: 6
             Layout.column: 0
         }
         MyComboBox {
             id: comboBox
-            Layout.row: 5
+            Layout.row: 6
             Layout.column: 2
             Layout.minimumWidth: 400
             Layout.maximumWidth: 400
@@ -231,12 +261,12 @@ MySettingsTab {
             id: suggestionModeLabel
             text: qsTr("Suggestion Mode")
             helpText: qsTr("Generate suggested follow-up questions at the end of responses.")
-            Layout.row: 6
+            Layout.row: 7
             Layout.column: 0
         }
         MyComboBox {
             id: suggestionModeBox
-            Layout.row: 6
+            Layout.row: 7
             Layout.column: 2
             Layout.minimumWidth: 400
             Layout.maximumWidth: 400
@@ -255,12 +285,12 @@ MySettingsTab {
             id: modelPathLabel
             text: qsTr("Download Path")
             helpText: qsTr("Where to store local models and the LocalDocs database.")
-            Layout.row: 7
+            Layout.row: 8
             Layout.column: 0
         }
 
         RowLayout {
-            Layout.row: 7
+            Layout.row: 8
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             Layout.minimumWidth: 400
@@ -297,12 +327,12 @@ MySettingsTab {
             id: dataLakeLabel
             text: qsTr("Enable Datalake")
             helpText: qsTr("Send chats and feedback to the GPT4All Open-Source Datalake.")
-            Layout.row: 8
+            Layout.row: 9
             Layout.column: 0
         }
         MyCheckBox {
             id: dataLakeBox
-            Layout.row: 8
+            Layout.row: 9
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             Component.onCompleted: { dataLakeBox.checked = MySettings.networkIsActive; }
@@ -320,7 +350,7 @@ MySettingsTab {
         }
 
         ColumnLayout {
-            Layout.row: 9
+            Layout.row: 10
             Layout.column: 0
             Layout.columnSpan: 3
             Layout.fillWidth: true
@@ -343,7 +373,7 @@ MySettingsTab {
             id: nThreadsLabel
             text: qsTr("CPU Threads")
             helpText: qsTr("The number of CPU threads used for inference and embedding.")
-            Layout.row: 10
+            Layout.row: 11
             Layout.column: 0
         }
         MyTextField {
@@ -351,7 +381,7 @@ MySettingsTab {
             color: theme.textColor
             font.pixelSize: theme.fontSizeLarge
             Layout.alignment: Qt.AlignRight
-            Layout.row: 10
+            Layout.row: 11
             Layout.column: 2
             Layout.minimumWidth: 200
             Layout.maximumWidth: 200
@@ -375,12 +405,12 @@ MySettingsTab {
             id: saveChatsContextLabel
             text: qsTr("Save Chat Context")
             helpText: qsTr("Save the chat model's state to disk for faster loading. WARNING: Uses ~2GB per chat.")
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 0
         }
         MyCheckBox {
             id: saveChatsContextBox
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             checked: MySettings.saveChatsContext
@@ -392,12 +422,12 @@ MySettingsTab {
             id: serverChatLabel
             text: qsTr("Enable Local Server")
             helpText: qsTr("Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.")
-            Layout.row: 12
+            Layout.row: 13
             Layout.column: 0
         }
         MyCheckBox {
             id: serverChatBox
-            Layout.row: 12
+            Layout.row: 13
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             checked: MySettings.serverChat
@@ -409,7 +439,7 @@ MySettingsTab {
             id: serverPortLabel
             text: qsTr("API Server Port")
             helpText: qsTr("The port to use for the local server. Requires restart.")
-            Layout.row: 13
+            Layout.row: 14
             Layout.column: 0
         }
         MyTextField {
@@ -417,7 +447,7 @@ MySettingsTab {
             text: MySettings.networkPort
             color: theme.textColor
             font.pixelSize: theme.fontSizeLarge
-            Layout.row: 13
+            Layout.row: 14
             Layout.column: 2
             Layout.minimumWidth: 200
             Layout.maximumWidth: 200
@@ -462,12 +492,12 @@ MySettingsTab {
             id: updatesLabel
             text: qsTr("Check For Updates")
             helpText: qsTr("Manually check for an update to GPT4All.");
-            Layout.row: 14
+            Layout.row: 15
             Layout.column: 0
         }
 
         MySettingsButton {
-            Layout.row: 14
+            Layout.row: 15
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             text: qsTr("Updates");
@@ -478,7 +508,7 @@ MySettingsTab {
         }
 
         Rectangle {
-            Layout.row: 15
+            Layout.row: 16
             Layout.column: 0
             Layout.columnSpan: 3
             Layout.fillWidth: true

--- a/gpt4all-chat/translations/gpt4all_en.ts
+++ b/gpt4all-chat/translations/gpt4all_en.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en">
 <context>
     <name>AddCollectionView</name>
     <message>
@@ -486,164 +486,176 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="165"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="165"/>
+        <location filename="../qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <source>Language and Locale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="167"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="167"/>
+        <source>The language and locale you wish to use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="195"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="195"/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or Metal.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="199"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="199"/>
+        <location filename="../qml/ApplicationSettings.qml" line="229"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="229"/>
         <source>Default Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="200"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="200"/>
+        <location filename="../qml/ApplicationSettings.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="230"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="232"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="232"/>
+        <location filename="../qml/ApplicationSettings.qml" line="262"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="262"/>
         <source>Suggestion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="233"/>
+        <location filename="../qml/ApplicationSettings.qml" line="263"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="263"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="244"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="244"/>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
         <source>When chatting with LocalDocs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="244"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="244"/>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
         <source>Whenever possible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="244"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="244"/>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
         <source>Never</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="256"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="256"/>
-        <source>Download Path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="257"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="257"/>
-        <source>Where to store local models and the LocalDocs database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="286"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="286"/>
-        <source>Browse</source>
+        <source>Download Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="287"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="287"/>
+        <source>Where to store local models and the LocalDocs database.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="316"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="316"/>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="317"/>
         <source>Choose where to save model files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="298"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="298"/>
+        <location filename="../qml/ApplicationSettings.qml" line="328"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="328"/>
         <source>Enable Datalake</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="299"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="299"/>
+        <location filename="../qml/ApplicationSettings.qml" line="329"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="329"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="332"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="332"/>
+        <location filename="../qml/ApplicationSettings.qml" line="362"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="362"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="344"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="344"/>
+        <location filename="../qml/ApplicationSettings.qml" line="374"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="374"/>
         <source>CPU Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="345"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="345"/>
+        <location filename="../qml/ApplicationSettings.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="375"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="376"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="376"/>
+        <location filename="../qml/ApplicationSettings.qml" line="406"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="406"/>
         <source>Save Chat Context</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="377"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="377"/>
+        <location filename="../qml/ApplicationSettings.qml" line="407"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="407"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="423"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="423"/>
         <source>Enable Local Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="394"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="394"/>
+        <location filename="../qml/ApplicationSettings.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="424"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="410"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../qml/ApplicationSettings.qml" line="440"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="440"/>
         <source>API Server Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="411"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../qml/ApplicationSettings.qml" line="441"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="441"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="463"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="463"/>
+        <location filename="../qml/ApplicationSettings.qml" line="493"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="493"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="464"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="464"/>
+        <location filename="../qml/ApplicationSettings.qml" line="494"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="494"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="473"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="473"/>
+        <location filename="../qml/ApplicationSettings.qml" line="503"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="503"/>
         <source>Updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1178,6 +1190,7 @@ model to get started</source>
         <source>%n file(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1185,6 +1198,7 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="89"/>
         <source>%n word(s)</source>
         <translation type="unfinished">
+            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
@@ -1593,6 +1607,7 @@ model to get started</source>
         <source>%n file(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1600,6 +1615,7 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="332"/>
         <source>%n word(s)</source>
         <translation type="unfinished">
+            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -1,573 +1,441 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-    <context>
-        <name>AddCollectionView</name>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="45" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="45" />
-            <source>← Existing Collections</source>
-            <translation>← Colecciones existentes</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="68" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="68" />
-            <source>Add Document Collection</source>
-            <translation>Agregar colección de documentos</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="78" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="78" />
-            <source>Add a folder containing plain text files, PDFs, or Markdown. Configure
+<TS version="2.1" language="es_MX">
+<context>
+    <name>AddCollectionView</name>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="45"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="45"/>
+        <source>← Existing Collections</source>
+        <translation>← Colecciones existentes</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="68"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="68"/>
+        <source>Add Document Collection</source>
+        <translation>Agregar colección de documentos</translation>
+    </message>
+    <message>
+        <source>Add a folder containing plain text files, PDFs, or Markdown. Configure
                 additional extensions in Settings.</source>
-            <translation>Agregue una carpeta que contenga archivos de texto plano, PDFs o Markdown.
+        <translation type="vanished">Agregue una carpeta que contenga archivos de texto plano, PDFs o Markdown.
                 Configure extensiones adicionales en Configuración.</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="94" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="94" />
-            <source>Please choose a directory</source>
-            <translation>Por favor, elija un directorio</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="106" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="106" />
-            <source>Name</source>
-            <translation>Nombre</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="121" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="121" />
-            <source>Collection name...</source>
-            <translation>Nombre de la colección...</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="123" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="123" />
-            <source>Name of the collection to add (Required)</source>
-            <translation>Nombre de la colección a agregar (Requerido)</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="139" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="139" />
-            <source>Folder</source>
-            <translation>Carpeta</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="156" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="156" />
-            <source>Folder path...</source>
-            <translation>Ruta de la carpeta...</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="159" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="159" />
-            <source>Folder path to documents (Required)</source>
-            <translation>Ruta de la carpeta de documentos (Requerido)</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="171" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="171" />
-            <source>Browse</source>
-            <translation>Explorar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddCollectionView.qml" line="184" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml"
-                line="184" />
-            <source>Create Collection</source>
-            <translation>Crear colección</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddModelView</name>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="51" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="51" />
-            <source>← Existing Models</source>
-            <translation>← Modelos existentes</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="71" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="71" />
-            <source>Explore Models</source>
-            <translation>Explorar modelos</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="88" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="88" />
-            <source>Discover and download models by keyword search...</source>
-            <translation>Descubre y descarga modelos mediante búsqueda por palabras clave...</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="91" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="91" />
-            <source>Text field for discovering and filtering downloadable models</source>
-            <translation>Campo de texto para descubrir y filtrar modelos descargables</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="167" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="167" />
-            <source>Initiate model discovery and filtering</source>
-            <translation>Iniciar descubrimiento y filtrado de modelos</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="168" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="168" />
-            <source>Triggers discovery and filtering of models</source>
-            <translation>Activa el descubrimiento y filtrado de modelos</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="186" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="186" />
-            <source>Default</source>
-            <translation>Predeterminado</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="186" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="186" />
-            <source>Likes</source>
-            <translation>Me gusta</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="186" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="186" />
-            <source>Downloads</source>
-            <translation>Descargas</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="186" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="186" />
-            <source>Recent</source>
-            <translation>Reciente</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="206" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="206" />
-            <source>Asc</source>
-            <translation>Asc</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="206" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="206" />
-            <source>Desc</source>
-            <translation>Desc</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="234" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="234" />
-            <source>None</source>
-            <translation>Ninguno</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="97" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="97" />
-            <source>Searching · %1</source>
-            <translation>Buscando · %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="193" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="193" />
-            <source>Sort by: %1</source>
-            <translation>Ordenar por: %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="218" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="218" />
-            <source>Sort dir: %1</source>
-            <translation>Dirección de ordenamiento: %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="254" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="254" />
-            <source>Limit: %1</source>
-            <translation>Límite: %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="287" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="287" />
-            <source>Network error: could not retrieve %1</source>
-            <translation>Error de red: no se pudo recuperar %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="297" />
-            <location filename="../qml/AddModelView.qml" line="560" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="297" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="560" />
-            <source>Busy indicator</source>
-            <translation>Indicador de ocupado</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="298" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="298" />
-            <source>Displayed when the models request is ongoing</source>
-            <translation>Se muestra cuando la solicitud de modelos está en curso</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="338" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="338" />
-            <source>Model file</source>
-            <translation>Archivo del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="339" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="339" />
-            <source>Model file to be downloaded</source>
-            <translation>Archivo del modelo a descargar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="362" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="362" />
-            <source>Description</source>
-            <translation>Descripción</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="363" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="363" />
-            <source>File description</source>
-            <translation>Descripción del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="396" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="396" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="396" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="396" />
-            <source>Resume</source>
-            <translation>Reanudar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="396" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="396" />
-            <source>Download</source>
-            <translation>Descargar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="404" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="404" />
-            <source>Stop/restart/start the download</source>
-            <translation>Detener/reiniciar/iniciar la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="416" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="416" />
-            <source>Remove</source>
-            <translation>Eliminar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="423" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="423" />
-            <source>Remove model from filesystem</source>
-            <translation>Eliminar modelo del sistema de archivos</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="437" />
-            <location filename="../qml/AddModelView.qml" line="446" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="437" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="446" />
-            <source>Install</source>
-            <translation>Instalar</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="447" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="447" />
-            <source>Install online model</source>
-            <translation>Instalar modelo en línea</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="476" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="476" />
-            <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="78"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="78"/>
+        <source>Add a folder containing plain text files, PDFs, or Markdown. Configure additional extensions in Settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="94"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="94"/>
+        <source>Please choose a directory</source>
+        <translation>Por favor, elija un directorio</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="106"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="106"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="121"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="121"/>
+        <source>Collection name...</source>
+        <translation>Nombre de la colección...</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="123"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="123"/>
+        <source>Name of the collection to add (Required)</source>
+        <translation>Nombre de la colección a agregar (Requerido)</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="139"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="139"/>
+        <source>Folder</source>
+        <translation>Carpeta</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="156"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="156"/>
+        <source>Folder path...</source>
+        <translation>Ruta de la carpeta...</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="159"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="159"/>
+        <source>Folder path to documents (Required)</source>
+        <translation>Ruta de la carpeta de documentos (Requerido)</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="171"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="171"/>
+        <source>Browse</source>
+        <translation>Explorar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddCollectionView.qml" line="184"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="184"/>
+        <source>Create Collection</source>
+        <translation>Crear colección</translation>
+    </message>
+</context>
+<context>
+    <name>AddModelView</name>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="51"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="51"/>
+        <source>← Existing Models</source>
+        <translation>← Modelos existentes</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="71"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="71"/>
+        <source>Explore Models</source>
+        <translation>Explorar modelos</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="88"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="88"/>
+        <source>Discover and download models by keyword search...</source>
+        <translation>Descubre y descarga modelos mediante búsqueda por palabras clave...</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="91"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="91"/>
+        <source>Text field for discovering and filtering downloadable models</source>
+        <translation>Campo de texto para descubrir y filtrar modelos descargables</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="167"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="167"/>
+        <source>Initiate model discovery and filtering</source>
+        <translation>Iniciar descubrimiento y filtrado de modelos</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="168"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="168"/>
+        <source>Triggers discovery and filtering of models</source>
+        <translation>Activa el descubrimiento y filtrado de modelos</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="186"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <source>Default</source>
+        <translation>Predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="186"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <source>Likes</source>
+        <translation>Me gusta</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="186"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <source>Downloads</source>
+        <translation>Descargas</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="186"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <source>Recent</source>
+        <translation>Reciente</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="206"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="206"/>
+        <source>Asc</source>
+        <translation>Asc</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="206"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="206"/>
+        <source>Desc</source>
+        <translation>Desc</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="234"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="234"/>
+        <source>None</source>
+        <translation>Ninguno</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="97"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="97"/>
+        <source>Searching · %1</source>
+        <translation>Buscando · %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
+        <source>Sort by: %1</source>
+        <translation>Ordenar por: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="218"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="218"/>
+        <source>Sort dir: %1</source>
+        <translation>Dirección de ordenamiento: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="254"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="254"/>
+        <source>Limit: %1</source>
+        <translation>Límite: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="287"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="287"/>
+        <source>Network error: could not retrieve %1</source>
+        <translation>Error de red: no se pudo recuperar %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="297"/>
+        <location filename="../qml/AddModelView.qml" line="560"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <source>Busy indicator</source>
+        <translation>Indicador de ocupado</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="298"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="298"/>
+        <source>Displayed when the models request is ongoing</source>
+        <translation>Se muestra cuando la solicitud de modelos está en curso</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="338"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="338"/>
+        <source>Model file</source>
+        <translation>Archivo del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="339"/>
+        <source>Model file to be downloaded</source>
+        <translation>Archivo del modelo a descargar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="362"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="362"/>
+        <source>Description</source>
+        <translation>Descripción</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="363"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="363"/>
+        <source>File description</source>
+        <translation>Descripción del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="396"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="396"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <source>Resume</source>
+        <translation>Reanudar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="396"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <source>Download</source>
+        <translation>Descargar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="404"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="404"/>
+        <source>Stop/restart/start the download</source>
+        <translation>Detener/reiniciar/iniciar la descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="423"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="423"/>
+        <source>Remove model from filesystem</source>
+        <translation>Eliminar modelo del sistema de archivos</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="437"/>
+        <location filename="../qml/AddModelView.qml" line="446"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="437"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="446"/>
+        <source>Install</source>
+        <translation>Instalar</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="447"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="447"/>
+        <source>Install online model</source>
+        <translation>Instalar modelo en línea</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="476"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
                 hardware. Model requires more memory (%1 GB) than your system has available
                 (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-            <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
                 para su hardware. El modelo requiere más memoria (%1 GB) de la que su sistema tiene
                 disponible
                 (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="628" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="628" />
-            <source>%1 GB</source>
-            <translation>%1 GB</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="628" />
-            <location filename="../qml/AddModelView.qml" line="650" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="628" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="650" />
-            <source>?</source>
-            <translation>?</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="463" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="463" />
-            <source>Describes an error that occurred when downloading</source>
-            <translation>Describe un error que ocurrió durante la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="457" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="457" />
-            <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <source>%1 GB</source>
+        <translation>%1 GB</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="650"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="650"/>
+        <source>?</source>
+        <translation>?</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="463"/>
+        <source>Describes an error that occurred when downloading</source>
+        <translation>Describe un error que ocurrió durante la descarga</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
                 href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
-            <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
                 href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="482" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="482" />
-            <source>Error for incompatible hardware</source>
-            <translation>Error por hardware incompatible</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="520" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="520" />
-            <source>Download progressBar</source>
-            <translation>Barra de progreso de descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="521" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="521" />
-            <source>Shows the progress made in the download</source>
-            <translation>Muestra el progreso realizado en la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="531" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="531" />
-            <source>Download speed</source>
-            <translation>Velocidad de descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="532" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="532" />
-            <source>Download speed in bytes/kilobytes/megabytes per second</source>
-            <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="549" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="549" />
-            <source>Calculating...</source>
-            <translation>Calculando...</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="553" />
-            <location filename="../qml/AddModelView.qml" line="582" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="553" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="582" />
-            <source>Whether the file hash is being calculated</source>
-            <translation>Si se está calculando el hash del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="561" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="561" />
-            <source>Displayed when the file hash is being calculated</source>
-            <translation>Se muestra cuando se está calculando el hash del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="579" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="579" />
-            <source>enter $API_KEY</source>
-            <translation>ingrese $API_KEY</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="601" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="601" />
-            <source>File size</source>
-            <translation>Tamaño del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="623" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="623" />
-            <source>RAM required</source>
-            <translation>RAM requerida</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="645" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="645" />
-            <source>Parameters</source>
-            <translation>Parámetros</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="667" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="667" />
-            <source>Quant</source>
-            <translation>Cuantificación</translation>
-        </message>
-        <message>
-            <location filename="../qml/AddModelView.qml" line="689" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml"
-                line="689" />
-            <source>Type</source>
-            <translation>Tipo</translation>
-        </message>
-    </context>
-    <context>
-        <name>ApplicationSettings</name>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="16" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="16" />
-            <source>Application</source>
-            <translation>Aplicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="25" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="25" />
-            <source>Network dialog</source>
-            <translation>Diálogo de red</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="26" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="26" />
-            <source>opt-in to share feedback/conversations</source>
-            <translation>optar por compartir comentarios/conversaciones</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="37" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="37" />
-            <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="482"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="482"/>
+        <source>Error for incompatible hardware</source>
+        <translation>Error por hardware incompatible</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="520"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="520"/>
+        <source>Download progressBar</source>
+        <translation>Barra de progreso de descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
+        <source>Shows the progress made in the download</source>
+        <translation>Muestra el progreso realizado en la descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="531"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="531"/>
+        <source>Download speed</source>
+        <translation>Velocidad de descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="532"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="532"/>
+        <source>Download speed in bytes/kilobytes/megabytes per second</source>
+        <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="549"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <source>Calculating...</source>
+        <translation>Calculando...</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="553"/>
+        <location filename="../qml/AddModelView.qml" line="582"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="553"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
+        <source>Whether the file hash is being calculated</source>
+        <translation>Si se está calculando el hash del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="561"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <source>Displayed when the file hash is being calculated</source>
+        <translation>Se muestra cuando se está calculando el hash del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="579"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="579"/>
+        <source>enter $API_KEY</source>
+        <translation>ingrese $API_KEY</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="601"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="601"/>
+        <source>File size</source>
+        <translation>Tamaño del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="623"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="623"/>
+        <source>RAM required</source>
+        <translation>RAM requerida</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="645"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <source>Parameters</source>
+        <translation>Parámetros</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
+        <source>Quant</source>
+        <translation>Cuantificación</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+</context>
+<context>
+    <name>ApplicationSettings</name>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="16"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="16"/>
+        <source>Application</source>
+        <translation>Aplicación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="25"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="25"/>
+        <source>Network dialog</source>
+        <translation>Diálogo de red</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="26"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="26"/>
+        <source>opt-in to share feedback/conversations</source>
+        <translation>optar por compartir comentarios/conversaciones</translation>
+    </message>
+    <message>
+        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
                 to check for updates!&lt;br&gt;&lt;br&gt;
                 Did you install this application using the online installer? If so,&lt;br&gt;
                 the MaintenanceTool executable should be located one directory&lt;br&gt;
@@ -575,7 +443,7 @@
                 If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have
                 to&lt;br&gt;
                 reinstall.</source>
-            <translation>ERROR: El sistema de actualización no pudo encontrar la herramienta de
+        <translation type="vanished">ERROR: El sistema de actualización no pudo encontrar la herramienta de
                 mantenimiento utilizada&lt;br&gt;
                 para buscar actualizaciones&lt;br&gt;&lt;br&gt;
                 ¿Instaló esta aplicación utilizando el instalador en línea? Si es así,&lt;br&gt;
@@ -585,821 +453,716 @@
                 archivos.&lt;br&gt;&lt;br&gt;
                 Si no puede iniciarlo manualmente, me temo que tendrá que&lt;br&gt;
                 reinstalar.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="48" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="48" />
-            <source>Error dialog</source>
-            <translation>Diálogo de error</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="72" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="72" />
-            <source>Application Settings</source>
-            <translation>Configuración de la aplicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="85" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="85" />
-            <source>General</source>
-            <translation>General</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="97" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="97" />
-            <source>Theme</source>
-            <translation>Tema</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="98" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="98" />
-            <source>The application color scheme.</source>
-            <translation>El esquema de colores de la aplicación.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="110" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="110" />
-            <source>Dark</source>
-            <translation>Oscuro</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="110" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="110" />
-            <source>Light</source>
-            <translation>Claro</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="110" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="110" />
-            <source>LegacyDark</source>
-            <translation>Oscuro legado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="131" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="131" />
-            <source>Font Size</source>
-            <translation>Tamaño de fuente</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="132" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="132" />
-            <source>The size of text in the application.</source>
-            <translation>El tamaño del texto en la aplicación.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="165" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="165" />
-            <source>Device</source>
-            <translation>Dispositivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="166" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="166" />
-            <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="48"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="48"/>
+        <source>Error dialog</source>
+        <translation>Diálogo de error</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="72"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="72"/>
+        <source>Application Settings</source>
+        <translation>Configuración de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="85"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="85"/>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="97"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="97"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="98"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="98"/>
+        <source>The application color scheme.</source>
+        <translation>El esquema de colores de la aplicación.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <source>Dark</source>
+        <translation>Oscuro</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <source>Light</source>
+        <translation>Claro</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <source>LegacyDark</source>
+        <translation>Oscuro legado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="131"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="131"/>
+        <source>Font Size</source>
+        <translation>Tamaño de fuente</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <source>The size of text in the application.</source>
+        <translation>El tamaño del texto en la aplicación.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="195"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="195"/>
+        <source>Device</source>
+        <translation>Dispositivo</translation>
+    </message>
+    <message>
+        <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or
                 Metal.</source>
-            <translation>El dispositivo de cómputo utilizado para la generación de texto.
+        <translation type="vanished">El dispositivo de cómputo utilizado para la generación de texto.
                 &quot;Auto&quot; utiliza Vulkan o Metal.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="199" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="199" />
-            <source>Default Model</source>
-            <translation>Modelo predeterminado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="200" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="200" />
-            <source>The preferred model for new chats. Also used as the local server fallback.</source>
-            <translation>El modelo preferido para nuevos chats. También se utiliza como respaldo del
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="37"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="37"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
+                   to check for updates!&lt;br&gt;&lt;br&gt;
+                   Did you install this application using the online installer? If so,&lt;br&gt;
+                   the MaintenanceTool executable should be located one directory&lt;br&gt;
+                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
+                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
+                   reinstall.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <source>Language and Locale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="167"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="167"/>
+        <source>The language and locale you wish to use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
+        <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or Metal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="229"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="229"/>
+        <source>Default Model</source>
+        <translation>Modelo predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="230"/>
+        <source>The preferred model for new chats. Also used as the local server fallback.</source>
+        <translation>El modelo preferido para nuevos chats. También se utiliza como respaldo del
                 servidor local.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="232" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="232" />
-            <source>Suggestion Mode</source>
-            <translation>Modo de sugerencia</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="233" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="233" />
-            <source>Generate suggested follow-up questions at the end of responses.</source>
-            <translation>Generar preguntas de seguimiento sugeridas al final de las respuestas.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="244" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="244" />
-            <source>When chatting with LocalDocs</source>
-            <translation>Al chatear con LocalDocs</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="244" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="244" />
-            <source>Whenever possible</source>
-            <translation>Siempre que sea posible</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="244" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="244" />
-            <source>Never</source>
-            <translation>Nunca</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="256" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="256" />
-            <source>Download Path</source>
-            <translation>Ruta de descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="257" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="257" />
-            <source>Where to store local models and the LocalDocs database.</source>
-            <translation>Dónde almacenar los modelos locales y la base de datos de LocalDocs.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="286" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="286" />
-            <source>Browse</source>
-            <translation>Explorar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="287" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="287" />
-            <source>Choose where to save model files</source>
-            <translation>Elegir dónde guardar los archivos del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="298" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="298" />
-            <source>Enable Datalake</source>
-            <translation>Habilitar Datalake</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="299" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="299" />
-            <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
-            <translation>Enviar chats y comentarios al Datalake de código abierto de GPT4All.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="332" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="332" />
-            <source>Advanced</source>
-            <translation>Avanzado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="344" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="344" />
-            <source>CPU Threads</source>
-            <translation>Hilos de CPU</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="345" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="345" />
-            <source>The number of CPU threads used for inference and embedding.</source>
-            <translation>El número de hilos de CPU utilizados para inferencia e incrustación.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="376" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="376" />
-            <source>Save Chat Context</source>
-            <translation>Guardar contexto del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="377" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="377" />
-            <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="262"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="262"/>
+        <source>Suggestion Mode</source>
+        <translation>Modo de sugerencia</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="263"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="263"/>
+        <source>Generate suggested follow-up questions at the end of responses.</source>
+        <translation>Generar preguntas de seguimiento sugeridas al final de las respuestas.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>When chatting with LocalDocs</source>
+        <translation>Al chatear con LocalDocs</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>Whenever possible</source>
+        <translation>Siempre que sea posible</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="286"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="286"/>
+        <source>Download Path</source>
+        <translation>Ruta de descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="287"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="287"/>
+        <source>Where to store local models and the LocalDocs database.</source>
+        <translation>Dónde almacenar los modelos locales y la base de datos de LocalDocs.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="316"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="316"/>
+        <source>Browse</source>
+        <translation>Explorar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="317"/>
+        <source>Choose where to save model files</source>
+        <translation>Elegir dónde guardar los archivos del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="328"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="328"/>
+        <source>Enable Datalake</source>
+        <translation>Habilitar Datalake</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="329"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="329"/>
+        <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
+        <translation>Enviar chats y comentarios al Datalake de código abierto de GPT4All.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="362"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="362"/>
+        <source>Advanced</source>
+        <translation>Avanzado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="374"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="374"/>
+        <source>CPU Threads</source>
+        <translation>Hilos de CPU</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="375"/>
+        <source>The number of CPU threads used for inference and embedding.</source>
+        <translation>El número de hilos de CPU utilizados para inferencia e incrustación.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="406"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="406"/>
+        <source>Save Chat Context</source>
+        <translation>Guardar contexto del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="407"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="407"/>
+        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="424"/>
+        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB
                 per chat.</source>
-            <translation>Guardar el estado del modelo de chat en el disco para una carga más rápida.
+        <translation type="vanished">Guardar el estado del modelo de chat en el disco para una carga más rápida.
                 ADVERTENCIA: Usa ~2GB por chat.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="393" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="393" />
-            <source>Enable Local Server</source>
-            <translation>Habilitar servidor local</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="394" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="394" />
-            <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="423"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="423"/>
+        <source>Enable Local Server</source>
+        <translation>Habilitar servidor local</translation>
+    </message>
+    <message>
+        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
                 resource usage.</source>
-            <translation>Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
+        <translation type="vanished">Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
                 en un mayor uso de recursos.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="410" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="410" />
-            <source>API Server Port</source>
-            <translation>Puerto del servidor API</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="411" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="411" />
-            <source>The port to use for the local server. Requires restart.</source>
-            <translation>El puerto a utilizar para el servidor local. Requiere reinicio.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="463" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="463" />
-            <source>Check For Updates</source>
-            <translation>Buscar actualizaciones</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="464" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="464" />
-            <source>Manually check for an update to GPT4All.</source>
-            <translation>Buscar manualmente una actualización para GPT4All.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ApplicationSettings.qml" line="473" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml"
-                line="473" />
-            <source>Updates</source>
-            <translation>Actualizaciones</translation>
-        </message>
-    </context>
-    <context>
-        <name>Chat</name>
-        <message>
-            <location filename="../chat.h" line="72" />
-            <location filename="../chat.cpp" line="25" />
-            <source>New Chat</source>
-            <translation>Nuevo chat</translation>
-        </message>
-        <message>
-            <location filename="../chat.cpp" line="38" />
-            <source>Server Chat</source>
-            <translation>Chat del servidor</translation>
-        </message>
-    </context>
-    <context>
-        <name>ChatDrawer</name>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="37" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="37" />
-            <source>Drawer</source>
-            <translation>Cajón</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="38" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="38" />
-            <source>Main navigation drawer</source>
-            <translation>Cajón de navegación principal</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="49" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="49" />
-            <source>＋ New Chat</source>
-            <translation>＋ Nuevo chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="50" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="50" />
-            <source>Create a new chat</source>
-            <translation>Crear un nuevo chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="199" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="199" />
-            <source>Select the current chat or edit the chat when in edit mode</source>
-            <translation>Seleccionar el chat actual o editar el chat cuando esté en modo de edición</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="216" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="216" />
-            <source>Edit chat name</source>
-            <translation>Editar nombre del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="229" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="229" />
-            <source>Save chat name</source>
-            <translation>Guardar nombre del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="246" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="246" />
-            <source>Delete chat</source>
-            <translation>Eliminar chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="283" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="283" />
-            <source>Confirm chat deletion</source>
-            <translation>Confirmar eliminación del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="305" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="305" />
-            <source>Cancel chat deletion</source>
-            <translation>Cancelar eliminación del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="317" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="317" />
-            <source>List of chats</source>
-            <translation>Lista de chats</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatDrawer.qml" line="318" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml"
-                line="318" />
-            <source>List of chats in the drawer dialog</source>
-            <translation>Lista de chats en el diálogo del cajón</translation>
-        </message>
-    </context>
-    <context>
-        <name>ChatListModel</name>
-        <message>
-            <location filename="../chatlistmodel.h" line="86" />
-            <source>TODAY</source>
-            <translation>HOY</translation>
-        </message>
-        <message>
-            <location filename="../chatlistmodel.h" line="88" />
-            <source>THIS WEEK</source>
-            <translation>ESTA SEMANA</translation>
-        </message>
-        <message>
-            <location filename="../chatlistmodel.h" line="90" />
-            <source>THIS MONTH</source>
-            <translation>ESTE MES</translation>
-        </message>
-        <message>
-            <location filename="../chatlistmodel.h" line="92" />
-            <source>LAST SIX MONTHS</source>
-            <translation>ÚLTIMOS SEIS MESES</translation>
-        </message>
-        <message>
-            <location filename="../chatlistmodel.h" line="94" />
-            <source>THIS YEAR</source>
-            <translation>ESTE AÑO</translation>
-        </message>
-        <message>
-            <location filename="../chatlistmodel.h" line="96" />
-            <source>LAST YEAR</source>
-            <translation>AÑO PASADO</translation>
-        </message>
-    </context>
-    <context>
-        <name>ChatView</name>
-        <message>
-            <location filename="../qml/ChatView.qml" line="77" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="77" />
-            <source>&lt;h3&gt;Warning&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-            <translation>&lt;h3&gt;Advertencia&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="86" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="86" />
-            <source>Switch model dialog</source>
-            <translation>Diálogo para cambiar de modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="87" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="87" />
-            <source>Warn the user if they switch models, then context will be erased</source>
-            <translation>Advertir al usuario si cambia de modelo, entonces se borrará el contexto</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="94" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="94" />
-            <source>Conversation copied to clipboard.</source>
-            <translation>Conversación copiada al portapapeles.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="101" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="101" />
-            <source>Code copied to clipboard.</source>
-            <translation>Código copiado al portapapeles.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="231" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="231" />
-            <source>Chat panel</source>
-            <translation>Panel de chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="232" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="232" />
-            <source>Chat panel with options</source>
-            <translation>Panel de chat con opciones</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="339" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="339" />
-            <source>Reload the currently loaded model</source>
-            <translation>Recargar el modelo actualmente cargado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="353" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="353" />
-            <source>Eject the currently loaded model</source>
-            <translation>Expulsar el modelo actualmente cargado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="365" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="365" />
-            <source>No model installed.</source>
-            <translation>No hay modelo instalado.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="367" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="367" />
-            <source>Model loading error.</source>
-            <translation>Error al cargar el modelo.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="369" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="369" />
-            <source>Waiting for model...</source>
-            <translation>Esperando al modelo...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="371" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="371" />
-            <source>Switching context...</source>
-            <translation>Cambiando contexto...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="373" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="373" />
-            <source>Choose a model...</source>
-            <translation>Elige un modelo...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="375" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="375" />
-            <source>Not found: %1</source>
-            <translation>No encontrado: %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="463" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="463" />
-            <source>The top item is the current model</source>
-            <translation>El elemento superior es el modelo actual</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="549" />
-            <location filename="../qml/ChatView.qml" line="1307" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="549" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1307" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="567" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="567" />
-            <source>Add documents</source>
-            <translation>Agregar documentos</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="568" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="568" />
-            <source>add collections of documents to the chat</source>
-            <translation>agregar colecciones de documentos al chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="732" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="732" />
-            <source>Load the default model</source>
-            <translation>Cargar el modelo predeterminado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="733" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="733" />
-            <source>Loads the default model which can be changed in settings</source>
-            <translation>Carga el modelo predeterminado que se puede cambiar en la configuración</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="744" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="744" />
-            <source>No Model Installed</source>
-            <translation>No hay modelo instalado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="753" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="753" />
-            <source>GPT4All requires that you install at least one
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="440"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="440"/>
+        <source>API Server Port</source>
+        <translation>Puerto del servidor API</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="441"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="441"/>
+        <source>The port to use for the local server. Requires restart.</source>
+        <translation>El puerto a utilizar para el servidor local. Requiere reinicio.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="493"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="493"/>
+        <source>Check For Updates</source>
+        <translation>Buscar actualizaciones</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="494"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="494"/>
+        <source>Manually check for an update to GPT4All.</source>
+        <translation>Buscar manualmente una actualización para GPT4All.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="503"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="503"/>
+        <source>Updates</source>
+        <translation>Actualizaciones</translation>
+    </message>
+</context>
+<context>
+    <name>Chat</name>
+    <message>
+        <location filename="../chat.h" line="72"/>
+        <location filename="../chat.cpp" line="25"/>
+        <source>New Chat</source>
+        <translation>Nuevo chat</translation>
+    </message>
+    <message>
+        <location filename="../chat.cpp" line="38"/>
+        <source>Server Chat</source>
+        <translation>Chat del servidor</translation>
+    </message>
+</context>
+<context>
+    <name>ChatDrawer</name>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="37"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="37"/>
+        <source>Drawer</source>
+        <translation>Cajón</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="38"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="38"/>
+        <source>Main navigation drawer</source>
+        <translation>Cajón de navegación principal</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="49"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="49"/>
+        <source>＋ New Chat</source>
+        <translation>＋ Nuevo chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="50"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="50"/>
+        <source>Create a new chat</source>
+        <translation>Crear un nuevo chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="199"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="199"/>
+        <source>Select the current chat or edit the chat when in edit mode</source>
+        <translation>Seleccionar el chat actual o editar el chat cuando esté en modo de edición</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="216"/>
+        <source>Edit chat name</source>
+        <translation>Editar nombre del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="229"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="229"/>
+        <source>Save chat name</source>
+        <translation>Guardar nombre del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="246"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="246"/>
+        <source>Delete chat</source>
+        <translation>Eliminar chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="283"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="283"/>
+        <source>Confirm chat deletion</source>
+        <translation>Confirmar eliminación del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="305"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="305"/>
+        <source>Cancel chat deletion</source>
+        <translation>Cancelar eliminación del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="317"/>
+        <source>List of chats</source>
+        <translation>Lista de chats</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatDrawer.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="318"/>
+        <source>List of chats in the drawer dialog</source>
+        <translation>Lista de chats en el diálogo del cajón</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListModel</name>
+    <message>
+        <location filename="../chatlistmodel.h" line="86"/>
+        <source>TODAY</source>
+        <translation>HOY</translation>
+    </message>
+    <message>
+        <location filename="../chatlistmodel.h" line="88"/>
+        <source>THIS WEEK</source>
+        <translation>ESTA SEMANA</translation>
+    </message>
+    <message>
+        <location filename="../chatlistmodel.h" line="90"/>
+        <source>THIS MONTH</source>
+        <translation>ESTE MES</translation>
+    </message>
+    <message>
+        <location filename="../chatlistmodel.h" line="92"/>
+        <source>LAST SIX MONTHS</source>
+        <translation>ÚLTIMOS SEIS MESES</translation>
+    </message>
+    <message>
+        <location filename="../chatlistmodel.h" line="94"/>
+        <source>THIS YEAR</source>
+        <translation>ESTE AÑO</translation>
+    </message>
+    <message>
+        <location filename="../chatlistmodel.h" line="96"/>
+        <source>LAST YEAR</source>
+        <translation>AÑO PASADO</translation>
+    </message>
+</context>
+<context>
+    <name>ChatView</name>
+    <message>
+        <location filename="../qml/ChatView.qml" line="77"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="77"/>
+        <source>&lt;h3&gt;Warning&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</source>
+        <translation>&lt;h3&gt;Advertencia&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="86"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="86"/>
+        <source>Switch model dialog</source>
+        <translation>Diálogo para cambiar de modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="87"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="87"/>
+        <source>Warn the user if they switch models, then context will be erased</source>
+        <translation>Advertir al usuario si cambia de modelo, entonces se borrará el contexto</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="94"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="94"/>
+        <source>Conversation copied to clipboard.</source>
+        <translation>Conversación copiada al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="101"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="101"/>
+        <source>Code copied to clipboard.</source>
+        <translation>Código copiado al portapapeles.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="231"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="231"/>
+        <source>Chat panel</source>
+        <translation>Panel de chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="232"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="232"/>
+        <source>Chat panel with options</source>
+        <translation>Panel de chat con opciones</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="339"/>
+        <source>Reload the currently loaded model</source>
+        <translation>Recargar el modelo actualmente cargado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="353"/>
+        <source>Eject the currently loaded model</source>
+        <translation>Expulsar el modelo actualmente cargado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="365"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="365"/>
+        <source>No model installed.</source>
+        <translation>No hay modelo instalado.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="367"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="367"/>
+        <source>Model loading error.</source>
+        <translation>Error al cargar el modelo.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="369"/>
+        <source>Waiting for model...</source>
+        <translation>Esperando al modelo...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="371"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="371"/>
+        <source>Switching context...</source>
+        <translation>Cambiando contexto...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="373"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="373"/>
+        <source>Choose a model...</source>
+        <translation>Elige un modelo...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="375"/>
+        <source>Not found: %1</source>
+        <translation>No encontrado: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="463"/>
+        <source>The top item is the current model</source>
+        <translation>El elemento superior es el modelo actual</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="549"/>
+        <location filename="../qml/ChatView.qml" line="1307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="549"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1307"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="567"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="567"/>
+        <source>Add documents</source>
+        <translation>Agregar documentos</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="568"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="568"/>
+        <source>add collections of documents to the chat</source>
+        <translation>agregar colecciones de documentos al chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="732"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="732"/>
+        <source>Load the default model</source>
+        <translation>Cargar el modelo predeterminado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="733"/>
+        <source>Loads the default model which can be changed in settings</source>
+        <translation>Carga el modelo predeterminado que se puede cambiar en la configuración</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="744"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="744"/>
+        <source>No Model Installed</source>
+        <translation>No hay modelo instalado</translation>
+    </message>
+    <message>
+        <source>GPT4All requires that you install at least one
                 model to get started</source>
-            <translation>GPT4All requiere que instales al menos un
+        <translation type="vanished">GPT4All requiere que instales al menos un
                 modelo para comenzar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="765" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="765" />
-            <source>Install a Model</source>
-            <translation>Instalar un modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="770" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="770" />
-            <source>Shows the add model view</source>
-            <translation>Muestra la vista de agregar modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="795" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="795" />
-            <source>Conversation with the model</source>
-            <translation>Conversación con el modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="796" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="796" />
-            <source>prompt / response pairs from the conversation</source>
-            <translation>pares de pregunta / respuesta de la conversación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="848" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="848" />
-            <source>GPT4All</source>
-            <translation>GPT4All</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="848" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="848" />
-            <source>You</source>
-            <translation>Tú</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="870" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="870" />
-            <source>recalculating context ...</source>
-            <translation>recalculando contexto ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="872" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="872" />
-            <source>response stopped ...</source>
-            <translation>respuesta detenida ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="875" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="875" />
-            <source>processing ...</source>
-            <translation>procesando ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="876" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="876" />
-            <source>generating response ...</source>
-            <translation>generando respuesta ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="877" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="877" />
-            <source>generating questions ...</source>
-            <translation>generando preguntas ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="943" />
-            <location filename="../qml/ChatView.qml" line="1899" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="943" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1899" />
-            <source>Copy</source>
-            <translation>Copiar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="949" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="949" />
-            <source>Copy Message</source>
-            <translation>Copiar mensaje</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="959" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="959" />
-            <source>Disable markdown</source>
-            <translation>Desactivar markdown</translation>
-        </message>
-        <message>
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="959" />
-            <source>Enable markdown</source>
-            <translation>Activar markdown</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1049" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1049" />
-            <source>Thumbs up</source>
-            <translation>Me gusta</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1050" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1050" />
-            <source>Gives a thumbs up to the response</source>
-            <translation>Da un me gusta a la respuesta</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1083" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1083" />
-            <source>Thumbs down</source>
-            <translation>No me gusta</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1084" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1084" />
-            <source>Opens thumbs down dialog</source>
-            <translation>Abre el diálogo de no me gusta</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1139" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1139" />
-            <source>%1 Sources</source>
-            <translation>%1 Fuentes</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1383" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1383" />
-            <source>Suggested follow-ups</source>
-            <translation>Seguimientos sugeridos</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1659" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1659" />
-            <source>Erase and reset chat session</source>
-            <translation>Borrar y reiniciar sesión de chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1680" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1680" />
-            <source>Copy chat session to clipboard</source>
-            <translation>Copiar sesión de chat al portapapeles</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1706" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1706" />
-            <source>Redo last chat response</source>
-            <translation>Rehacer última respuesta del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1955" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1955" />
-            <source>Stop generating</source>
-            <translation>Detener generación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1956" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1956" />
-            <source>Stop the current response generation</source>
-            <translation>Detener la generación de la respuesta actual</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1771" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1771" />
-            <source>Reloads the model</source>
-            <translation>Recarga el modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="58" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="58" />
-            <source>&lt;h3&gt;Encountered an error loading
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="58"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="58"/>
+        <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="753"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="753"/>
+        <source>GPT4All requires that you install at least one
+model to get started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="765"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="765"/>
+        <source>Install a Model</source>
+        <translation>Instalar un modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="770"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="770"/>
+        <source>Shows the add model view</source>
+        <translation>Muestra la vista de agregar modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="795"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="795"/>
+        <source>Conversation with the model</source>
+        <translation>Conversación con el modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="796"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="796"/>
+        <source>prompt / response pairs from the conversation</source>
+        <translation>pares de pregunta / respuesta de la conversación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
+        <source>GPT4All</source>
+        <translation>GPT4All</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
+        <source>You</source>
+        <translation>Tú</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="870"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="870"/>
+        <source>recalculating context ...</source>
+        <translation>recalculando contexto ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="872"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="872"/>
+        <source>response stopped ...</source>
+        <translation>respuesta detenida ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="875"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="875"/>
+        <source>processing ...</source>
+        <translation>procesando ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="876"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="876"/>
+        <source>generating response ...</source>
+        <translation>generando respuesta ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="877"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="877"/>
+        <source>generating questions ...</source>
+        <translation>generando preguntas ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="943"/>
+        <location filename="../qml/ChatView.qml" line="1899"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="943"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1899"/>
+        <source>Copy</source>
+        <translation>Copiar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="949"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="949"/>
+        <source>Copy Message</source>
+        <translation>Copiar mensaje</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="959"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
+        <source>Disable markdown</source>
+        <translation>Desactivar markdown</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="959"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
+        <source>Enable markdown</source>
+        <translation>Activar markdown</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1049"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1049"/>
+        <source>Thumbs up</source>
+        <translation>Me gusta</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1050"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1050"/>
+        <source>Gives a thumbs up to the response</source>
+        <translation>Da un me gusta a la respuesta</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1083"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1083"/>
+        <source>Thumbs down</source>
+        <translation>No me gusta</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1084"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1084"/>
+        <source>Opens thumbs down dialog</source>
+        <translation>Abre el diálogo de no me gusta</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1139"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1139"/>
+        <source>%1 Sources</source>
+        <translation>%1 Fuentes</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1383"/>
+        <source>Suggested follow-ups</source>
+        <translation>Seguimientos sugeridos</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1659"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1659"/>
+        <source>Erase and reset chat session</source>
+        <translation>Borrar y reiniciar sesión de chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1680"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1680"/>
+        <source>Copy chat session to clipboard</source>
+        <translation>Copiar sesión de chat al portapapeles</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1706"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1706"/>
+        <source>Redo last chat response</source>
+        <translation>Rehacer última respuesta del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1955"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1955"/>
+        <source>Stop generating</source>
+        <translation>Detener generación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1956"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1956"/>
+        <source>Stop the current response generation</source>
+        <translation>Detener la generación de la respuesta actual</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1771"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1771"/>
+        <source>Reloads the model</source>
+        <translation>Recarga el modelo</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;Encountered an error loading
                 model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model
                 loading failures can happen for a variety of reasons, but the most common causes
                 include a bad file format, an incomplete or corrupted download, the wrong file type,
@@ -1412,7 +1175,7 @@
                 href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the
                 gui&lt;li&gt;Check out our &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
-            <translation>&lt;h3&gt;Se encontró un error al cargar el
+        <translation type="vanished">&lt;h3&gt;Se encontró un error al cargar el
                 modelo:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Los
                 fallos de carga de modelos pueden ocurrir por varias razones, pero las causas más
                 comunes incluyen un formato de archivo incorrecto, una descarga incompleta o
@@ -1428,1567 +1191,1333 @@
                 interfaz gráfica&lt;li&gt;Consulte nuestro &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canal de Discord&lt;/a&gt; para
                 obtener ayuda</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="377" />
-            <location filename="../qml/ChatView.qml" line="1769" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="377" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1769" />
-            <source>Reload · %1</source>
-            <translation>Recargar · %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="379" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="379" />
-            <source>Loading · %1</source>
-            <translation>Cargando · %1</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="708" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="708" />
-            <source>Load · %1 (default) →</source>
-            <translation>Cargar · %1 (predeterminado) →</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="873" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="873" />
-            <source>retrieving localdocs: %1 ...</source>
-            <translation>recuperando documentos locales: %1 ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="874" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="874" />
-            <source>searching localdocs: %1 ...</source>
-            <translation>buscando en documentos locales: %1 ...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1845" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1845" />
-            <source>Send a message...</source>
-            <translation>Enviar un mensaje...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1845" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1845" />
-            <source>Load a model to continue...</source>
-            <translation>Carga un modelo para continuar...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1848" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1848" />
-            <source>Send messages/prompts to the model</source>
-            <translation>Enviar mensajes/indicaciones al modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1893" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1893" />
-            <source>Cut</source>
-            <translation>Cortar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1905" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1905" />
-            <source>Paste</source>
-            <translation>Pegar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1909" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1909" />
-            <source>Select All</source>
-            <translation>Seleccionar todo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1979" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1979" />
-            <source>Send message</source>
-            <translation>Enviar mensaje</translation>
-        </message>
-        <message>
-            <location filename="../qml/ChatView.qml" line="1980" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml"
-                line="1980" />
-            <source>Sends the message/prompt contained in textfield to the model</source>
-            <translation>Envía el mensaje/indicación contenido en el campo de texto al modelo</translation>
-        </message>
-    </context>
-    <context>
-        <name>CollectionsDrawer</name>
-        <message>
-            <location filename="../qml/CollectionsDrawer.qml" line="72" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="72" />
-            <source>Warning: searching collections while indexing can return incomplete results</source>
-            <translation>Advertencia: buscar en colecciones mientras se indexan puede devolver
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="377"/>
+        <location filename="../qml/ChatView.qml" line="1769"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="377"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1769"/>
+        <source>Reload · %1</source>
+        <translation>Recargar · %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="379"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="379"/>
+        <source>Loading · %1</source>
+        <translation>Cargando · %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="708"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="708"/>
+        <source>Load · %1 (default) →</source>
+        <translation>Cargar · %1 (predeterminado) →</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="873"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="873"/>
+        <source>retrieving localdocs: %1 ...</source>
+        <translation>recuperando documentos locales: %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="874"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="874"/>
+        <source>searching localdocs: %1 ...</source>
+        <translation>buscando en documentos locales: %1 ...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1845"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
+        <source>Send a message...</source>
+        <translation>Enviar un mensaje...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1845"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
+        <source>Load a model to continue...</source>
+        <translation>Carga un modelo para continuar...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1848"/>
+        <source>Send messages/prompts to the model</source>
+        <translation>Enviar mensajes/indicaciones al modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1893"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1893"/>
+        <source>Cut</source>
+        <translation>Cortar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1905"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1905"/>
+        <source>Paste</source>
+        <translation>Pegar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1909"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1909"/>
+        <source>Select All</source>
+        <translation>Seleccionar todo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1979"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1979"/>
+        <source>Send message</source>
+        <translation>Enviar mensaje</translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1980"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1980"/>
+        <source>Sends the message/prompt contained in textfield to the model</source>
+        <translation>Envía el mensaje/indicación contenido en el campo de texto al modelo</translation>
+    </message>
+</context>
+<context>
+    <name>CollectionsDrawer</name>
+    <message>
+        <location filename="../qml/CollectionsDrawer.qml" line="72"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="72"/>
+        <source>Warning: searching collections while indexing can return incomplete results</source>
+        <translation>Advertencia: buscar en colecciones mientras se indexan puede devolver
                 resultados incompletos</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../qml/CollectionsDrawer.qml" line="89" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="89" />
-            <source>%n file(s)</source>
-            <translation>
-                <numerusform>%n archivo</numerusform>
-                <numerusform>%n archivos</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../qml/CollectionsDrawer.qml" line="89" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="89" />
-            <source>%n word(s)</source>
-            <translation>
-                <numerusform>%n palabra</numerusform>
-                <numerusform>%n palabras</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../qml/CollectionsDrawer.qml" line="105" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="105" />
-            <source>Updating</source>
-            <translation>Actualizando</translation>
-        </message>
-        <message>
-            <location filename="../qml/CollectionsDrawer.qml" line="130" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="130" />
-            <source>＋ Add Docs</source>
-            <translation>＋ Agregar documentos</translation>
-        </message>
-        <message>
-            <location filename="../qml/CollectionsDrawer.qml" line="139" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml"
-                line="139" />
-            <source>Select a collection to make it available to the chat model.</source>
-            <translation>Seleccione una colección para hacerla disponible al modelo de chat.</translation>
-        </message>
-    </context>
-    <context>
-        <name>HomeView</name>
-        <message>
-            <location filename="../qml/HomeView.qml" line="49" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="49" />
-            <source>Welcome to GPT4All</source>
-            <translation>Bienvenido a GPT4All</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="56" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="56" />
-            <source>The privacy-first LLM chat application</source>
-            <translation>La aplicación de chat LLM que prioriza la privacidad</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="66" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="66" />
-            <source>Start chatting</source>
-            <translation>Comenzar a chatear</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="81" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="81" />
-            <source>Start Chatting</source>
-            <translation>Iniciar chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="82" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="82" />
-            <source>Chat with any LLM</source>
-            <translation>Chatear con cualquier LLM</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="92" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="92" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="93" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="93" />
-            <source>Chat with your local files</source>
-            <translation>Chatear con tus archivos locales</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="103" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="103" />
-            <source>Find Models</source>
-            <translation>Buscar modelos</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="104" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="104" />
-            <source>Explore and download models</source>
-            <translation>Explorar y descargar modelos</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="190" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="190" />
-            <source>Latest news</source>
-            <translation>Últimas noticias</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="191" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="191" />
-            <source>Latest news from GPT4All</source>
-            <translation>Últimas noticias de GPT4All</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="222" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="222" />
-            <source>Release Notes</source>
-            <translation>Notas de la versión</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="228" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="228" />
-            <source>Documentation</source>
-            <translation>Documentación</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="234" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="234" />
-            <source>Discord</source>
-            <translation>Discord</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="240" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="240" />
-            <source>X (Twitter)</source>
-            <translation>X (Twitter)</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="246" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="246" />
-            <source>Github</source>
-            <translation>Github</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="257" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="257" />
-            <source>GPT4All.io</source>
-            <translation>GPT4All.io</translation>
-        </message>
-        <message>
-            <location filename="../qml/HomeView.qml" line="282" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml"
-                line="282" />
-            <source>Subscribe to Newsletter</source>
-            <translation>Suscribirse al boletín</translation>
-        </message>
-    </context>
-    <context>
-        <name>LocalDocsSettings</name>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="19" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="19" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="29" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="29" />
-            <source>LocalDocs Settings</source>
-            <translation>Configuración de DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="38" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="38" />
-            <source>Indexing</source>
-            <translation>Indexación</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="51" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="51" />
-            <source>Allowed File Extensions</source>
-            <translation>Extensiones de archivo permitidas</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="52" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="52" />
-            <source>Comma-separated list. LocalDocs will only attempt to process files with these
+    </message>
+    <message numerus="yes">
+        <location filename="../qml/CollectionsDrawer.qml" line="89"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="89"/>
+        <source>%n file(s)</source>
+        <translation>
+            <numerusform>%n archivo</numerusform>
+            <numerusform>%n archivos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../qml/CollectionsDrawer.qml" line="89"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="89"/>
+        <source>%n word(s)</source>
+        <translation>
+            <numerusform>%n palabra</numerusform>
+            <numerusform>%n palabras</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../qml/CollectionsDrawer.qml" line="105"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="105"/>
+        <source>Updating</source>
+        <translation>Actualizando</translation>
+    </message>
+    <message>
+        <location filename="../qml/CollectionsDrawer.qml" line="130"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="130"/>
+        <source>＋ Add Docs</source>
+        <translation>＋ Agregar documentos</translation>
+    </message>
+    <message>
+        <location filename="../qml/CollectionsDrawer.qml" line="139"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="139"/>
+        <source>Select a collection to make it available to the chat model.</source>
+        <translation>Seleccione una colección para hacerla disponible al modelo de chat.</translation>
+    </message>
+</context>
+<context>
+    <name>HomeView</name>
+    <message>
+        <location filename="../qml/HomeView.qml" line="49"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="49"/>
+        <source>Welcome to GPT4All</source>
+        <translation>Bienvenido a GPT4All</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="56"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="56"/>
+        <source>The privacy-first LLM chat application</source>
+        <translation>La aplicación de chat LLM que prioriza la privacidad</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="66"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="66"/>
+        <source>Start chatting</source>
+        <translation>Comenzar a chatear</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="81"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="81"/>
+        <source>Start Chatting</source>
+        <translation>Iniciar chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="82"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="82"/>
+        <source>Chat with any LLM</source>
+        <translation>Chatear con cualquier LLM</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="92"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="92"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="93"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="93"/>
+        <source>Chat with your local files</source>
+        <translation>Chatear con tus archivos locales</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="103"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="103"/>
+        <source>Find Models</source>
+        <translation>Buscar modelos</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="104"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="104"/>
+        <source>Explore and download models</source>
+        <translation>Explorar y descargar modelos</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="190"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="190"/>
+        <source>Latest news</source>
+        <translation>Últimas noticias</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="191"/>
+        <source>Latest news from GPT4All</source>
+        <translation>Últimas noticias de GPT4All</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="222"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="222"/>
+        <source>Release Notes</source>
+        <translation>Notas de la versión</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="228"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="228"/>
+        <source>Documentation</source>
+        <translation>Documentación</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="234"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="234"/>
+        <source>Discord</source>
+        <translation>Discord</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="240"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="240"/>
+        <source>X (Twitter)</source>
+        <translation>X (Twitter)</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="246"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="246"/>
+        <source>Github</source>
+        <translation>Github</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="257"/>
+        <source>GPT4All.io</source>
+        <translation>GPT4All.io</translation>
+    </message>
+    <message>
+        <location filename="../qml/HomeView.qml" line="282"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="282"/>
+        <source>Subscribe to Newsletter</source>
+        <translation>Suscribirse al boletín</translation>
+    </message>
+</context>
+<context>
+    <name>LocalDocsSettings</name>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="19"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="19"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="29"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="29"/>
+        <source>LocalDocs Settings</source>
+        <translation>Configuración de DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="38"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="38"/>
+        <source>Indexing</source>
+        <translation>Indexación</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="51"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="51"/>
+        <source>Allowed File Extensions</source>
+        <translation>Extensiones de archivo permitidas</translation>
+    </message>
+    <message>
+        <source>Comma-separated list. LocalDocs will only attempt to process files with these
                 extensions.</source>
-            <translation>Lista separada por comas. DocumentosLocales solo intentará procesar
+        <translation type="vanished">Lista separada por comas. DocumentosLocales solo intentará procesar
                 archivos con estas extensiones.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="100" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="100" />
-            <source>Embedding</source>
-            <translation>Incrustación</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="112" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="112" />
-            <source>Use Nomic Embed API</source>
-            <translation>Usar API de incrustación Nomic</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="113" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="113" />
-            <source>Embed documents using the fast Nomic API instead of a private local model.
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="100"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="100"/>
+        <source>Embedding</source>
+        <translation>Incrustación</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="112"/>
+        <source>Use Nomic Embed API</source>
+        <translation>Usar API de incrustación Nomic</translation>
+    </message>
+    <message>
+        <source>Embed documents using the fast Nomic API instead of a private local model.
                 Requires restart.</source>
-            <translation>Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
+        <translation type="vanished">Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
                 local privado. Requiere reinicio.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="130" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="130" />
-            <source>Nomic API Key</source>
-            <translation>Clave API de Nomic</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="131" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="131" />
-            <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="130"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="130"/>
+        <source>Nomic API Key</source>
+        <translation>Clave API de Nomic</translation>
+    </message>
+    <message>
+        <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a
                 href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;.
                 Requires restart.</source>
-            <translation>Clave API para usar con Nomic Embed. Obtén una en la &lt;a
+        <translation type="vanished">Clave API para usar con Nomic Embed. Obtén una en la &lt;a
                 href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;página de claves API&lt;/a&gt;
                 de Atlas. Requiere reinicio.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="165" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="165" />
-            <source>Embeddings Device</source>
-            <translation>Dispositivo de incrustaciones</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="166" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="166" />
-            <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="165"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="165"/>
+        <source>Embeddings Device</source>
+        <translation>Dispositivo de incrustaciones</translation>
+    </message>
+    <message>
+        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires
                 restart.</source>
-            <translation>El dispositivo de cómputo utilizado para las incrustaciones.
+        <translation type="vanished">El dispositivo de cómputo utilizado para las incrustaciones.
                 &quot;Auto&quot; usa la CPU. Requiere reinicio.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="202" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="202" />
-            <source>Display</source>
-            <translation>Visualización</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="215" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="215" />
-            <source>Show Sources</source>
-            <translation>Mostrar fuentes</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="216" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="216" />
-            <source>Display the sources used for each response.</source>
-            <translation>Mostrar las fuentes utilizadas para cada respuesta.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="233" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="233" />
-            <source>Advanced</source>
-            <translation>Avanzado</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="249" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="249" />
-            <source>Warning: Advanced usage only.</source>
-            <translation>Advertencia: Solo para uso avanzado.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="250" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="250" />
-            <source>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="52"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="52"/>
+        <source>Comma-separated list. LocalDocs will only attempt to process files with these extensions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="113"/>
+        <source>Embed documents using the fast Nomic API instead of a private local model. Requires restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="131"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="131"/>
+        <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;. Requires restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
+        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <source>Display</source>
+        <translation>Visualización</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <source>Show Sources</source>
+        <translation>Mostrar fuentes</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <source>Display the sources used for each response.</source>
+        <translation>Mostrar las fuentes utilizadas para cada respuesta.</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <source>Advanced</source>
+        <translation>Avanzado</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <source>Warning: Advanced usage only.</source>
+        <translation>Advertencia: Solo para uso avanzado.</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
                 Values too large may cause localdocs failure, extremely slow responses or
                 failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to
                 the model&apos;s context window. More info &lt;a
                 href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
-            <translation>
+        <translation type="vanished">
                 Valores demasiado grandes pueden causar fallos en documentos locales,
                 respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N
                 caracteres x N fragmentos} se agregan a la ventana de contexto del modelo. Más
                 información &lt;a
                 href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="258" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="258" />
-            <source>Document snippet size (characters)</source>
-            <translation>Tamaño del fragmento de documento (caracteres)</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="259" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="259" />
-            <source>Number of characters per document snippet. Larger numbers increase likelihood of
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <source>Document snippet size (characters)</source>
+        <translation>Tamaño del fragmento de documento (caracteres)</translation>
+    </message>
+    <message>
+        <source>Number of characters per document snippet. Larger numbers increase likelihood of
                 factual responses, but also result in slower generation.</source>
-            <translation>Número de caracteres por fragmento de documento. Números más grandes
+        <translation type="vanished">Número de caracteres por fragmento de documento. Números más grandes
                 aumentan la probabilidad de respuestas fácticas, pero también resultan en una
                 generación más lenta.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="284" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="284" />
-            <source>Max document snippets per prompt</source>
-            <translation>Máximo de fragmentos de documento por indicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsSettings.qml" line="285" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml"
-                line="285" />
-            <source>Max best N matches of retrieved document snippets to add to the context for
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <source>Max document snippets per prompt</source>
+        <translation>Máximo de fragmentos de documento por indicación</translation>
+    </message>
+    <message>
+        <source>Max best N matches of retrieved document snippets to add to the context for
                 prompt. Larger numbers increase likelihood of factual responses, but also result in
                 slower generation.</source>
-            <translation>Máximo de los mejores N coincidencias de fragmentos de documento
+        <translation type="vanished">Máximo de los mejores N coincidencias de fragmentos de documento
                 recuperados para agregar al contexto de la indicación. Números más grandes aumentan
                 la probabilidad de respuestas fácticas, pero también resultan en una generación más
                 lenta.</translation>
-        </message>
-    </context>
-    <context>
-        <name>LocalDocsView</name>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="52" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="52" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="58" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="58" />
-            <source>Chat with your local files</source>
-            <translation>Chatea con tus archivos locales</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="71" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="71" />
-            <source>＋ Add Collection</source>
-            <translation>＋ Agregar colección</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="86" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="86" />
-            <source>ERROR: The LocalDocs database is not valid.</source>
-            <translation>ERROR: La base de datos de DocumentosLocales no es válida.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="104" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="104" />
-            <source>No Collections Installed</source>
-            <translation>No hay colecciones instaladas</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="113" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="113" />
-            <source>Install a collection of local documents to get started using this feature</source>
-            <translation>Instala una colección de documentos locales para comenzar a usar esta
+    </message>
+</context>
+<context>
+    <name>LocalDocsView</name>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="52"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="52"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="58"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="58"/>
+        <source>Chat with your local files</source>
+        <translation>Chatea con tus archivos locales</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="71"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="71"/>
+        <source>＋ Add Collection</source>
+        <translation>＋ Agregar colección</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="86"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="86"/>
+        <source>ERROR: The LocalDocs database is not valid.</source>
+        <translation>ERROR: La base de datos de DocumentosLocales no es válida.</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="104"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="104"/>
+        <source>No Collections Installed</source>
+        <translation>No hay colecciones instaladas</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="113"/>
+        <source>Install a collection of local documents to get started using this feature</source>
+        <translation>Instala una colección de documentos locales para comenzar a usar esta
                 función</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="124" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="124" />
-            <source>＋ Add Doc Collection</source>
-            <translation>＋ Agregar colección de documentos</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="129" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="129" />
-            <source>Shows the add model view</source>
-            <translation>Muestra la vista de agregar modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="226" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="226" />
-            <source>Indexing progressBar</source>
-            <translation>Barra de progreso de indexación</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="227" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="227" />
-            <source>Shows the progress made in the indexing</source>
-            <translation>Muestra el progreso realizado en la indexación</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="252" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="252" />
-            <source>ERROR</source>
-            <translation>ERROR</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="256" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="256" />
-            <source>INDEXING</source>
-            <translation>INDEXANDO</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="260" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="260" />
-            <source>EMBEDDING</source>
-            <translation>INCRUSTANDO</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="263" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="263" />
-            <source>REQUIRES UPDATE</source>
-            <translation>REQUIERE ACTUALIZACIÓN</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="266" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="266" />
-            <source>READY</source>
-            <translation>LISTO</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="268" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="268" />
-            <source>INSTALLING</source>
-            <translation>INSTALANDO</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="295" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="295" />
-            <source>Indexing in progress</source>
-            <translation>Indexación en progreso</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="298" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="298" />
-            <source>Embedding in progress</source>
-            <translation>Incrustación en progreso</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="301" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="301" />
-            <source>This collection requires an update after version change</source>
-            <translation>Esta colección requiere una actualización después del cambio de versión</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="304" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="304" />
-            <source>Automatically reindexes upon changes to the folder</source>
-            <translation>Reindexación automática al cambiar la carpeta</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="306" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="306" />
-            <source>Installation in progress</source>
-            <translation>Instalación en progreso</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="320" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="320" />
-            <source>%</source>
-            <translation>%</translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../qml/LocalDocsView.qml" line="332" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="332" />
-            <source>%n file(s)</source>
-            <translation>
-                <numerusform>%n archivo</numerusform>
-                <numerusform>%n archivos</numerusform>
-            </translation>
-        </message>
-        <message numerus="yes">
-            <location filename="../qml/LocalDocsView.qml" line="332" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="332" />
-            <source>%n word(s)</source>
-            <translation>
-                <numerusform>%n palabra</numerusform>
-                <numerusform>%n palabras</numerusform>
-            </translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="403" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="403" />
-            <source>Remove</source>
-            <translation>Eliminar</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="415" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="415" />
-            <source>Rebuild</source>
-            <translation>Reconstruir</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="418" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="418" />
-            <source>Reindex this folder from scratch. This is slow and usually not needed.</source>
-            <translation>Reindexar esta carpeta desde cero. Esto es lento y generalmente no es
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="124"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="124"/>
+        <source>＋ Add Doc Collection</source>
+        <translation>＋ Agregar colección de documentos</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="129"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="129"/>
+        <source>Shows the add model view</source>
+        <translation>Muestra la vista de agregar modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="226"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="226"/>
+        <source>Indexing progressBar</source>
+        <translation>Barra de progreso de indexación</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="227"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="227"/>
+        <source>Shows the progress made in the indexing</source>
+        <translation>Muestra el progreso realizado en la indexación</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="252"/>
+        <source>ERROR</source>
+        <translation>ERROR</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="256"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="256"/>
+        <source>INDEXING</source>
+        <translation>INDEXANDO</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="260"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="260"/>
+        <source>EMBEDDING</source>
+        <translation>INCRUSTANDO</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="263"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="263"/>
+        <source>REQUIRES UPDATE</source>
+        <translation>REQUIERE ACTUALIZACIÓN</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="266"/>
+        <source>READY</source>
+        <translation>LISTO</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="268"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="268"/>
+        <source>INSTALLING</source>
+        <translation>INSTALANDO</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="295"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="295"/>
+        <source>Indexing in progress</source>
+        <translation>Indexación en progreso</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="298"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="298"/>
+        <source>Embedding in progress</source>
+        <translation>Incrustación en progreso</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="301"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="301"/>
+        <source>This collection requires an update after version change</source>
+        <translation>Esta colección requiere una actualización después del cambio de versión</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="304"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="304"/>
+        <source>Automatically reindexes upon changes to the folder</source>
+        <translation>Reindexación automática al cambiar la carpeta</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="306"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="306"/>
+        <source>Installation in progress</source>
+        <translation>Instalación en progreso</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="320"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="320"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../qml/LocalDocsView.qml" line="332"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="332"/>
+        <source>%n file(s)</source>
+        <translation>
+            <numerusform>%n archivo</numerusform>
+            <numerusform>%n archivos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../qml/LocalDocsView.qml" line="332"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="332"/>
+        <source>%n word(s)</source>
+        <translation>
+            <numerusform>%n palabra</numerusform>
+            <numerusform>%n palabras</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="403"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="403"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="415"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="415"/>
+        <source>Rebuild</source>
+        <translation>Reconstruir</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="418"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="418"/>
+        <source>Reindex this folder from scratch. This is slow and usually not needed.</source>
+        <translation>Reindexar esta carpeta desde cero. Esto es lento y generalmente no es
                 necesario.</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="425" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="425" />
-            <source>Update</source>
-            <translation>Actualizar</translation>
-        </message>
-        <message>
-            <location filename="../qml/LocalDocsView.qml" line="428" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml"
-                line="428" />
-            <source>Update the collection to the new version. This is a slow operation.</source>
-            <translation>Actualizar la colección a la nueva versión. Esta es una operación lenta.</translation>
-        </message>
-    </context>
-    <context>
-        <name>ModelList</name>
-        <message>
-            <location filename="../modellist.cpp" line="1537" />
-            <source>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="425"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="425"/>
+        <source>Update</source>
+        <translation>Actualizar</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsView.qml" line="428"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="428"/>
+        <source>Update the collection to the new version. This is a slow operation.</source>
+        <translation>Actualizar la colección a la nueva versión. Esta es una operación lenta.</translation>
+    </message>
+</context>
+<context>
+    <name>ModelList</name>
+    <message>
+        <source>
                 &lt;ul&gt;&lt;li&gt;Requires personal OpenAI API
                 key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
                 OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
                 disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
                 OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
                 href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
-            <translation>
+        <translation type="vanished">
                 &lt;ul&gt;&lt;li&gt;Requiere clave API personal de
                 OpenAI.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a
                 OpenAI!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el
                 disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con
                 OpenAI&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a
                 href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aquí.&lt;/a&gt;&lt;/li&gt;</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1556" />
-            <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
+    </message>
+    <message>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
                 %1</source>
-            <translation>&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
+        <translation type="vanished">&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
                 OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1584" />
-            <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt; %1 %2</source>
-            <translation>&lt;strong&gt;Modelo ChatGPT GPT-4 de OpenAI&lt;/strong&gt;&lt;br&gt; %1 %2</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1615" />
-            <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt; %1</source>
-            <translation>&lt;strong&gt;Modelo Mistral Tiny&lt;/strong&gt;&lt;br&gt; %1</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1640" />
-            <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt; %1</source>
-            <translation>&lt;strong&gt;Modelo Mistral Small&lt;/strong&gt;&lt;br&gt; %1</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1666" />
-            <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt; %1</source>
-            <translation>&lt;strong&gt;Modelo Mistral Medium&lt;/strong&gt;&lt;br&gt; %1</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1569" />
-            <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1537"/>
+        <source>&lt;ul&gt;&lt;li&gt;Requires personal OpenAI API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1556"/>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1569"/>
+        <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does not guarantee API key access. Contact OpenAI for more info.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1584"/>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt; %1 %2</source>
+        <translation>&lt;strong&gt;Modelo ChatGPT GPT-4 de OpenAI&lt;/strong&gt;&lt;br&gt; %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1596"/>
+        <source>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1615"/>
+        <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation>&lt;strong&gt;Modelo Mistral Tiny&lt;/strong&gt;&lt;br&gt; %1</translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1640"/>
+        <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation>&lt;strong&gt;Modelo Mistral Small&lt;/strong&gt;&lt;br&gt; %1</translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1666"/>
+        <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation>&lt;strong&gt;Modelo Mistral Medium&lt;/strong&gt;&lt;br&gt; %1</translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="2081"/>
+        <source>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does
                 not guarantee API key access. Contact OpenAI for more info.</source>
-            <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Aunque pague a OpenAI por ChatGPT-4, esto no
+        <translation type="vanished">&lt;br&gt;&lt;br&gt;&lt;i&gt;* Aunque pague a OpenAI por ChatGPT-4, esto no
                 garantiza el acceso a la clave API. Contacte a OpenAI para más información.</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="1596" />
-            <source>
+    </message>
+    <message>
+        <source>
                 &lt;ul&gt;&lt;li&gt;Requires personal Mistral API
                 key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
                 Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
                 disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
                 Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
                 href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
-            <translation>
+        <translation type="vanished">
                 &lt;ul&gt;&lt;li&gt;Requiere clave API personal de
                 Mistral.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a
                 Mistral!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el
                 disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con
                 Mistral&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a
                 href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aquí&lt;/a&gt;.&lt;/li&gt;</translation>
-        </message>
-        <message>
-            <location filename="../modellist.cpp" line="2081" />
-            <source>&lt;strong&gt;Created by
+    </message>
+    <message>
+        <source>&lt;strong&gt;Created by
                 %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model
                 has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found
                 &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
-            <translation>&lt;strong&gt;Creado por
+        <translation type="vanished">&lt;strong&gt;Creado por
                 %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicado el %2.&lt;li&gt;Este
                 modelo tiene %3 me gusta.&lt;li&gt;Este modelo tiene %4 descargas.&lt;li&gt;Puede
                 encontrar más información &lt;a
                 href=&quot;https://huggingface.co/%5&quot;&gt;aquí.&lt;/a&gt;&lt;/ul&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>ModelSettings</name>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="14" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="14" />
-            <source>Model</source>
-            <translation>Modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="33" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="33" />
-            <source>Model Settings</source>
-            <translation>Configuración del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="83" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="83" />
-            <source>Clone</source>
-            <translation>Clonar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="93" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="93" />
-            <source>Remove</source>
-            <translation>Eliminar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="107" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="107" />
-            <source>Name</source>
-            <translation>Nombre</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="140" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="140" />
-            <source>Model File</source>
-            <translation>Archivo del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="158" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="158" />
-            <source>System Prompt</source>
-            <translation>Indicación del sistema</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="159" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="159" />
-            <source>Prefixed at the beginning of every conversation. Must contain the appropriate
+    </message>
+</context>
+<context>
+    <name>ModelSettings</name>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="14"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="14"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="33"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="33"/>
+        <source>Model Settings</source>
+        <translation>Configuración del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="83"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="83"/>
+        <source>Clone</source>
+        <translation>Clonar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="93"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="93"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="107"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="107"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="140"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="140"/>
+        <source>Model File</source>
+        <translation>Archivo del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="158"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="158"/>
+        <source>System Prompt</source>
+        <translation>Indicación del sistema</translation>
+    </message>
+    <message>
+        <source>Prefixed at the beginning of every conversation. Must contain the appropriate
                 framing tokens.</source>
-            <translation>Prefijado al inicio de cada conversación. Debe contener los tokens de
+        <translation type="vanished">Prefijado al inicio de cada conversación. Debe contener los tokens de
                 encuadre apropiados.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="205" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="205" />
-            <source>Prompt Template</source>
-            <translation>Plantilla de indicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="206" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="206" />
-            <source>The template that wraps every prompt.</source>
-            <translation>La plantilla que envuelve cada indicación.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="210" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="210" />
-            <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="205"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="205"/>
+        <source>Prompt Template</source>
+        <translation>Plantilla de indicación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="206"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="206"/>
+        <source>The template that wraps every prompt.</source>
+        <translation>La plantilla que envuelve cada indicación.</translation>
+    </message>
+    <message>
+        <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s
                 input.</source>
-            <translation>Debe contener la cadena &quot;%1&quot; para ser reemplazada con la entrada
+        <translation type="vanished">Debe contener la cadena &quot;%1&quot; para ser reemplazada con la entrada
                 del usuario.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="255" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="255" />
-            <source>Chat Name Prompt</source>
-            <translation>Indicación para el nombre del chat</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="256" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="256" />
-            <source>Prompt used to automatically generate chat names.</source>
-            <translation>Indicación utilizada para generar automáticamente nombres de chat.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="283" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="283" />
-            <source>Suggested FollowUp Prompt</source>
-            <translation>Indicación de seguimiento sugerida</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="284" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="284" />
-            <source>Prompt used to generate suggested follow-up questions.</source>
-            <translation>Indicación utilizada para generar preguntas de seguimiento sugeridas.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="322" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="322" />
-            <source>Context Length</source>
-            <translation>Longitud del contexto</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="323" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="323" />
-            <source>Number of input and output tokens the model sees.</source>
-            <translation>Número de tokens de entrada y salida que el modelo ve.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="344" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="344" />
-            <source>Maximum combined prompt/response tokens before information is lost.
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="255"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="255"/>
+        <source>Chat Name Prompt</source>
+        <translation>Indicación para el nombre del chat</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="256"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="256"/>
+        <source>Prompt used to automatically generate chat names.</source>
+        <translation>Indicación utilizada para generar automáticamente nombres de chat.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="283"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="283"/>
+        <source>Suggested FollowUp Prompt</source>
+        <translation>Indicación de seguimiento sugerida</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="284"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="284"/>
+        <source>Prompt used to generate suggested follow-up questions.</source>
+        <translation>Indicación utilizada para generar preguntas de seguimiento sugeridas.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="322"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="322"/>
+        <source>Context Length</source>
+        <translation>Longitud del contexto</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="323"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="323"/>
+        <source>Number of input and output tokens the model sees.</source>
+        <translation>Número de tokens de entrada y salida que el modelo ve.</translation>
+    </message>
+    <message>
+        <source>Maximum combined prompt/response tokens before information is lost.
                 Using more context than the model was trained on will yield poor results.
                 NOTE: Does not take effect until you reload the model.</source>
-            <translation>Máximo de tokens combinados de indicación/respuesta antes de que se pierda
+        <translation type="vanished">Máximo de tokens combinados de indicación/respuesta antes de que se pierda
                 información.
                 Usar más contexto del que se utilizó para entrenar el modelo producirá resultados
                 pobres.
                 NOTA: No tiene efecto hasta que recargues el modelo.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="382" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="382" />
-            <source>Temperature</source>
-            <translation>Temperatura</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="383" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="383" />
-            <source>Randomness of model output. Higher -&gt; more variation.</source>
-            <translation>Aleatoriedad de la salida del modelo. Mayor -&gt; más variación.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="394" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="394" />
-            <source>Temperature increases the chances of choosing less likely tokens.
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="382"/>
+        <source>Temperature</source>
+        <translation>Temperatura</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="383"/>
+        <source>Randomness of model output. Higher -&gt; more variation.</source>
+        <translation>Aleatoriedad de la salida del modelo. Mayor -&gt; más variación.</translation>
+    </message>
+    <message>
+        <source>Temperature increases the chances of choosing less likely tokens.
                 NOTE: Higher temperature gives more creative but less predictable outputs.</source>
-            <translation>La temperatura aumenta las probabilidades de elegir tokens menos probables.
+        <translation type="vanished">La temperatura aumenta las probabilidades de elegir tokens menos probables.
                 NOTA: Una temperatura más alta da resultados más creativos pero menos predecibles.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="428" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="428" />
-            <source>Top-P</source>
-            <translation>Top-P</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="429" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="429" />
-            <source>Nucleus Sampling factor. Lower -&gt; more predicatable.</source>
-            <translation>Factor de muestreo de núcleo. Menor -&gt; más predecible.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="439" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="439" />
-            <source>Only the most likely tokens up to a total probability of top_p can be chosen.
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="428"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="428"/>
+        <source>Top-P</source>
+        <translation>Top-P</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="429"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="429"/>
+        <source>Nucleus Sampling factor. Lower -&gt; more predicatable.</source>
+        <translation>Factor de muestreo de núcleo. Menor -&gt; más predecible.</translation>
+    </message>
+    <message>
+        <source>Only the most likely tokens up to a total probability of top_p can be chosen.
                 NOTE: Prevents choosing highly unlikely tokens.</source>
-            <translation>Solo se pueden elegir los tokens más probables hasta una probabilidad total
+        <translation type="vanished">Solo se pueden elegir los tokens más probables hasta una probabilidad total
                 de top_p.
                 NOTA: Evita elegir tokens altamente improbables.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="473" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="473" />
-            <source>Min-P</source>
-            <translation>Min-P</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="474" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="474" />
-            <source>Minimum token probability. Higher -&gt; more predictable.</source>
-            <translation>Probabilidad mínima del token. Mayor -&gt; más predecible.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="484" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="484" />
-            <source>Sets the minimum relative probability for a token to be considered.</source>
-            <translation>Establece la probabilidad relativa mínima para que un token sea
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="159"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="159"/>
+        <source>Prefixed at the beginning of every conversation. Must contain the appropriate framing tokens.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="210"/>
+        <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s input.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="344"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="344"/>
+        <source>Maximum combined prompt/response tokens before information is lost.
+Using more context than the model was trained on will yield poor results.
+NOTE: Does not take effect until you reload the model.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="394"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="394"/>
+        <source>Temperature increases the chances of choosing less likely tokens.
+NOTE: Higher temperature gives more creative but less predictable outputs.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="439"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="439"/>
+        <source>Only the most likely tokens up to a total probability of top_p can be chosen.
+NOTE: Prevents choosing highly unlikely tokens.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="473"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="473"/>
+        <source>Min-P</source>
+        <translation>Min-P</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="474"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="474"/>
+        <source>Minimum token probability. Higher -&gt; more predictable.</source>
+        <translation>Probabilidad mínima del token. Mayor -&gt; más predecible.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="484"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="484"/>
+        <source>Sets the minimum relative probability for a token to be considered.</source>
+        <translation>Establece la probabilidad relativa mínima para que un token sea
                 considerado.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="520" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="520" />
-            <source>Top-K</source>
-            <translation>Top-K</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="521" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="521" />
-            <source>Size of selection pool for tokens.</source>
-            <translation>Tamaño del grupo de selección para tokens.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="532" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="532" />
-            <source>Only the top K most likely tokens will be chosen from.</source>
-            <translation>Solo se elegirán los K tokens más probables.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="567" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="567" />
-            <source>Max Length</source>
-            <translation>Longitud máxima</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="568" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="568" />
-            <source>Maximum response length, in tokens.</source>
-            <translation>Longitud máxima de respuesta, en tokens.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="613" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="613" />
-            <source>Prompt Batch Size</source>
-            <translation>Tamaño del lote de indicaciones</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="614" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="614" />
-            <source>The batch size used for prompt processing.</source>
-            <translation>El tamaño del lote utilizado para el procesamiento de indicaciones.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="625" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="625" />
-            <source>Amount of prompt tokens to process at once.
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="520"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="520"/>
+        <source>Top-K</source>
+        <translation>Top-K</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="521"/>
+        <source>Size of selection pool for tokens.</source>
+        <translation>Tamaño del grupo de selección para tokens.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="532"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="532"/>
+        <source>Only the top K most likely tokens will be chosen from.</source>
+        <translation>Solo se elegirán los K tokens más probables.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="567"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="567"/>
+        <source>Max Length</source>
+        <translation>Longitud máxima</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="568"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="568"/>
+        <source>Maximum response length, in tokens.</source>
+        <translation>Longitud máxima de respuesta, en tokens.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="613"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="613"/>
+        <source>Prompt Batch Size</source>
+        <translation>Tamaño del lote de indicaciones</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="614"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="614"/>
+        <source>The batch size used for prompt processing.</source>
+        <translation>El tamaño del lote utilizado para el procesamiento de indicaciones.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="625"/>
+        <source>Amount of prompt tokens to process at once.
+NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="763"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="763"/>
+        <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of VRAM while loading this model.
+Lower values increase CPU load and RAM usage, and make inference slower.
+NOTE: Does not take effect until you reload the model.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amount of prompt tokens to process at once.
                 NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
-            <translation>Cantidad de tokens de indicación para procesar a la vez.
+        <translation type="vanished">Cantidad de tokens de indicación para procesar a la vez.
                 NOTA: Valores más altos pueden acelerar la lectura de indicaciones pero usarán más
                 RAM.</translation>
-        </message>
-        <message>
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="660" />
-            <source>Repeat Penalty</source>
-            <translation>Penalización por repetición</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="661" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="661" />
-            <source>Repetition penalty factor. Set to 1 to disable.</source>
-            <translation>Factor de penalización por repetición. Establecer a 1 para desactivar.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="705" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="705" />
-            <source>Repeat Penalty Tokens</source>
-            <translation>Tokens de penalización por repetición</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="706" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="706" />
-            <source>Number of previous tokens used for penalty.</source>
-            <translation>Número de tokens anteriores utilizados para la penalización.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="751" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="751" />
-            <source>GPU Layers</source>
-            <translation>Capas de GPU</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="752" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="752" />
-            <source>Number of model layers to load into VRAM.</source>
-            <translation>Número de capas del modelo a cargar en la VRAM.</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelSettings.qml" line="763" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml"
-                line="763" />
-            <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="660"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="660"/>
+        <source>Repeat Penalty</source>
+        <translation>Penalización por repetición</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="661"/>
+        <source>Repetition penalty factor. Set to 1 to disable.</source>
+        <translation>Factor de penalización por repetición. Establecer a 1 para desactivar.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="705"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="705"/>
+        <source>Repeat Penalty Tokens</source>
+        <translation>Tokens de penalización por repetición</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="706"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="706"/>
+        <source>Number of previous tokens used for penalty.</source>
+        <translation>Número de tokens anteriores utilizados para la penalización.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="751"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="751"/>
+        <source>GPU Layers</source>
+        <translation>Capas de GPU</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="752"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="752"/>
+        <source>Number of model layers to load into VRAM.</source>
+        <translation>Número de capas del modelo a cargar en la VRAM.</translation>
+    </message>
+    <message>
+        <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of
                 VRAM while loading this model.
                 Lower values increase CPU load and RAM usage, and make inference slower.
                 NOTE: Does not take effect until you reload the model.</source>
-            <translation>Cuántas capas del modelo cargar en la VRAM. Disminuye esto si GPT4All se
+        <translation type="vanished">Cuántas capas del modelo cargar en la VRAM. Disminuye esto si GPT4All se
                 queda sin VRAM al cargar este modelo.
                 Valores más bajos aumentan la carga de CPU y el uso de RAM, y hacen la inferencia
                 más lenta.
                 NOTA: No tiene efecto hasta que recargues el modelo.</translation>
-        </message>
-    </context>
-    <context>
-        <name>ModelsView</name>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="36" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="36" />
-            <source>No Models Installed</source>
-            <translation>No hay modelos instalados</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="45" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="45" />
-            <source>Install a model to get started using GPT4All</source>
-            <translation>Instala un modelo para empezar a usar GPT4All</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="56" />
-            <location filename="../qml/ModelsView.qml" line="98" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="56" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="98" />
-            <source>＋ Add Model</source>
-            <translation>＋ Agregar modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="61" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="61" />
-            <source>Shows the add model view</source>
-            <translation>Muestra la vista de agregar modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="79" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="79" />
-            <source>Installed Models</source>
-            <translation>Modelos instalados</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="85" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="85" />
-            <source>Locally installed chat models</source>
-            <translation>Modelos de chat instalados localmente</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="143" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="143" />
-            <source>Model file</source>
-            <translation>Archivo del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="144" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="144" />
-            <source>Model file to be downloaded</source>
-            <translation>Archivo del modelo a descargar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="166" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="166" />
-            <source>Description</source>
-            <translation>Descripción</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="167" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="167" />
-            <source>File description</source>
-            <translation>Descripción del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="192" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="192" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="192" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="192" />
-            <source>Resume</source>
-            <translation>Reanudar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="200" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="200" />
-            <source>Stop/restart/start the download</source>
-            <translation>Detener/reiniciar/iniciar la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="212" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="212" />
-            <source>Remove</source>
-            <translation>Eliminar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="219" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="219" />
-            <source>Remove model from filesystem</source>
-            <translation>Eliminar modelo del sistema de archivos</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="233" />
-            <location filename="../qml/ModelsView.qml" line="242" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="233" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="242" />
-            <source>Install</source>
-            <translation>Instalar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="243" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="243" />
-            <source>Install online model</source>
-            <translation>Instalar modelo en línea</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="253" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="253" />
-            <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+    </message>
+</context>
+<context>
+    <name>ModelsView</name>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="36"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="36"/>
+        <source>No Models Installed</source>
+        <translation>No hay modelos instalados</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="45"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="45"/>
+        <source>Install a model to get started using GPT4All</source>
+        <translation>Instala un modelo para empezar a usar GPT4All</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="56"/>
+        <location filename="../qml/ModelsView.qml" line="98"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="56"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="98"/>
+        <source>＋ Add Model</source>
+        <translation>＋ Agregar modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="61"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="61"/>
+        <source>Shows the add model view</source>
+        <translation>Muestra la vista de agregar modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="79"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="79"/>
+        <source>Installed Models</source>
+        <translation>Modelos instalados</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="85"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="85"/>
+        <source>Locally installed chat models</source>
+        <translation>Modelos de chat instalados localmente</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="143"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="143"/>
+        <source>Model file</source>
+        <translation>Archivo del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="144"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="144"/>
+        <source>Model file to be downloaded</source>
+        <translation>Archivo del modelo a descargar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="166"/>
+        <source>Description</source>
+        <translation>Descripción</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="167"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="167"/>
+        <source>File description</source>
+        <translation>Descripción del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="192"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="192"/>
+        <source>Resume</source>
+        <translation>Reanudar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="200"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="200"/>
+        <source>Stop/restart/start the download</source>
+        <translation>Detener/reiniciar/iniciar la descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="212"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="212"/>
+        <source>Remove</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="219"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="219"/>
+        <source>Remove model from filesystem</source>
+        <translation>Eliminar modelo del sistema de archivos</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="233"/>
+        <location filename="../qml/ModelsView.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="233"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="242"/>
+        <source>Install</source>
+        <translation>Instalar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="243"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="243"/>
+        <source>Install online model</source>
+        <translation>Instalar modelo en línea</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
                 href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
-            <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
                 href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="272" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="272" />
-            <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
                 hardware. Model requires more memory (%1 GB) than your system has available
                 (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-            <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado
                 para su hardware. El modelo requiere más memoria (%1 GB) de la que su sistema tiene
                 disponible (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="424" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="424" />
-            <source>%1 GB</source>
-            <translation>%1 GB</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="424" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="424" />
-            <source>?</source>
-            <translation>?</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="259" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="259" />
-            <source>Describes an error that occurred when downloading</source>
-            <translation>Describe un error que ocurrió durante la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="278" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="278" />
-            <source>Error for incompatible hardware</source>
-            <translation>Error por hardware incompatible</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="316" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="316" />
-            <source>Download progressBar</source>
-            <translation>Barra de progreso de descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="317" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="317" />
-            <source>Shows the progress made in the download</source>
-            <translation>Muestra el progreso realizado en la descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="327" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="327" />
-            <source>Download speed</source>
-            <translation>Velocidad de descarga</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="328" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="328" />
-            <source>Download speed in bytes/kilobytes/megabytes per second</source>
-            <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="345" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="345" />
-            <source>Calculating...</source>
-            <translation>Calculando...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="349" />
-            <location filename="../qml/ModelsView.qml" line="378" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="349" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="378" />
-            <source>Whether the file hash is being calculated</source>
-            <translation>Si se está calculando el hash del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="356" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="356" />
-            <source>Busy indicator</source>
-            <translation>Indicador de ocupado</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="357" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="357" />
-            <source>Displayed when the file hash is being calculated</source>
-            <translation>Se muestra cuando se está calculando el hash del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="375" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="375" />
-            <source>enter $API_KEY</source>
-            <translation>ingrese $API_KEY</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="397" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="397" />
-            <source>File size</source>
-            <translation>Tamaño del archivo</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="419" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="419" />
-            <source>RAM required</source>
-            <translation>RAM requerida</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="441" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="441" />
-            <source>Parameters</source>
-            <translation>Parámetros</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="463" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="463" />
-            <source>Quant</source>
-            <translation>Cuantificación</translation>
-        </message>
-        <message>
-            <location filename="../qml/ModelsView.qml" line="485" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml"
-                line="485" />
-            <source>Type</source>
-            <translation>Tipo</translation>
-        </message>
-    </context>
-    <context>
-        <name>MyFancyLink</name>
-        <message>
-            <location filename="../qml/MyFancyLink.qml" line="42" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml"
-                line="42" />
-            <source>Fancy link</source>
-            <translation>Enlace elegante</translation>
-        </message>
-        <message>
-            <location filename="../qml/MyFancyLink.qml" line="43" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml"
-                line="43" />
-            <source>A stylized link</source>
-            <translation>Un enlace estilizado</translation>
-        </message>
-    </context>
-    <context>
-        <name>MySettingsStack</name>
-        <message>
-            <location filename="../qml/MySettingsStack.qml" line="66" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsStack.qml"
-                line="66" />
-            <source>Please choose a directory</source>
-            <translation>Por favor, elija un directorio</translation>
-        </message>
-    </context>
-    <context>
-        <name>MySettingsTab</name>
-        <message>
-            <location filename="../qml/MySettingsTab.qml" line="62" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml"
-                line="62" />
-            <source>Restore Defaults</source>
-            <translation>Restaurar valores predeterminados</translation>
-        </message>
-        <message>
-            <location filename="../qml/MySettingsTab.qml" line="66" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml"
-                line="66" />
-            <source>Restores settings dialog to a default state</source>
-            <translation>Restaura el diálogo de configuración a su estado predeterminado</translation>
-        </message>
-    </context>
-    <context>
-        <name>NetworkDialog</name>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="39" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="39" />
-            <source>Contribute data to the GPT4All Opensource Datalake.</source>
-            <translation>Contribuir datos al Datalake de código abierto de GPT4All.</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="55" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="55" />
-            <source>By enabling this feature, you will be able to participate in the democratic
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <source>%1 GB</source>
+        <translation>%1 GB</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <source>?</source>
+        <translation>?</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="259"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="259"/>
+        <source>Describes an error that occurred when downloading</source>
+        <translation>Describe un error que ocurrió durante la descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="253"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="253"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="272"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="272"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="278"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="278"/>
+        <source>Error for incompatible hardware</source>
+        <translation>Error por hardware incompatible</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="316"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="316"/>
+        <source>Download progressBar</source>
+        <translation>Barra de progreso de descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="317"/>
+        <source>Shows the progress made in the download</source>
+        <translation>Muestra el progreso realizado en la descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="327"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="327"/>
+        <source>Download speed</source>
+        <translation>Velocidad de descarga</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="328"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="328"/>
+        <source>Download speed in bytes/kilobytes/megabytes per second</source>
+        <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="345"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="345"/>
+        <source>Calculating...</source>
+        <translation>Calculando...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="349"/>
+        <location filename="../qml/ModelsView.qml" line="378"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="349"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="378"/>
+        <source>Whether the file hash is being calculated</source>
+        <translation>Si se está calculando el hash del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="356"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="356"/>
+        <source>Busy indicator</source>
+        <translation>Indicador de ocupado</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="357"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="357"/>
+        <source>Displayed when the file hash is being calculated</source>
+        <translation>Se muestra cuando se está calculando el hash del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="375"/>
+        <source>enter $API_KEY</source>
+        <translation>ingrese $API_KEY</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="397"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="397"/>
+        <source>File size</source>
+        <translation>Tamaño del archivo</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="419"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="419"/>
+        <source>RAM required</source>
+        <translation>RAM requerida</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="441"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="441"/>
+        <source>Parameters</source>
+        <translation>Parámetros</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="463"/>
+        <source>Quant</source>
+        <translation>Cuantificación</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="485"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="485"/>
+        <source>Type</source>
+        <translation>Tipo</translation>
+    </message>
+</context>
+<context>
+    <name>MyFancyLink</name>
+    <message>
+        <location filename="../qml/MyFancyLink.qml" line="42"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml" line="42"/>
+        <source>Fancy link</source>
+        <translation>Enlace elegante</translation>
+    </message>
+    <message>
+        <location filename="../qml/MyFancyLink.qml" line="43"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MyFancyLink.qml" line="43"/>
+        <source>A stylized link</source>
+        <translation>Un enlace estilizado</translation>
+    </message>
+</context>
+<context>
+    <name>MySettingsStack</name>
+    <message>
+        <location filename="../qml/MySettingsStack.qml" line="66"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsStack.qml" line="66"/>
+        <source>Please choose a directory</source>
+        <translation>Por favor, elija un directorio</translation>
+    </message>
+</context>
+<context>
+    <name>MySettingsTab</name>
+    <message>
+        <location filename="../qml/MySettingsTab.qml" line="62"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml" line="62"/>
+        <source>Restore Defaults</source>
+        <translation>Restaurar valores predeterminados</translation>
+    </message>
+    <message>
+        <location filename="../qml/MySettingsTab.qml" line="66"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml" line="66"/>
+        <source>Restores settings dialog to a default state</source>
+        <translation>Restaura el diálogo de configuración a su estado predeterminado</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkDialog</name>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="39"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="39"/>
+        <source>Contribute data to the GPT4All Opensource Datalake.</source>
+        <translation>Contribuir datos al Datalake de código abierto de GPT4All.</translation>
+    </message>
+    <message>
+        <source>By enabling this feature, you will be able to participate in the democratic
                 process of training a large language model by contributing data for future model
                 improvements.
 
@@ -3004,7 +2533,7 @@
                 used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
                 attribution information attached to your data and you will be credited as a
                 contributor to any GPT4All model release that uses your data!</source>
-            <translation>Al habilitar esta función, podrá participar en el proceso democrático de
+        <translation type="vanished">Al habilitar esta función, podrá participar en el proceso democrático de
                 entrenamiento de un modelo de lenguaje grande contribuyendo con datos para futuras
                 mejoras del modelo.
 
@@ -3020,225 +2549,179 @@
                 utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará
                 toda la información de atribución adjunta a sus datos y se le acreditará como
                 contribuyente en cualquier lanzamiento de modelo GPT4All que utilice sus datos.</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="63" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="63" />
-            <source>Terms for opt-in</source>
-            <translation>Términos para optar por participar</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="64" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="64" />
-            <source>Describes what will happen when you opt-in</source>
-            <translation>Describe lo que sucederá cuando opte por participar</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="72" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="72" />
-            <source>Please provide a name for attribution (optional)</source>
-            <translation>Por favor, proporcione un nombre para la atribución (opcional)</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="74" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="74" />
-            <source>Attribution (optional)</source>
-            <translation>Atribución (opcional)</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="75" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="75" />
-            <source>Provide attribution</source>
-            <translation>Proporcionar atribución</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="88" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="88" />
-            <source>Enable</source>
-            <translation>Habilitar</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="89" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="89" />
-            <source>Enable opt-in</source>
-            <translation>Habilitar participación</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="93" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="93" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../qml/NetworkDialog.qml" line="94" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml"
-                line="94" />
-            <source>Cancel opt-in</source>
-            <translation>Cancelar participación</translation>
-        </message>
-    </context>
-    <context>
-        <name>NewVersionDialog</name>
-        <message>
-            <location filename="../qml/NewVersionDialog.qml" line="34" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
-                line="34" />
-            <source>New version is available</source>
-            <translation>Nueva versión disponible</translation>
-        </message>
-        <message>
-            <location filename="../qml/NewVersionDialog.qml" line="46" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
-                line="46" />
-            <source>Update</source>
-            <translation>Actualizar</translation>
-        </message>
-        <message>
-            <location filename="../qml/NewVersionDialog.qml" line="48" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml"
-                line="48" />
-            <source>Update to new version</source>
-            <translation>Actualizar a nueva versión</translation>
-        </message>
-    </context>
-    <context>
-        <name>PopupDialog</name>
-        <message>
-            <location filename="../qml/PopupDialog.qml" line="38" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
-                line="38" />
-            <source>Reveals a shortlived help balloon</source>
-            <translation>Muestra un globo de ayuda de corta duración</translation>
-        </message>
-        <message>
-            <location filename="../qml/PopupDialog.qml" line="48" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
-                line="48" />
-            <source>Busy indicator</source>
-            <translation>Indicador de ocupado</translation>
-        </message>
-        <message>
-            <location filename="../qml/PopupDialog.qml" line="49" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml"
-                line="49" />
-            <source>Displayed when the popup is showing busy</source>
-            <translation>Se muestra cuando la ventana emergente está ocupada</translation>
-        </message>
-    </context>
-    <context>
-        <name>SettingsView</name>
-        <message>
-            <location filename="../qml/SettingsView.qml" line="22" />
-            <location filename="../qml/SettingsView.qml" line="61" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="22" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="61" />
-            <source>Settings</source>
-            <translation>Configuración</translation>
-        </message>
-        <message>
-            <location filename="../qml/SettingsView.qml" line="23" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="23" />
-            <source>Contains various application settings</source>
-            <translation>Contiene varias configuraciones de la aplicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/SettingsView.qml" line="29" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="29" />
-            <source>Application</source>
-            <translation>Aplicación</translation>
-        </message>
-        <message>
-            <location filename="../qml/SettingsView.qml" line="32" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="32" />
-            <source>Model</source>
-            <translation>Modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/SettingsView.qml" line="35" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml"
-                line="35" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-    </context>
-    <context>
-        <name>StartupDialog</name>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="50" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="50" />
-            <source>Welcome!</source>
-            <translation>¡Bienvenido!</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="67" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="67" />
-            <source>### Release notes
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="55"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="55"/>
+        <source>By enabling this feature, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
+
+When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
+
+NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="63"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="63"/>
+        <source>Terms for opt-in</source>
+        <translation>Términos para optar por participar</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="64"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="64"/>
+        <source>Describes what will happen when you opt-in</source>
+        <translation>Describe lo que sucederá cuando opte por participar</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="72"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="72"/>
+        <source>Please provide a name for attribution (optional)</source>
+        <translation>Por favor, proporcione un nombre para la atribución (opcional)</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="74"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="74"/>
+        <source>Attribution (optional)</source>
+        <translation>Atribución (opcional)</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="75"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="75"/>
+        <source>Provide attribution</source>
+        <translation>Proporcionar atribución</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="88"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="88"/>
+        <source>Enable</source>
+        <translation>Habilitar</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="89"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="89"/>
+        <source>Enable opt-in</source>
+        <translation>Habilitar participación</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="93"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="93"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../qml/NetworkDialog.qml" line="94"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="94"/>
+        <source>Cancel opt-in</source>
+        <translation>Cancelar participación</translation>
+    </message>
+</context>
+<context>
+    <name>NewVersionDialog</name>
+    <message>
+        <location filename="../qml/NewVersionDialog.qml" line="34"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml" line="34"/>
+        <source>New version is available</source>
+        <translation>Nueva versión disponible</translation>
+    </message>
+    <message>
+        <location filename="../qml/NewVersionDialog.qml" line="46"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml" line="46"/>
+        <source>Update</source>
+        <translation>Actualizar</translation>
+    </message>
+    <message>
+        <location filename="../qml/NewVersionDialog.qml" line="48"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml" line="48"/>
+        <source>Update to new version</source>
+        <translation>Actualizar a nueva versión</translation>
+    </message>
+</context>
+<context>
+    <name>PopupDialog</name>
+    <message>
+        <location filename="../qml/PopupDialog.qml" line="38"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml" line="38"/>
+        <source>Reveals a shortlived help balloon</source>
+        <translation>Muestra un globo de ayuda de corta duración</translation>
+    </message>
+    <message>
+        <location filename="../qml/PopupDialog.qml" line="48"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml" line="48"/>
+        <source>Busy indicator</source>
+        <translation>Indicador de ocupado</translation>
+    </message>
+    <message>
+        <location filename="../qml/PopupDialog.qml" line="49"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml" line="49"/>
+        <source>Displayed when the popup is showing busy</source>
+        <translation>Se muestra cuando la ventana emergente está ocupada</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsView</name>
+    <message>
+        <location filename="../qml/SettingsView.qml" line="22"/>
+        <location filename="../qml/SettingsView.qml" line="61"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="22"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="61"/>
+        <source>Settings</source>
+        <translation>Configuración</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsView.qml" line="23"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="23"/>
+        <source>Contains various application settings</source>
+        <translation>Contiene varias configuraciones de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsView.qml" line="29"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="29"/>
+        <source>Application</source>
+        <translation>Aplicación</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsView.qml" line="32"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="32"/>
+        <source>Model</source>
+        <translation>Modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/SettingsView.qml" line="35"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="35"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+</context>
+<context>
+    <name>StartupDialog</name>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="50"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="50"/>
+        <source>Welcome!</source>
+        <translation>¡Bienvenido!</translation>
+    </message>
+    <message>
+        <source>### Release notes
                 %1### Contributors
                 %2</source>
-            <translation>### Notas de la versión
+        <translation type="vanished">### Notas de la versión
                 %1### Contribuidores
                 %2</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="71" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="71" />
-            <source>Release notes</source>
-            <translation>Notas de la versión</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="72" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="72" />
-            <source>Release notes for this version</source>
-            <translation>Notas de la versión para esta versión</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="87" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="87" />
-            <source>### Opt-ins for anonymous usage analytics and datalake
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="71"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="71"/>
+        <source>Release notes</source>
+        <translation>Notas de la versión</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="72"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="72"/>
+        <source>Release notes for this version</source>
+        <translation>Notas de la versión para esta versión</translation>
+    </message>
+    <message>
+        <source>### Opt-ins for anonymous usage analytics and datalake
                 By enabling these features, you will be able to participate in the democratic
                 process of training a
                 large language model by contributing data for future model improvements.
@@ -3261,7 +2744,7 @@
                 attribution information attached to your data and you will be credited as a
                 contributor to any GPT4All
                 model release that uses your data!</source>
-            <translation>### Aceptación para análisis de uso anónimo y datalake
+        <translation type="vanished">### Aceptación para análisis de uso anónimo y datalake
                 Al habilitar estas funciones, podrá participar en el proceso democrático de entrenar
                 un
                 modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo.
@@ -3283,228 +2766,200 @@
                 información de atribución adjunta a sus datos y se le acreditará como contribuyente
                 en cualquier lanzamiento de modelo GPT4All
                 que utilice sus datos.</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="106" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="106" />
-            <source>Terms for opt-in</source>
-            <translation>Términos para aceptar</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="107" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="107" />
-            <source>Describes what will happen when you opt-in</source>
-            <translation>Describe lo que sucederá cuando acepte</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="124" />
-            <location filename="../qml/StartupDialog.qml" line="150" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="124" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="150" />
-            <source>Opt-in for anonymous usage statistics</source>
-            <translation>Aceptar estadísticas de uso anónimas</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="147" />
-            <location filename="../qml/StartupDialog.qml" line="262" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="147" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="262" />
-            <source>Yes</source>
-            <translation>Sí</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="151" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="151" />
-            <source>Allow opt-in for anonymous usage statistics</source>
-            <translation>Permitir aceptación de estadísticas de uso anónimas</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="189" />
-            <location filename="../qml/StartupDialog.qml" line="304" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="189" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="304" />
-            <source>No</source>
-            <translation>No</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="192" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="192" />
-            <source>Opt-out for anonymous usage statistics</source>
-            <translation>Rechazar estadísticas de uso anónimas</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="193" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="193" />
-            <source>Allow opt-out for anonymous usage statistics</source>
-            <translation>Permitir rechazo de estadísticas de uso anónimas</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="238" />
-            <location filename="../qml/StartupDialog.qml" line="265" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="238" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="265" />
-            <source>Opt-in for network</source>
-            <translation>Aceptar para la red</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="239" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="239" />
-            <source>Allow opt-in for network</source>
-            <translation>Permitir aceptación para la red</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="266" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="266" />
-            <source>Allow opt-in anonymous sharing of chats to the GPT4All Datalake</source>
-            <translation>Permitir compartir anónimamente los chats con el Datalake de GPT4All</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="307" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="307" />
-            <source>Opt-out for network</source>
-            <translation>Rechazar para la red</translation>
-        </message>
-        <message>
-            <location filename="../qml/StartupDialog.qml" line="308" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml"
-                line="308" />
-            <source>Allow opt-out anonymous sharing of chats to the GPT4All Datalake</source>
-            <translation>Permitir rechazar el compartir anónimo de chats con el Datalake de GPT4All</translation>
-        </message>
-    </context>
-    <context>
-        <name>SwitchModelDialog</name>
-        <message>
-            <location filename="../qml/SwitchModelDialog.qml" line="22" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
-                line="22" />
-            <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="67"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="67"/>
+        <source>### Release notes
+%1### Contributors
+%2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="87"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="87"/>
+        <source>### Opt-ins for anonymous usage analytics and datalake
+By enabling these features, you will be able to participate in the democratic process of training a
+large language model by contributing data for future model improvements.
+
+When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All
+Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you
+can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
+
+NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake.
+You should have no expectation of chat privacy when this feature is enabled. You should; however, have
+an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone
+to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
+attribution information attached to your data and you will be credited as a contributor to any GPT4All
+model release that uses your data!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="106"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="106"/>
+        <source>Terms for opt-in</source>
+        <translation>Términos para aceptar</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="107"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="107"/>
+        <source>Describes what will happen when you opt-in</source>
+        <translation>Describe lo que sucederá cuando acepte</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="124"/>
+        <location filename="../qml/StartupDialog.qml" line="150"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="124"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="150"/>
+        <source>Opt-in for anonymous usage statistics</source>
+        <translation>Aceptar estadísticas de uso anónimas</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="147"/>
+        <location filename="../qml/StartupDialog.qml" line="262"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="147"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="262"/>
+        <source>Yes</source>
+        <translation>Sí</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="151"/>
+        <source>Allow opt-in for anonymous usage statistics</source>
+        <translation>Permitir aceptación de estadísticas de uso anónimas</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="189"/>
+        <location filename="../qml/StartupDialog.qml" line="304"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="189"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="304"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="192"/>
+        <source>Opt-out for anonymous usage statistics</source>
+        <translation>Rechazar estadísticas de uso anónimas</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="193"/>
+        <source>Allow opt-out for anonymous usage statistics</source>
+        <translation>Permitir rechazo de estadísticas de uso anónimas</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="238"/>
+        <location filename="../qml/StartupDialog.qml" line="265"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="238"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="265"/>
+        <source>Opt-in for network</source>
+        <translation>Aceptar para la red</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="239"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="239"/>
+        <source>Allow opt-in for network</source>
+        <translation>Permitir aceptación para la red</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="266"/>
+        <source>Allow opt-in anonymous sharing of chats to the GPT4All Datalake</source>
+        <translation>Permitir compartir anónimamente los chats con el Datalake de GPT4All</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="307"/>
+        <source>Opt-out for network</source>
+        <translation>Rechazar para la red</translation>
+    </message>
+    <message>
+        <location filename="../qml/StartupDialog.qml" line="308"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="308"/>
+        <source>Allow opt-out anonymous sharing of chats to the GPT4All Datalake</source>
+        <translation>Permitir rechazar el compartir anónimo de chats con el Datalake de GPT4All</translation>
+    </message>
+</context>
+<context>
+    <name>SwitchModelDialog</name>
+    <message>
+        <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
                 conversation. Do you wish to continue?</source>
-            <translation>&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
+        <translation type="vanished">&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
                 actual. ¿Desea continuar?</translation>
-        </message>
-        <message>
-            <location filename="../qml/SwitchModelDialog.qml" line="33" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
-                line="33" />
-            <source>Continue</source>
-            <translation>Continuar</translation>
-        </message>
-        <message>
-            <location filename="../qml/SwitchModelDialog.qml" line="34" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
-                line="34" />
-            <source>Continue with model loading</source>
-            <translation>Continuar con la carga del modelo</translation>
-        </message>
-        <message>
-            <location filename="../qml/SwitchModelDialog.qml" line="38" />
-            <location filename="../qml/SwitchModelDialog.qml" line="39" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
-                line="38" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml"
-                line="39" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThumbsDownDialog</name>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="39" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="39" />
-            <source>Please edit the text below to provide a better response. (optional)</source>
-            <translation>Por favor, edite el texto a continuación para proporcionar una mejor
+    </message>
+    <message>
+        <location filename="../qml/SwitchModelDialog.qml" line="22"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="22"/>
+        <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current conversation. Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/SwitchModelDialog.qml" line="33"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="33"/>
+        <source>Continue</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <location filename="../qml/SwitchModelDialog.qml" line="34"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="34"/>
+        <source>Continue with model loading</source>
+        <translation>Continuar con la carga del modelo</translation>
+    </message>
+    <message>
+        <location filename="../qml/SwitchModelDialog.qml" line="38"/>
+        <location filename="../qml/SwitchModelDialog.qml" line="39"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="38"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="39"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>ThumbsDownDialog</name>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="39"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="39"/>
+        <source>Please edit the text below to provide a better response. (optional)</source>
+        <translation>Por favor, edite el texto a continuación para proporcionar una mejor
                 respuesta. (opcional)</translation>
-        </message>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="54" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="54" />
-            <source>Please provide a better response...</source>
-            <translation>Por favor, proporcione una mejor respuesta...</translation>
-        </message>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="64" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="64" />
-            <source>Submit</source>
-            <translation>Enviar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="65" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="65" />
-            <source>Submits the user&apos;s response</source>
-            <translation>Envía la respuesta del usuario</translation>
-        </message>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="69" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="69" />
-            <source>Cancel</source>
-            <translation>Cancelar</translation>
-        </message>
-        <message>
-            <location filename="../qml/ThumbsDownDialog.qml" line="70" />
-            <location
-                filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml"
-                line="70" />
-            <source>Closes the response dialog</source>
-            <translation>Cierra el diálogo de respuesta</translation>
-        </message>
-    </context>
-    <context>
-        <name>main</name>
-        <message>
-            <location filename="../main.qml" line="111" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="111" />
-            <source>
+    </message>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="54"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="54"/>
+        <source>Please provide a better response...</source>
+        <translation>Por favor, proporcione una mejor respuesta...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="64"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="64"/>
+        <source>Submit</source>
+        <translation>Enviar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="65"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="65"/>
+        <source>Submits the user&apos;s response</source>
+        <translation>Envía la respuesta del usuario</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="69"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="69"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../qml/ThumbsDownDialog.qml" line="70"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="70"/>
+        <source>Closes the response dialog</source>
+        <translation>Cierra el diálogo de respuesta</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>
                 &lt;h3&gt;Encountered an error starting
                 up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware
                 detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet
@@ -3513,7 +2968,7 @@
                 model. The only solution at this time is to upgrade your hardware to a more modern
                 CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a
                 href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-            <translation>
+        <translation type="vanished">
                 &lt;h3&gt;Se encontró un error al
                 iniciar:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatible
                 detectado.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Desafortunadamente, su CPU no cumple
@@ -3523,26 +2978,22 @@
                 hardware a una CPU más moderna.&lt;br&gt;&lt;br&gt;Vea aquí para más información:
                 &lt;a
                 href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="23" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="23" />
-            <source>GPT4All v%1</source>
-            <translation>GPT4All v%1</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="127" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="127" />
-            <source>&lt;h3&gt;Encountered an error starting
+    </message>
+    <message>
+        <location filename="../main.qml" line="23"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="23"/>
+        <source>GPT4All v%1</source>
+        <translation>GPT4All v%1</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;Encountered an error starting
                 up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings
                 file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the
                 program from accessing the settings file. This could be caused by incorrect
                 permissions in the local app config directory where the settings file is located.
                 Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord
                 channel&lt;/a&gt; for help.</source>
-            <translation>&lt;h3&gt;Se encontró un error al
+        <translation type="vanished">&lt;h3&gt;Se encontró un error al
                 iniciar:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;No se puede acceder al archivo de
                 configuración.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Desafortunadamente, algo está
                 impidiendo que el programa acceda al archivo de configuración. Esto podría ser
@@ -3550,162 +3001,150 @@
                 aplicación donde se encuentra el archivo de configuración. Consulte nuestro &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canal de Discord&lt;/a&gt; para
                 obtener ayuda.</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="155" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="155" />
-            <source>Connection to datalake failed.</source>
-            <translation>La conexión al datalake falló.</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="166" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="166" />
-            <source>Saving chats.</source>
-            <translation>Guardando chats.</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="177" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="177" />
-            <source>Network dialog</source>
-            <translation>Diálogo de red</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="178" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="178" />
-            <source>opt-in to share feedback/conversations</source>
-            <translation>optar por compartir comentarios/conversaciones</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="231" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="231" />
-            <source>Home view</source>
-            <translation>Vista de inicio</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="232" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="232" />
-            <source>Home view of application</source>
-            <translation>Vista de inicio de la aplicación</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="240" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="240" />
-            <source>Home</source>
-            <translation>Inicio</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="266" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="266" />
-            <source>Chat view</source>
-            <translation>Vista de chat</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="267" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="267" />
-            <source>Chat view to interact with models</source>
-            <translation>Vista de chat para interactuar con modelos</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="275" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="275" />
-            <source>Chats</source>
-            <translation>Chats</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="300" />
-            <location filename="../main.qml" line="309" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="300" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="309" />
-            <source>Models</source>
-            <translation>Modelos</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="301" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="301" />
-            <source>Models view for installed models</source>
-            <translation>Vista de modelos para modelos instalados</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="334" />
-            <location filename="../main.qml" line="343" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="334" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="343" />
-            <source>LocalDocs</source>
-            <translation>DocumentosLocales</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="335" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="335" />
-            <source>LocalDocs view to configure and use local docs</source>
-            <translation>Vista de DocumentosLocales para configurar y usar documentos locales</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="368" />
-            <location filename="../main.qml" line="377" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="368" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="377" />
-            <source>Settings</source>
-            <translation>Configuración</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="369" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="369" />
-            <source>Settings view for application configuration</source>
-            <translation>Vista de configuración para la configuración de la aplicación</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="422" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="422" />
-            <source>The datalake is enabled</source>
-            <translation>El datalake está habilitado</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="424" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="424" />
-            <source>Using a network model</source>
-            <translation>Usando un modelo de red</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="426" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="426" />
-            <source>Server mode is enabled</source>
-            <translation>El modo servidor está habilitado</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="640" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="640" />
-            <source>Installed models</source>
-            <translation>Modelos instalados</translation>
-        </message>
-        <message>
-            <location filename="../main.qml" line="641" />
-            <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml"
-                line="641" />
-            <source>View of installed models</source>
-            <translation>Vista de modelos instalados</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <location filename="../main.qml" line="111"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="111"/>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only solution at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="127"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="127"/>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing the settings file. This could be caused by incorrect permissions in the local app config directory where the settings file is located. Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="155"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="155"/>
+        <source>Connection to datalake failed.</source>
+        <translation>La conexión al datalake falló.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="166"/>
+        <source>Saving chats.</source>
+        <translation>Guardando chats.</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="177"/>
+        <source>Network dialog</source>
+        <translation>Diálogo de red</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="178"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="178"/>
+        <source>opt-in to share feedback/conversations</source>
+        <translation>optar por compartir comentarios/conversaciones</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="231"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="231"/>
+        <source>Home view</source>
+        <translation>Vista de inicio</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="232"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="232"/>
+        <source>Home view of application</source>
+        <translation>Vista de inicio de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="240"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="240"/>
+        <source>Home</source>
+        <translation>Inicio</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="266"/>
+        <source>Chat view</source>
+        <translation>Vista de chat</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="267"/>
+        <source>Chat view to interact with models</source>
+        <translation>Vista de chat para interactuar con modelos</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="275"/>
+        <source>Chats</source>
+        <translation>Chats</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="300"/>
+        <location filename="../main.qml" line="309"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="300"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="309"/>
+        <source>Models</source>
+        <translation>Modelos</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="301"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="301"/>
+        <source>Models view for installed models</source>
+        <translation>Vista de modelos para modelos instalados</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="334"/>
+        <location filename="../main.qml" line="343"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="334"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="343"/>
+        <source>LocalDocs</source>
+        <translation>DocumentosLocales</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="335"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="335"/>
+        <source>LocalDocs view to configure and use local docs</source>
+        <translation>Vista de DocumentosLocales para configurar y usar documentos locales</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="368"/>
+        <location filename="../main.qml" line="377"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="377"/>
+        <source>Settings</source>
+        <translation>Configuración</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="369"/>
+        <source>Settings view for application configuration</source>
+        <translation>Vista de configuración para la configuración de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="422"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="422"/>
+        <source>The datalake is enabled</source>
+        <translation>El datalake está habilitado</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="424"/>
+        <source>Using a network model</source>
+        <translation>Usando un modelo de red</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="426"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="426"/>
+        <source>Server mode is enabled</source>
+        <translation>El modo servidor está habilitado</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="640"/>
+        <source>Installed models</source>
+        <translation>Modelos instalados</translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="641"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="641"/>
+        <source>View of installed models</source>
+        <translation>Vista de modelos instalados</translation>
+    </message>
+</context>
 </TS>

--- a/gpt4all-chat/translations/gpt4all_zh_CN.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_CN.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AddCollectionView</name>
     <message>
@@ -103,10 +103,8 @@
         <translation>用于发现和筛选可下载模型的文本字段</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="97"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="97"/>
         <source>Searching · </source>
-        <translation>搜索中</translation>
+        <translation type="vanished">搜索中</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="167"/>
@@ -145,10 +143,8 @@
         <translation>近期</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="193"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Sort by: </source>
-        <translation>排序：</translation>
+        <translation type="vanished">排序：</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="206"/>
@@ -163,10 +159,8 @@
         <translation>倒序</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="218"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="218"/>
         <source>Sort dir: </source>
-        <translation>排序目录:</translation>
+        <translation type="vanished">排序目录:</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="234"/>
@@ -175,22 +169,48 @@
         <translation>无</translation>
     </message>
     <message>
+        <source>Limit: </source>
+        <translation type="vanished">限制：</translation>
+    </message>
+    <message>
+        <source>Network error: could not retrieve http://gpt4all.io/models/models3.json</source>
+        <translation type="vanished">网络问题：无法访问 http://gpt4all.io/models/models3.json</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="97"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="97"/>
+        <source>Searching · %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
+        <source>Sort by: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="218"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="218"/>
+        <source>Sort dir: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../qml/AddModelView.qml" line="254"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="254"/>
-        <source>Limit: </source>
-        <translation>限制：</translation>
+        <source>Limit: %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="287"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="287"/>
-        <source>Network error: could not retrieve http://gpt4all.io/models/models3.json</source>
-        <translation>网络问题：无法访问 http://gpt4all.io/models/models3.json</translation>
+        <source>Network error: could not retrieve %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="297"/>
-        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../qml/AddModelView.qml" line="560"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="297"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
         <source>Busy indicator</source>
         <translation>繁忙程度</translation>
     </message>
@@ -275,124 +295,140 @@
         <translation>安装在线模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="458"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="458"/>
-        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;#error&quot;&gt;错误&lt;/a&gt;</translation>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="465"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="465"/>
-        <source>Describes an error that occurred when downloading</source>
-        <translation>描述下载过程中发生的错误</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="478"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="478"/>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
-        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="479"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="479"/>
-        <source> Model requires more memory (</source>
-        <translation>需要更多内存（</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="480"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="480"/>
-        <source> GB) than your system has available (</source>
-        <translation>你的系统需要 (</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="487"/>
-        <source>Error for incompatible hardware</source>
-        <translation>硬件不兼容的错误</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="525"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="525"/>
-        <source>Download progressBar</source>
-        <translation>下载进度</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="526"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="526"/>
-        <source>Shows the progress made in the download</source>
-        <translation>显示下载进度</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="536"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="536"/>
-        <source>Download speed</source>
-        <translation>下载速度</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="537"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="537"/>
-        <source>Download speed in bytes/kilobytes/megabytes per second</source>
-        <translation>下载速度  b/kb/mb /s</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="554"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="554"/>
-        <source>Calculating...</source>
-        <translation>计算中</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="558"/>
-        <location filename="../qml/AddModelView.qml" line="587"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="587"/>
-        <source>Whether the file hash is being calculated</source>
-        <translation>是否正在计算文件哈希</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="566"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
-        <source>Displayed when the file hash is being calculated</source>
-        <translation>在计算文件哈希时显示</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="584"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="584"/>
-        <source>enter $API_KEY</source>
-        <translation>输入$API_KEY</translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="606"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
-        <source>File size</source>
-        <translation>文件大小</translation>
+        <location filename="../qml/AddModelView.qml" line="476"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="628"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <source>%1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="650"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="650"/>
+        <source>?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
+        <translation type="vanished">&lt;a href=&quot;#error&quot;&gt;错误&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="463"/>
+        <source>Describes an error that occurred when downloading</source>
+        <translation>描述下载过程中发生的错误</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
+    </message>
+    <message>
+        <source> Model requires more memory (</source>
+        <translation type="vanished">需要更多内存（</translation>
+    </message>
+    <message>
+        <source> GB) than your system has available (</source>
+        <translation type="vanished">你的系统需要 (</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="482"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="482"/>
+        <source>Error for incompatible hardware</source>
+        <translation>硬件不兼容的错误</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="520"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="520"/>
+        <source>Download progressBar</source>
+        <translation>下载进度</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
+        <source>Shows the progress made in the download</source>
+        <translation>显示下载进度</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="531"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="531"/>
+        <source>Download speed</source>
+        <translation>下载速度</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="532"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="532"/>
+        <source>Download speed in bytes/kilobytes/megabytes per second</source>
+        <translation>下载速度  b/kb/mb /s</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="549"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <source>Calculating...</source>
+        <translation>计算中</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="553"/>
+        <location filename="../qml/AddModelView.qml" line="582"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="553"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
+        <source>Whether the file hash is being calculated</source>
+        <translation>是否正在计算文件哈希</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="561"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <source>Displayed when the file hash is being calculated</source>
+        <translation>在计算文件哈希时显示</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="579"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="579"/>
+        <source>enter $API_KEY</source>
+        <translation>输入$API_KEY</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="601"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="601"/>
+        <source>File size</source>
+        <translation>文件大小</translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="623"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="623"/>
         <source>RAM required</source>
         <translation>RAM 需要</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
         <source> GB</source>
-        <translation>GB</translation>
+        <translation type="vanished">GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="650"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="650"/>
+        <location filename="../qml/AddModelView.qml" line="645"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
         <source>Parameters</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="672"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="672"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>Quant</source>
         <translation>量化</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="694"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="694"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
@@ -493,134 +529,176 @@
         <translation>应用中的文本大小。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="165"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="165"/>
+        <location filename="../qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <source>Language and Locale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="167"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="167"/>
+        <source>The language and locale you wish to use.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="195"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="195"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or Metal.</source>
         <translation>用于文本生成的计算设备. &quot;自动&quot; 使用 Vulkan or Metal.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="199"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="199"/>
+        <location filename="../qml/ApplicationSettings.qml" line="229"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="229"/>
         <source>Default Model</source>
         <translation>默认模型</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="200"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="200"/>
+        <location filename="../qml/ApplicationSettings.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="230"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>新聊天的首选模式。也用作本地服务器回退。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="232"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="232"/>
-        <source>Download Path</source>
-        <translation>下载目录</translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="233"/>
-        <source>Where to store local models and the LocalDocs database.</source>
-        <translation>本地模型和本地文档数据库存储目录</translation>
-    </message>
-    <message>
         <location filename="../qml/ApplicationSettings.qml" line="262"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="262"/>
-        <source>Browse</source>
-        <translation>查看</translation>
+        <source>Suggestion Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="263"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="263"/>
-        <source>Choose where to save model files</source>
-        <translation>模型下载目录</translation>
+        <source>Generate suggested follow-up questions at the end of responses.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="274"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>When chatting with LocalDocs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>Whenever possible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <source>Never</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="286"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="286"/>
+        <source>Download Path</source>
+        <translation>下载目录</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="287"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="287"/>
+        <source>Where to store local models and the LocalDocs database.</source>
+        <translation>本地模型和本地文档数据库存储目录</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="316"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="316"/>
+        <source>Browse</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="317"/>
+        <source>Choose where to save model files</source>
+        <translation>模型下载目录</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="328"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="328"/>
         <source>Enable Datalake</source>
         <translation>开启数据湖</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="275"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../qml/ApplicationSettings.qml" line="329"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="329"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>发送对话和反馈给GPT4All 的开源数据湖。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="308"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="308"/>
+        <location filename="../qml/ApplicationSettings.qml" line="362"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="362"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="320"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="320"/>
+        <location filename="../qml/ApplicationSettings.qml" line="374"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="374"/>
         <source>CPU Threads</source>
         <translation>CPU线程</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="321"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="321"/>
+        <location filename="../qml/ApplicationSettings.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="375"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>用于推理和嵌入的CPU线程数</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="352"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="352"/>
+        <location filename="../qml/ApplicationSettings.qml" line="406"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="406"/>
         <source>Save Chat Context</source>
         <translation>保存对话上下文</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="353"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../qml/ApplicationSettings.qml" line="407"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="407"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>保存模型&apos;s 状态以提供更快加载速度. 警告: 需用 ~2GB 每个对话.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="369"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../qml/ApplicationSettings.qml" line="423"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="423"/>
         <source>Enable Local Server</source>
         <translation>开启本地服务</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="370"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="370"/>
+        <location filename="../qml/ApplicationSettings.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="424"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>将OpenAI兼容服务器暴露给本地主机。警告：导致资源使用量增加。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="386"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="386"/>
+        <location filename="../qml/ApplicationSettings.qml" line="440"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="440"/>
         <source>API Server Port</source>
         <translation>API 服务端口</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="387"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="387"/>
+        <location filename="../qml/ApplicationSettings.qml" line="441"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="441"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>使用本地服务的端口，需要重启</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="493"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="493"/>
         <source>Check For Updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="440"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="440"/>
+        <location filename="../qml/ApplicationSettings.qml" line="494"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="494"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>手动检查更新</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="449"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="449"/>
+        <location filename="../qml/ApplicationSettings.qml" line="503"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="503"/>
         <source>Updates</source>
         <translation>更新</translation>
     </message>
@@ -628,7 +706,7 @@
 <context>
     <name>Chat</name>
     <message>
-        <location filename="../chat.h" line="70"/>
+        <location filename="../chat.h" line="72"/>
         <location filename="../chat.cpp" line="25"/>
         <source>New Chat</source>
         <translation>新对话</translation>
@@ -639,16 +717,12 @@
         <translation>服务器对话</translation>
     </message>
     <message>
-        <location filename="../chat.cpp" line="232"/>
-        <location filename="../chat.cpp" line="241"/>
         <source>Prompt: </source>
-        <translation>提示词：</translation>
+        <translation type="vanished">提示词：</translation>
     </message>
     <message>
-        <location filename="../chat.cpp" line="233"/>
-        <location filename="../chat.cpp" line="242"/>
         <source>Response: </source>
-        <translation>响应：</translation>
+        <translation type="vanished">响应：</translation>
     </message>
 </context>
 <context>
@@ -762,16 +836,12 @@
 <context>
     <name>ChatView</name>
     <message>
-        <location filename="../qml/ChatView.qml" line="58"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="58"/>
         <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;</source>
-        <translation>&lt;h3&gt;加载模型时遇到错误:&lt;/h3&gt;&lt;br&gt;</translation>
+        <translation type="vanished">&lt;h3&gt;加载模型时遇到错误:&lt;/h3&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="60"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="60"/>
         <source>&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
-        <translation>lt;br&gt;&lt;br&gt;模型加载失败可能由多种原因造成，但最常见的原因包括文件格式错误、下载不完整或损坏、文件类型错误、系统 RAM 不足或模型类型不兼容。以下是解决该问题的一些建议：&lt;br&gt;&lt;ul&gt;&lt;li&gt;确保模型文件具有兼容的格式和类型&lt;li&gt;检查下载文件夹中的模型文件是否完整&lt;li&gt;您可以在设置对话框中找到下载文件夹&lt;li&gt;如果您已侧载模型，请通过检查 md5sum 确保文件未损坏&lt;li&gt;在我们的&lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;文档&lt;/a&gt;中了解有关支持哪些模型的更多信息对于 gui&lt;li&gt;查看我们的&lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord 频道&lt;/a&gt; 获取帮助</translation>
+        <translation type="vanished">lt;br&gt;&lt;br&gt;模型加载失败可能由多种原因造成，但最常见的原因包括文件格式错误、下载不完整或损坏、文件类型错误、系统 RAM 不足或模型类型不兼容。以下是解决该问题的一些建议：&lt;br&gt;&lt;ul&gt;&lt;li&gt;确保模型文件具有兼容的格式和类型&lt;li&gt;检查下载文件夹中的模型文件是否完整&lt;li&gt;您可以在设置对话框中找到下载文件夹&lt;li&gt;如果您已侧载模型，请通过检查 md5sum 确保文件未损坏&lt;li&gt;在我们的&lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;文档&lt;/a&gt;中了解有关支持哪些模型的更多信息对于 gui&lt;li&gt;查看我们的&lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord 频道&lt;/a&gt; 获取帮助</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="77"/>
@@ -804,26 +874,8 @@
         <translation>复制代码到剪切板</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="110"/>
-        <location filename="../qml/ChatView.qml" line="124"/>
-        <location filename="../qml/ChatView.qml" line="812"/>
-        <location filename="../qml/ChatView.qml" line="834"/>
-        <location filename="../qml/ChatView.qml" line="842"/>
-        <location filename="../qml/ChatView.qml" line="887"/>
-        <location filename="../qml/ChatView.qml" line="1000"/>
-        <location filename="../qml/ChatView.qml" line="1026"/>
-        <location filename="../qml/ChatView.qml" line="1464"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="110"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="124"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="812"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="834"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="842"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="887"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1000"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1026"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1464"/>
         <source>Response: </source>
-        <translation>响应：</translation>
+        <translation type="vanished">响应：</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="231"/>
@@ -886,297 +938,335 @@
         <translation>没找到: %1</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="377"/>
-        <location filename="../qml/ChatView.qml" line="1555"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="377"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1555"/>
         <source>Reload · </source>
-        <translation>重载· </translation>
+        <translation type="vanished">重载· </translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="379"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="379"/>
         <source>Loading · </source>
-        <translation>载入中· </translation>
+        <translation type="vanished">载入中· </translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="460"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="460"/>
+        <location filename="../qml/ChatView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="463"/>
         <source>The top item is the current model</source>
         <translation>当前模型的最佳选项</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="546"/>
-        <location filename="../qml/ChatView.qml" line="1281"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="546"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1281"/>
+        <location filename="../qml/ChatView.qml" line="549"/>
+        <location filename="../qml/ChatView.qml" line="1307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="549"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1307"/>
         <source>LocalDocs</source>
         <translation>本地文档</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="564"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="564"/>
+        <location filename="../qml/ChatView.qml" line="567"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="567"/>
         <source>Add documents</source>
         <translation>添加文档</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="565"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="565"/>
+        <location filename="../qml/ChatView.qml" line="568"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="568"/>
         <source>add collections of documents to the chat</source>
         <translation>将文档集合添加到聊天中</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="705"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="705"/>
         <source>Load · </source>
-        <translation>加载· </translation>
+        <translation type="vanished">加载· </translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="705"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="705"/>
         <source> (default) →</source>
-        <translation>(默认) →</translation>
+        <translation type="vanished">(默认) →</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="729"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="729"/>
+        <location filename="../qml/ChatView.qml" line="732"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="732"/>
         <source>Load the default model</source>
         <translation>载入默认模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="730"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="730"/>
+        <location filename="../qml/ChatView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="733"/>
         <source>Loads the default model which can be changed in settings</source>
         <translation>加载默认模型，可以在设置中更改</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="741"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="741"/>
+        <location filename="../qml/ChatView.qml" line="744"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="744"/>
         <source>No Model Installed</source>
         <translation>没有下载模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="750"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="750"/>
+        <location filename="../qml/ChatView.qml" line="753"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="753"/>
         <source>GPT4All requires that you install at least one
 model to get started</source>
         <translation>GPT4All要求您至少安装一个模型才能开始</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="762"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="762"/>
+        <location filename="../qml/ChatView.qml" line="765"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="765"/>
         <source>Install a Model</source>
         <translation>下载模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="767"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="767"/>
+        <location filename="../qml/ChatView.qml" line="770"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="770"/>
         <source>Shows the add model view</source>
         <translation>查看添加的模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="792"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="792"/>
+        <location filename="../qml/ChatView.qml" line="795"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="795"/>
         <source>Conversation with the model</source>
         <translation>使用此模型对话</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="793"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="793"/>
+        <location filename="../qml/ChatView.qml" line="796"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="796"/>
         <source>prompt / response pairs from the conversation</source>
         <translation>对话中的提示/响应对</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="834"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="834"/>
+        <location filename="../qml/ChatView.qml" line="848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
         <source>GPT4All</source>
         <translation>GPT4All</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="834"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="834"/>
+        <location filename="../qml/ChatView.qml" line="848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
         <source>You</source>
         <translation>您</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="853"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="853"/>
         <source>Busy indicator</source>
-        <translation>繁忙程度</translation>
+        <translation type="vanished">繁忙程度</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="854"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="854"/>
         <source>The model is thinking</source>
-        <translation>模型在思考</translation>
+        <translation type="vanished">模型在思考</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="861"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="861"/>
+        <location filename="../qml/ChatView.qml" line="870"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="870"/>
         <source>recalculating context ...</source>
         <translation>重新生成上下文...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="863"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="863"/>
+        <location filename="../qml/ChatView.qml" line="872"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="872"/>
         <source>response stopped ...</source>
         <translation>响应停止...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="864"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="864"/>
         <source>retrieving localdocs: </source>
-        <translation>检索本地文档：</translation>
+        <translation type="vanished">检索本地文档：</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="865"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="865"/>
         <source>searching localdocs: </source>
-        <translation>检索本地文档：</translation>
+        <translation type="vanished">检索本地文档：</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="866"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="866"/>
+        <location filename="../qml/ChatView.qml" line="875"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="875"/>
         <source>processing ...</source>
         <translation>处理中</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="867"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="867"/>
+        <location filename="../qml/ChatView.qml" line="876"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="876"/>
         <source>generating response ...</source>
         <translation>响应中...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="935"/>
-        <location filename="../qml/ChatView.qml" line="1685"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="935"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1685"/>
+        <location filename="../qml/ChatView.qml" line="877"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="877"/>
+        <source>generating questions ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="943"/>
+        <location filename="../qml/ChatView.qml" line="1899"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="943"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1899"/>
         <source>Copy</source>
         <translation>复制</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="941"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="941"/>
+        <location filename="../qml/ChatView.qml" line="949"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="949"/>
         <source>Copy Message</source>
         <translation>复制内容</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="951"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="951"/>
+        <location filename="../qml/ChatView.qml" line="959"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
         <source>Disable markdown</source>
         <translation>不允许markdown</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="951"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="951"/>
+        <location filename="../qml/ChatView.qml" line="959"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
         <source>Enable markdown</source>
         <translation>允许markdown</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1041"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1041"/>
+        <location filename="../qml/ChatView.qml" line="1049"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1049"/>
         <source>Thumbs up</source>
         <translation>点赞</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1042"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1042"/>
+        <location filename="../qml/ChatView.qml" line="1050"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1050"/>
         <source>Gives a thumbs up to the response</source>
         <translation>点赞响应</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1075"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1075"/>
+        <location filename="../qml/ChatView.qml" line="1083"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1083"/>
         <source>Thumbs down</source>
         <translation>点踩</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1076"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1076"/>
+        <location filename="../qml/ChatView.qml" line="1084"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1084"/>
         <source>Opens thumbs down dialog</source>
         <translation>打开点踩对话框</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1122"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1122"/>
+        <location filename="../qml/ChatView.qml" line="1139"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1139"/>
         <source>%1 Sources</source>
         <translation>%1 资源</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1428"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1428"/>
+        <location filename="../qml/ChatView.qml" line="1383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1383"/>
+        <source>Suggested follow-ups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1659"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1659"/>
         <source>Erase and reset chat session</source>
         <translation>擦除并重置聊天会话</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1449"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1449"/>
+        <location filename="../qml/ChatView.qml" line="1680"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1680"/>
         <source>Copy chat session to clipboard</source>
         <translation>复制对话到剪切板</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1475"/>
+        <location filename="../qml/ChatView.qml" line="1706"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1706"/>
         <source>Redo last chat response</source>
         <translation>重新生成上个响应</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1492"/>
+        <location filename="../qml/ChatView.qml" line="1955"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1955"/>
+        <source>Stop generating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1956"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1956"/>
         <source>Stop the current response generation</source>
         <translation>停止当前响应</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1557"/>
+        <location filename="../qml/ChatView.qml" line="1771"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1771"/>
         <source>Reloads the model</source>
         <translation>重载模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1631"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1631"/>
+        <location filename="../qml/ChatView.qml" line="58"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="58"/>
+        <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="377"/>
+        <location filename="../qml/ChatView.qml" line="1769"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="377"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1769"/>
+        <source>Reload · %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="379"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="379"/>
+        <source>Loading · %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="708"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="708"/>
+        <source>Load · %1 (default) →</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="873"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="873"/>
+        <source>retrieving localdocs: %1 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="874"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="874"/>
+        <source>searching localdocs: %1 ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ChatView.qml" line="1845"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
         <source>Send a message...</source>
         <translation>发送消息...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1631"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1631"/>
+        <location filename="../qml/ChatView.qml" line="1845"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
         <source>Load a model to continue...</source>
         <translation>选择模型并继续</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1634"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1634"/>
+        <location filename="../qml/ChatView.qml" line="1848"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1848"/>
         <source>Send messages/prompts to the model</source>
         <translation>发送消息/提示词给模型</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1679"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1679"/>
+        <location filename="../qml/ChatView.qml" line="1893"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1893"/>
         <source>Cut</source>
         <translation>剪切</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1691"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1691"/>
+        <location filename="../qml/ChatView.qml" line="1905"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1905"/>
         <source>Paste</source>
         <translation>粘贴</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1695"/>
+        <location filename="../qml/ChatView.qml" line="1909"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1909"/>
         <source>Select All</source>
         <translation>全选</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1714"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1714"/>
+        <location filename="../qml/ChatView.qml" line="1979"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1979"/>
         <source>Send message</source>
         <translation>发送消息</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1715"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1715"/>
+        <location filename="../qml/ChatView.qml" line="1980"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1980"/>
         <source>Sends the message/prompt contained in textfield to the model</source>
         <translation>将文本框中包含的消息/提示发送给模型</translation>
     </message>
@@ -1293,44 +1383,44 @@ model to get started</source>
         <translation>GPT4All新闻</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="219"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="219"/>
+        <location filename="../qml/HomeView.qml" line="222"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="222"/>
         <source>Release Notes</source>
         <translation>发布日志</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="225"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="225"/>
+        <location filename="../qml/HomeView.qml" line="228"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="228"/>
         <source>Documentation</source>
         <translation>文档</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="231"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="231"/>
+        <location filename="../qml/HomeView.qml" line="234"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="234"/>
         <source>Discord</source>
         <translation>Discord</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="237"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="237"/>
+        <location filename="../qml/HomeView.qml" line="240"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="240"/>
         <source>X (Twitter)</source>
         <translation>X (Twitter)</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="243"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="243"/>
+        <location filename="../qml/HomeView.qml" line="246"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="246"/>
         <source>Github</source>
         <translation>Github</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="254"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="254"/>
+        <location filename="../qml/HomeView.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="257"/>
         <source>GPT4All.io</source>
         <translation>GPT4All.io</translation>
     </message>
     <message>
-        <location filename="../qml/HomeView.qml" line="279"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="279"/>
+        <location filename="../qml/HomeView.qml" line="282"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="282"/>
         <source>Subscribe to Newsletter</source>
         <translation>订阅信息</translation>
     </message>
@@ -1654,47 +1744,67 @@ model to get started</source>
 <context>
     <name>ModelList</name>
     <message>
-        <location filename="../modellist.cpp" line="1503"/>
+        <location filename="../modellist.cpp" line="1537"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal OpenAI API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;需要个人 OpenAI API 密钥。&lt;/li&gt;&lt;li&gt;警告：将把您的聊天内容发送给 OpenAI！&lt;/li&gt;&lt;li&gt;您的 API 密钥将存储在磁盘上&lt;/li&gt;&lt;li&gt;仅用于与 OpenAI 通信&lt;/li&gt;&lt;li&gt;您可以在此处&lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;申请 API 密钥。&lt;/a&gt;&lt;/li&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1522"/>
-        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</source>
-        <translation>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</translation>
+        <location filename="../modellist.cpp" line="1556"/>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1535"/>
+        <location filename="../modellist.cpp" line="1584"/>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt; %1 %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1615"/>
+        <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1640"/>
+        <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1666"/>
+        <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt; %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</source>
+        <translation type="vanished">&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../modellist.cpp" line="1569"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does not guarantee API key access. Contact OpenAI for more info.</source>
         <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* 即使您为ChatGPT-4向OpenAI付款，这也不能保证API密钥访问。联系OpenAI获取更多信息。</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1550"/>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt;</source>
-        <translation>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1562"/>
+        <location filename="../modellist.cpp" line="1596"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1581"/>
         <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1606"/>
         <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1632"/>
         <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="2039"/>
+        <location filename="../modellist.cpp" line="2081"/>
         <source>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
         <translation>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</translation>
     </message>
@@ -1714,81 +1824,103 @@ model to get started</source>
         <translation>模型设置</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="82"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="82"/>
+        <location filename="../qml/ModelSettings.qml" line="83"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="83"/>
         <source>Clone</source>
         <translation>克隆</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="92"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="92"/>
+        <location filename="../qml/ModelSettings.qml" line="93"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="93"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="106"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="106"/>
+        <location filename="../qml/ModelSettings.qml" line="107"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="107"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="139"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="139"/>
+        <location filename="../qml/ModelSettings.qml" line="140"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="140"/>
         <source>Model File</source>
         <translation>模型文件</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="157"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="157"/>
+        <location filename="../qml/ModelSettings.qml" line="158"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="158"/>
         <source>System Prompt</source>
         <translation>系统提示词</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="158"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="158"/>
+        <location filename="../qml/ModelSettings.qml" line="159"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="159"/>
         <source>Prefixed at the beginning of every conversation. Must contain the appropriate framing tokens.</source>
         <translation>每次对话开始时的前缀</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="204"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="204"/>
+        <location filename="../qml/ModelSettings.qml" line="205"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="205"/>
         <source>Prompt Template</source>
         <translation>提示词模版</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="205"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="205"/>
+        <location filename="../qml/ModelSettings.qml" line="206"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="206"/>
         <source>The template that wraps every prompt.</source>
         <translation>包装每个提示的模板</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="209"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="209"/>
+        <location filename="../qml/ModelSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="210"/>
         <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s input.</source>
         <translation>必须包含字符串 &quot;%1&quot; 替换为用户的&apos;s 输入.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="278"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="278"/>
         <source>Add
 optional image</source>
-        <translation>添加可选图片</translation>
+        <translation type="vanished">添加可选图片</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="302"/>
+        <location filename="../qml/ModelSettings.qml" line="255"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="255"/>
+        <source>Chat Name Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="256"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="256"/>
+        <source>Prompt used to automatically generate chat names.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="283"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="283"/>
+        <source>Suggested FollowUp Prompt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="284"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="284"/>
+        <source>Prompt used to generate suggested follow-up questions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelSettings.qml" line="322"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="322"/>
         <source>Context Length</source>
         <translation>上下文长度</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="303"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="303"/>
+        <location filename="../qml/ModelSettings.qml" line="323"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="323"/>
         <source>Number of input and output tokens the model sees.</source>
         <translation>模型看到的输入和输出令牌的数量。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="324"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="324"/>
+        <location filename="../qml/ModelSettings.qml" line="344"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="344"/>
         <source>Maximum combined prompt/response tokens before information is lost.
 Using more context than the model was trained on will yield poor results.
 NOTE: Does not take effect until you reload the model.</source>
@@ -1797,152 +1929,152 @@ NOTE: Does not take effect until you reload the model.</source>
         注意：在重新加载模型之前不会生效。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="362"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="362"/>
+        <location filename="../qml/ModelSettings.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="382"/>
         <source>Temperature</source>
         <translation>温度</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="363"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="363"/>
+        <location filename="../qml/ModelSettings.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="383"/>
         <source>Randomness of model output. Higher -&gt; more variation.</source>
         <translation>模型输出的随机性。更高-&gt;更多的变化。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="374"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="374"/>
+        <location filename="../qml/ModelSettings.qml" line="394"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="394"/>
         <source>Temperature increases the chances of choosing less likely tokens.
 NOTE: Higher temperature gives more creative but less predictable outputs.</source>
         <translation>温度增加了选择不太可能的token的机会。
         注：温度越高，输出越有创意，但预测性越低。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="408"/>
+        <location filename="../qml/ModelSettings.qml" line="428"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="428"/>
         <source>Top-P</source>
         <translation>Top-P</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="409"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="409"/>
+        <location filename="../qml/ModelSettings.qml" line="429"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="429"/>
         <source>Nucleus Sampling factor. Lower -&gt; more predicatable.</source>
         <translation>核子取样系数。较低-&gt;更具可预测性。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="419"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="419"/>
+        <location filename="../qml/ModelSettings.qml" line="439"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="439"/>
         <source>Only the most likely tokens up to a total probability of top_p can be chosen.
 NOTE: Prevents choosing highly unlikely tokens.</source>
         <translation>只能选择总概率高达top_p的最有可能的令牌。
         注意：防止选择极不可能的token。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="453"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="453"/>
+        <location filename="../qml/ModelSettings.qml" line="473"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="473"/>
         <source>Min-P</source>
         <translation>Min-P</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="454"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="454"/>
+        <location filename="../qml/ModelSettings.qml" line="474"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="474"/>
         <source>Minimum token probability. Higher -&gt; more predictable.</source>
         <translation>最小令牌概率。更高 -&gt; 更可预测。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="464"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="464"/>
+        <location filename="../qml/ModelSettings.qml" line="484"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="484"/>
         <source>Sets the minimum relative probability for a token to be considered.</source>
         <translation>设置被考虑的标记的最小相对概率。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="500"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="500"/>
+        <location filename="../qml/ModelSettings.qml" line="520"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="520"/>
         <source>Top-K</source>
         <translation>Top-K</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="501"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="501"/>
+        <location filename="../qml/ModelSettings.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="521"/>
         <source>Size of selection pool for tokens.</source>
         <translation>令牌选择池的大小。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="512"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="512"/>
+        <location filename="../qml/ModelSettings.qml" line="532"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="532"/>
         <source>Only the top K most likely tokens will be chosen from.</source>
         <translation>仅从最可能的前 K 个标记中选择</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="547"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="547"/>
+        <location filename="../qml/ModelSettings.qml" line="567"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="567"/>
         <source>Max Length</source>
         <translation>最大长度</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="548"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="548"/>
+        <location filename="../qml/ModelSettings.qml" line="568"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="568"/>
         <source>Maximum response length, in tokens.</source>
         <translation>最大响应长度（以令牌为单位）</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="593"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="593"/>
+        <location filename="../qml/ModelSettings.qml" line="613"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="613"/>
         <source>Prompt Batch Size</source>
         <translation>提示词大小</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="594"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="594"/>
+        <location filename="../qml/ModelSettings.qml" line="614"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="614"/>
         <source>The batch size used for prompt processing.</source>
         <translation>用于快速处理的批量大小。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="605"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="605"/>
+        <location filename="../qml/ModelSettings.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="625"/>
         <source>Amount of prompt tokens to process at once.
 NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
         <translation>一次要处理的提示令牌数量。
         注意：较高的值可以加快读取提示，但会使用更多的RAM。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="640"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="640"/>
+        <location filename="../qml/ModelSettings.qml" line="660"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="660"/>
         <source>Repeat Penalty</source>
         <translation>重复惩罚</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="641"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="641"/>
+        <location filename="../qml/ModelSettings.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="661"/>
         <source>Repetition penalty factor. Set to 1 to disable.</source>
         <translation>重复处罚系数。设置为1可禁用。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="685"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="685"/>
+        <location filename="../qml/ModelSettings.qml" line="705"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="705"/>
         <source>Repeat Penalty Tokens</source>
         <translation>重复惩罚数</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="686"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="686"/>
+        <location filename="../qml/ModelSettings.qml" line="706"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="706"/>
         <source>Number of previous tokens used for penalty.</source>
         <translation>用于惩罚的先前令牌数量。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="731"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="731"/>
+        <location filename="../qml/ModelSettings.qml" line="751"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="751"/>
         <source>GPU Layers</source>
         <translation>GPU 层</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="732"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="732"/>
+        <location filename="../qml/ModelSettings.qml" line="752"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="752"/>
         <source>Number of model layers to load into VRAM.</source>
         <translation>要加载到VRAM中的模型层数。</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="743"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="743"/>
+        <location filename="../qml/ModelSettings.qml" line="763"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="763"/>
         <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of VRAM while loading this model.
 Lower values increase CPU load and RAM usage, and make inference slower.
 NOTE: Does not take effect until you reload the model.</source>
@@ -2060,130 +2192,144 @@ NOTE: Does not take effect until you reload the model.</source>
         <translation>安装在线模型</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="254"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="254"/>
-        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;#错误&quot;&gt;错误&lt;/a&gt;</translation>
+        <location filename="../qml/ModelsView.qml" line="253"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="253"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="261"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="261"/>
-        <source>Describes an error that occurred when downloading</source>
-        <translation>描述下载时发生的错误</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="274"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="274"/>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
-        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="275"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="275"/>
-        <source> Model requires more memory (</source>
-        <translation>模型需要更多内存(</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="276"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="276"/>
-        <source> GB) than your system has available (</source>
-        <translation>GB) 你的系统需要 (</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="283"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="283"/>
-        <source>Error for incompatible hardware</source>
-        <translation>硬件不兼容的错误</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="321"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="321"/>
-        <source>Download progressBar</source>
-        <translation>下载进度</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="322"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="322"/>
-        <source>Shows the progress made in the download</source>
-        <translation>显示下载进度</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="332"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="332"/>
-        <source>Download speed</source>
-        <translation>下载速度</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="333"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="333"/>
-        <source>Download speed in bytes/kilobytes/megabytes per second</source>
-        <translation>下载速度  b/kb/mb /s</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="350"/>
-        <source>Calculating...</source>
-        <translation>计算中...</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="354"/>
-        <location filename="../qml/ModelsView.qml" line="383"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="354"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="383"/>
-        <source>Whether the file hash is being calculated</source>
-        <translation>是否正在计算文件哈希</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="361"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="361"/>
-        <source>Busy indicator</source>
-        <translation>繁忙程度</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="362"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="362"/>
-        <source>Displayed when the file hash is being calculated</source>
-        <translation>在计算文件哈希时显示</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="380"/>
-        <source>enter $API_KEY</source>
-        <translation>输入 $API_KEY</translation>
-    </message>
-    <message>
-        <location filename="../qml/ModelsView.qml" line="402"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="402"/>
-        <source>File size</source>
-        <translation>文件大小</translation>
+        <location filename="../qml/ModelsView.qml" line="272"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="272"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="424"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <source>%1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <source>?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
+        <translation type="vanished">&lt;a href=&quot;#错误&quot;&gt;错误&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="259"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="259"/>
+        <source>Describes an error that occurred when downloading</source>
+        <translation>描述下载时发生的错误</translation>
+    </message>
+    <message>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
+    </message>
+    <message>
+        <source> Model requires more memory (</source>
+        <translation type="vanished">模型需要更多内存(</translation>
+    </message>
+    <message>
+        <source> GB) than your system has available (</source>
+        <translation type="vanished">GB) 你的系统需要 (</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="278"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="278"/>
+        <source>Error for incompatible hardware</source>
+        <translation>硬件不兼容的错误</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="316"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="316"/>
+        <source>Download progressBar</source>
+        <translation>下载进度</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="317"/>
+        <source>Shows the progress made in the download</source>
+        <translation>显示下载进度</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="327"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="327"/>
+        <source>Download speed</source>
+        <translation>下载速度</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="328"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="328"/>
+        <source>Download speed in bytes/kilobytes/megabytes per second</source>
+        <translation>下载速度  b/kb/mb /s</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="345"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="345"/>
+        <source>Calculating...</source>
+        <translation>计算中...</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="349"/>
+        <location filename="../qml/ModelsView.qml" line="378"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="349"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="378"/>
+        <source>Whether the file hash is being calculated</source>
+        <translation>是否正在计算文件哈希</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="356"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="356"/>
+        <source>Busy indicator</source>
+        <translation>繁忙程度</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="357"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="357"/>
+        <source>Displayed when the file hash is being calculated</source>
+        <translation>在计算文件哈希时显示</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="375"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="375"/>
+        <source>enter $API_KEY</source>
+        <translation>输入 $API_KEY</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="397"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="397"/>
+        <source>File size</source>
+        <translation>文件大小</translation>
+    </message>
+    <message>
+        <location filename="../qml/ModelsView.qml" line="419"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="419"/>
         <source>RAM required</source>
         <translation>需要 RAM</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="429"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="429"/>
         <source> GB</source>
-        <translation> GB</translation>
+        <translation type="vanished"> GB</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="446"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="446"/>
+        <location filename="../qml/ModelsView.qml" line="441"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="441"/>
         <source>Parameters</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="468"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="468"/>
+        <location filename="../qml/ModelsView.qml" line="463"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="463"/>
         <source>Quant</source>
         <translation>量化</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="490"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="490"/>
+        <location filename="../qml/ModelsView.qml" line="485"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="485"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
@@ -2390,34 +2536,38 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <translation>欢迎！</translation>
     </message>
     <message>
+        <source>### Release notes
+</source>
+        <translation type="vanished">### 发布日志</translation>
+    </message>
+    <message>
+        <source>### Contributors
+</source>
+        <translation type="vanished">### 贡献者</translation>
+    </message>
+    <message>
         <location filename="../qml/StartupDialog.qml" line="67"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="67"/>
         <source>### Release notes
-</source>
-        <translation>### 发布日志</translation>
+%1### Contributors
+%2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="69"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="69"/>
-        <source>### Contributors
-</source>
-        <translation>### 贡献者</translation>
-    </message>
-    <message>
-        <location filename="../qml/StartupDialog.qml" line="74"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="74"/>
+        <location filename="../qml/StartupDialog.qml" line="71"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="71"/>
         <source>Release notes</source>
         <translation>发布日志</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="75"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="75"/>
+        <location filename="../qml/StartupDialog.qml" line="72"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="72"/>
         <source>Release notes for this version</source>
         <translation>本版本发布日志</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="90"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="90"/>
+        <location filename="../qml/StartupDialog.qml" line="87"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="87"/>
         <source>### Opt-ins for anonymous usage analytics and datalake
 By enabling these features, you will be able to participate in the democratic process of training a
 large language model by contributing data for future model improvements.
@@ -2442,88 +2592,88 @@ model release that uses your data!</source>
         模型发布的贡献者！</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="109"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="109"/>
+        <location filename="../qml/StartupDialog.qml" line="106"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="106"/>
         <source>Terms for opt-in</source>
         <translation>选择加入选项</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="110"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="110"/>
+        <location filename="../qml/StartupDialog.qml" line="107"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="107"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>描述选择加入时会发生的情况</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="127"/>
-        <location filename="../qml/StartupDialog.qml" line="153"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="127"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="153"/>
+        <location filename="../qml/StartupDialog.qml" line="124"/>
+        <location filename="../qml/StartupDialog.qml" line="150"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="124"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="150"/>
         <source>Opt-in for anonymous usage statistics</source>
         <translation>允许选择加入匿名使用统计数据</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="150"/>
-        <location filename="../qml/StartupDialog.qml" line="265"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="150"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="265"/>
+        <location filename="../qml/StartupDialog.qml" line="147"/>
+        <location filename="../qml/StartupDialog.qml" line="262"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="147"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="262"/>
         <source>Yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="154"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="154"/>
+        <location filename="../qml/StartupDialog.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="151"/>
         <source>Allow opt-in for anonymous usage statistics</source>
         <translation>允许选择加入匿名使用统计数据</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="192"/>
-        <location filename="../qml/StartupDialog.qml" line="307"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="192"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="307"/>
+        <location filename="../qml/StartupDialog.qml" line="189"/>
+        <location filename="../qml/StartupDialog.qml" line="304"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="189"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="304"/>
         <source>No</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="195"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="195"/>
+        <location filename="../qml/StartupDialog.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="192"/>
         <source>Opt-out for anonymous usage statistics</source>
         <translation>退出匿名使用统计数据</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="196"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="196"/>
+        <location filename="../qml/StartupDialog.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="193"/>
         <source>Allow opt-out for anonymous usage statistics</source>
         <translation>允许选择退出匿名使用统计数据</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="241"/>
-        <location filename="../qml/StartupDialog.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="241"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="268"/>
+        <location filename="../qml/StartupDialog.qml" line="238"/>
+        <location filename="../qml/StartupDialog.qml" line="265"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="238"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="265"/>
         <source>Opt-in for network</source>
         <translation>加入网络</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="242"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="242"/>
+        <location filename="../qml/StartupDialog.qml" line="239"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="239"/>
         <source>Allow opt-in for network</source>
         <translation>允许选择加入网络</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="269"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="269"/>
+        <location filename="../qml/StartupDialog.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="266"/>
         <source>Allow opt-in anonymous sharing of chats to the GPT4All Datalake</source>
         <translation>允许选择加入匿名共享聊天至 GPT4All 数据湖</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="310"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="310"/>
+        <location filename="../qml/StartupDialog.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="307"/>
         <source>Opt-out for network</source>
         <translation>取消网络</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="311"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="311"/>
+        <location filename="../qml/StartupDialog.qml" line="308"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="308"/>
         <source>Allow opt-out anonymous sharing of chats to the GPT4All Datalake</source>
         <translation>允许选择退出将聊天匿名共享至 GPT4All 数据湖</translation>
     </message>
@@ -2599,90 +2749,78 @@ model release that uses your data!</source>
 <context>
     <name>main</name>
     <message>
+        <source>GPT4All v</source>
+        <translation type="vanished">GPT4All v</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;</source>
+        <translation type="vanished">&lt;h3&gt;启动时遇到错误：:&lt;/h3&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;</source>
+        <translation type="vanished">&lt;i&gt;&quot;检测到硬件不兼容&quot;&lt;/i&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run </source>
+        <translation type="vanished">&lt;br&gt;&lt;br&gt;您的CPU不符合运行的最低要求</translation>
+    </message>
+    <message>
+        <source>this program. In particular, it does not support AVX intrinsics which this </source>
+        <translation type="vanished">这个问题是因为它不支持AVX 版本</translation>
+    </message>
+    <message>
+        <source>program requires to successfully run a modern large language model. </source>
+        <translation type="vanished">程序需要成功运行现代大型语言模型</translation>
+    </message>
+    <message>
+        <source>The only solution at this time is to upgrade your hardware to a more modern CPU.</source>
+        <translation type="vanished">目前唯一的解决方案是将硬件升级到更现代化的CPU。</translation>
+    </message>
+    <message>
+        <source>&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</source>
+        <translation type="vanished">&lt;br&gt;&lt;br&gt;请参阅此处了解更多信息： &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</translation>
+    </message>
+    <message>
+        <source>https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+        <translation type="vanished">https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;</source>
+        <translation type="vanished">&lt;i&gt;&quot;无法访问设置文件。&quot;&lt;/i&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing </source>
+        <translation type="vanished">&lt;br&gt;&lt;br&gt;不幸的是，有什么东西阻止了程序访问 </translation>
+    </message>
+    <message>
+        <source>the settings file. This could be caused by incorrect permissions in the local </source>
+        <translation type="vanished">设置文件。这可能是由于本地中的权限不正确造成的</translation>
+    </message>
+    <message>
+        <source>app config directory where the settings file is located. </source>
+        <translation type="vanished">设置文件所在的应用程序配置目录</translation>
+    </message>
+    <message>
+        <source>Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
+        <translation type="vanished">检查链接 &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; 寻求.</translation>
+    </message>
+    <message>
         <location filename="../main.qml" line="23"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="23"/>
-        <source>GPT4All v</source>
-        <translation>GPT4All v</translation>
+        <source>GPT4All v%1</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="111"/>
-        <location filename="../main.qml" line="127"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="111"/>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only solution at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../main.qml" line="127"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="127"/>
-        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;</source>
-        <translation>&lt;h3&gt;启动时遇到错误：:&lt;/h3&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="112"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="112"/>
-        <source>&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;</source>
-        <translation>&lt;i&gt;&quot;检测到硬件不兼容&quot;&lt;/i&gt;</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="113"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="113"/>
-        <source>&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run </source>
-        <translation>&lt;br&gt;&lt;br&gt;您的CPU不符合运行的最低要求</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="114"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="114"/>
-        <source>this program. In particular, it does not support AVX intrinsics which this </source>
-        <translation>这个问题是因为它不支持AVX 版本</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="115"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="115"/>
-        <source>program requires to successfully run a modern large language model. </source>
-        <translation>程序需要成功运行现代大型语言模型</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="116"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="116"/>
-        <source>The only solution at this time is to upgrade your hardware to a more modern CPU.</source>
-        <translation>目前唯一的解决方案是将硬件升级到更现代化的CPU。</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="117"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="117"/>
-        <source>&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</source>
-        <translation>&lt;br&gt;&lt;br&gt;请参阅此处了解更多信息： &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="118"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="118"/>
-        <source>https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-        <translation>https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="128"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="128"/>
-        <source>&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;</source>
-        <translation>&lt;i&gt;&quot;无法访问设置文件。&quot;&lt;/i&gt;</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="129"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="129"/>
-        <source>&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing </source>
-        <translation>&lt;br&gt;&lt;br&gt;不幸的是，有什么东西阻止了程序访问 </translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="130"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="130"/>
-        <source>the settings file. This could be caused by incorrect permissions in the local </source>
-        <translation>设置文件。这可能是由于本地中的权限不正确造成的</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="131"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="131"/>
-        <source>app config directory where the settings file is located. </source>
-        <translation>设置文件所在的应用程序配置目录</translation>
-    </message>
-    <message>
-        <location filename="../main.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="132"/>
-        <source>Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
-        <translation>检查链接 &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; 寻求.</translation>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing the settings file. This could be caused by incorrect permissions in the local app config directory where the settings file is located. Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="155"/>


### PR DESCRIPTION
This change updates the UI to allow for dynamic changes of language and locale at runtime. Right now none of the language translations are finished yet or in releasable shape so it also adds a new option to the build that enables/disables the feature. By default no translations are currently enabled to be built as part of a release.

https://github.com/nomic-ai/gpt4all/blob/main/gpt4all-chat/contributing_translations.md has been updated to show this PR in action.

It is necessary to merge this into the main branch even though none of the translations are built by default without turning on a build flag. Without merging this into the main branch the strings will hopelessly fall behind what the translators are using. I think this is a good compromise of putting it in main but not changing any default behavior before the translations are ready.