### PR TITLE
Improve LocalDocs view's error message

### DIFF
--- a/gpt4all-chat/database.cpp
+++ b/gpt4all-chat/database.cpp
@@ -844,6 +844,10 @@ bool Database::hasContent()
 
 int Database::openDatabase(const QString &modelPath, bool create, int ver)
 {
+    if (!QFileInfo(modelPath).isDir()) {
+        qWarning() << "ERROR: invalid download path" << modelPath;
+        return -1;
+    }
     if (m_db.isOpen())
         m_db.close();
     auto dbPath = u"%1/localdocs_v%2.db"_s.arg(modelPath).arg(ver);
@@ -851,7 +855,7 @@ int Database::openDatabase(const QString &modelPath, bool create, int ver)
         return 0;
     m_db.setDatabaseName(dbPath);
     if (!m_db.open()) {
-        qWarning() << "ERROR: opening db" << m_db.lastError();
+        qWarning() << "ERROR: opening db" << dbPath << m_db.lastError();
         return -1;
     }
     return hasContent();

--- a/gpt4all-chat/qml/LocalDocsView.qml
+++ b/gpt4all-chat/qml/LocalDocsView.qml
@@ -82,11 +82,16 @@ Rectangle {
             visible: !LocalDocs.databaseValid
             Text {
                 anchors.centerIn: parent
-                horizontalAlignment: Qt.AlignHCenter
-                text: qsTr("ERROR: The LocalDocs database is not valid.")
+                text: qsTr("<h3>ERROR: The LocalDocs database cannot be accessed or is not valid.</h3><br>"
+                         + "<i>Note: You will need to restart after trying any of the following suggested fixes.</i><br>"
+                         + "<ul><li>Make sure that the folder set as <b>Download Path</b> exists on the file system.</li>"
+                         + "<li>Check ownership as well as read and write permissions of the <b>Download Path</b>.</li>"
+                         + "<li>If there is a <b>localdocs_v2.db</b> file, check its ownership and read/write "
+                         + "permissions, too.</li></ul><br>"
+                         + "If the problem persists and there are any 'localdocs_v*.db' files present, as a last resort you can<br>"
+                         + "try backing them up and removing them. You will have to recreate your collections, however.")
                 color: theme.textErrorColor
-                font.bold: true
-                font.pixelSize: theme.fontSizeLargest
+                font.pixelSize: theme.fontSizeLarger
             }
         }
 


### PR DESCRIPTION
- See notes below, there are some additional considerations.


## Describe your changes
- LocalDocsView.qml: better message and suggested fixes
- database.cpp:
  - log db path
  - error if Download Path doesn't exist

## Issue ticket number and link
- Regarding: #2516

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
New `LocalDocsView.qml` message:
![image](https://github.com/user-attachments/assets/a36a096b-bd73-4563-bded-9e9718b6b436)

### Steps to Reproduce
For people who run into edge cases. E.g. set *Download Path* to a non-existent directory, relaunch, then switch to LocalDocs view.

## Notes
I have tried a few things since the original PR (#2652) but have not been able to reproduce the case where simply deleting the DB files fixes the problem. (Although it could always be a permissions issue.)

**I'll leave it at this PR for now, might revisit with some other improvements in a new one if I manage to pin it down.**

As mentioned in the older PR, there are some things to be wary of in general:
- As far as I understand, SQLite can write several temporary files for bookkeeping not only next to the DB (*Download Path*),
but also in a system temp folder and potentially even the current working directory. All of these could cause permission problems in rare cases. See SQLite docs: [Temporary Files Used By SQLite](https://www.sqlite.org/tempfiles.html)

- When something goes wrong with `QSqlDatabase::open()`, at least there's a connection error returned from the Qt DB API, which is then logged. Unfortunately, it might just be an SQLite error code + general message. Codes in SQLite docs which I think correspond to this: [Primary Result Code List](https://www.sqlite.org/rescode.html#primary_result_code_list)
  - Not sure if this should be exposed in some way other than the log.
  - The log should also at least include the DB's file name or path (as mentioned on discord).

- Unclear what happens when people try to mount and use remote file systems, i.e. the *Download Path* is on a shared folder. I think SQLite has some expectations regarding file system capabilities, which might not fulfilled in such a scenario.
