### PR TITLE
chatllm: fix loading of chats after #2676

### DIFF
--- a/gpt4all-chat/chatllm.cpp
+++ b/gpt4all-chat/chatllm.cpp
@@ -37,6 +37,7 @@ using namespace Qt::Literals::StringLiterals;
 //#define DEBUG
 //#define DEBUG_MODEL_LOADING
 
+#define GPTJ_INTERNAL_STATE_VERSION  0 // GPT-J is gone but old chats still use this
 #define LLAMA_INTERNAL_STATE_VERSION 0
 
 class LLModelStore {
@@ -1055,6 +1056,7 @@ bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
     if (version > 1) {
         stream << m_llModelType;
         switch (m_llModelType) {
+        case GPTJ_: stream << GPTJ_INTERNAL_STATE_VERSION; break;
         case LLAMA_: stream << LLAMA_INTERNAL_STATE_VERSION; break;
         default: Q_UNREACHABLE();
         }

--- a/gpt4all-chat/chatllm.h
+++ b/gpt4all-chat/chatllm.h
@@ -28,9 +28,12 @@ using namespace Qt::Literals::StringLiterals;
 
 class QDataStream;
 
+// NOTE: values serialized to disk, do not change or reuse
 enum LLModelType {
-    LLAMA_,
-    API_,
+    GPTJ_  = 0, // no longer used
+    LLAMA_ = 1,
+    API_   = 2,
+    BERT_  = 3, // no longer used
 };
 
 class ChatLLM;


### PR DESCRIPTION
After #2676, attempting to load old chats crashes GPT4All. This is because the values of LLModelType, which are serialized to disk, have changed. The new builds of GPT4All misinterpret the old values of LLModelType and read bad data (Llama is loaded as ChatAPI).

This PR adds back the old enumeration values and tries to make it as clear as possible that they are not arbitrary and should not be changed.

Serialization for the GPT-J model type is also restored so GPT4All does not hit Q_UNREACHABLE on exit if there is an existing chat with one of these models.