### PR TITLE
Show scrollbar in CollectionsDrawer as needed

### DIFF
--- a/gpt4all-chat/qml/CollectionsDrawer.qml
+++ b/gpt4all-chat/qml/CollectionsDrawer.qml
@@ -40,12 +40,6 @@ Rectangle {
             id: listView
             model: LocalDocs.localDocsModel
             boundsBehavior: Flickable.StopAtBounds
-            ScrollBar.vertical: ScrollBar {
-                parent: listView.parent
-                anchors.top: listView.top
-                anchors.left: listView.right
-                anchors.bottom: listView.bottom
-            }
             spacing: 15
 
             delegate: Rectangle {

--- a/gpt4all-chat/qml/CollectionsDrawer.qml
+++ b/gpt4all-chat/qml/CollectionsDrawer.qml
@@ -31,7 +31,8 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.left: borderLeft.right
         anchors.right: parent.right
-        anchors.margins: 15
+        anchors.margins: 2
+        anchors.bottomMargin: 10
         clip: true
         contentHeight: 300
         ScrollBar.vertical.policy: ScrollBar.AsNeeded
@@ -39,6 +40,9 @@ Rectangle {
         ListView {
             id: listView
             model: LocalDocs.localDocsModel
+            anchors.fill: parent
+            anchors.margins: 13
+            anchors.bottomMargin: 5
             boundsBehavior: Flickable.StopAtBounds
             spacing: 15
 

--- a/gpt4all-chat/qml/CollectionsDrawer.qml
+++ b/gpt4all-chat/qml/CollectionsDrawer.qml
@@ -34,7 +34,7 @@ Rectangle {
         anchors.margins: 15
         clip: true
         contentHeight: 300
-        ScrollBar.vertical.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical.policy: ScrollBar.AsNeeded
 
         ListView {
             id: listView


### PR DESCRIPTION
Fixes #2573.

## Describe your changes
Make the scrollbar visible (`AsNeeded`) when there are more collections to display than what fits the height.

## Issue ticket number and link
* #2573 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Before: see linked issue
After:
![image](https://github.com/user-attachments/assets/0289ba49-d5bf-4e8b-9b71-698ab3006870)

### Steps to Reproduce
Have more collections than what fits in the right drawer in chat.

## Notes
Maybe I'm missing something here, but there already was a `ScrollView` in place, just the scrollbar turned off for some reason.
So this might not be the proper way to address the issue.
