### PR TITLE
ci: update deprecated Windows Server 2022 image

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1083,7 +1083,7 @@ jobs:
 
   build-bindings-backend-windows:
     machine:
-      image: 'windows-server-2022-gui:2023.03.1'
+      image: 'windows-server-2022-gui:current'
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1427,8 +1427,6 @@ workflows:
     jobs:
       - hold:
           type: approval
-      - nuget-hold:
-          type: approval
       - nodejs-hold:
           type: approval
       - npm-hold:


### PR DESCRIPTION
As per [this post](https://discuss.circleci.com/t/windows-image-deprecations-and-eol-for-2024/50179), the `windows-server-2022-gui:2023.03.1` image is deprecated and will be subject to a brownout this month (25th as per e-mail, 31st as per the post).

This PR changes the tag to `current` to avoid this problem in the future.