### PR TITLE
Case insensitive compare that pairs with issue #2609

### DIFF
--- a/gpt4all-chat/database.h
+++ b/gpt4all-chat/database.h
@@ -45,7 +45,7 @@ struct DocumentInfo
     size_t currentPosition = 0;
     bool currentlyProcessing = false;
     bool isPdf() const {
-        return doc.suffix() == u"pdf"_s;
+        return doc.suffix().compare(u"pdf"_s, Qt::CaseInsensitive) == 0;
     }
 };
 


### PR DESCRIPTION
In previous commit 9e4991aced0571eb8db1fc07dfb7a5000932ed33 allowed case insensitive matches of file extensions. As cosmic-snow aptly pointed out this still was a case sensitive match.

