### PR TITLE
llamamodel: always print special tokens

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -542,10 +542,10 @@ std::vector<LLModel::Token> LLamaModel::tokenize(PromptContext &ctx, const std::
 std::string LLamaModel::tokenToString(Token id) const
 {
     std::vector<char> result(8, 0);
-    const int n_tokens = llama_token_to_piece(d_ptr->model, id, result.data(), result.size(), 0, false);
+    const int n_tokens = llama_token_to_piece(d_ptr->model, id, result.data(), result.size(), 0, true);
     if (n_tokens < 0) {
         result.resize(-n_tokens);
-        int check = llama_token_to_piece(d_ptr->model, id, result.data(), result.size(), 0, false);
+        int check = llama_token_to_piece(d_ptr->model, id, result.data(), result.size(), 0, true);
         GGML_ASSERT(check == -n_tokens);
     }
     else {


### PR DESCRIPTION
This assertion fails when [gemma-2-9b-it](https://huggingface.co/google/gemma-2-9b-it) tries to print `<end_of_text>`, which is not its EOS token. Historically, special tokens in output have been rendered as an empty string in llama.cpp and thus GPT4All has done the same.

https://github.com/nomic-ai/gpt4all/blob/54ed30937f717286083c7071e288393a3c49a769/gpt4all-chat/chatllm.cpp#L694

This is a familiar problem with other models such as Hermes 2 Pro Mistral 7B and even Llama 3 (prior to the [upstream fix](https://huggingface.co/meta-llama/Meta-Llama-3-8B-Instruct/commit/a8977699a3d0820e80129fb3c93c20fbd9972c41)), see also #2167.

This works around the problem by printing the tokens instead of rendering them as blanks, which recently became possible with the `special` argument to llama_token_to_piece. We should also fix the bugs that cause empty tokens to crash/hang GPT4All, as there's nothing strictly preventing tokenToString from returning an empty string, but this should get us by for now.

Hermes 2 Pro Mistral 7B generates garbage after its response with this change since it was never trained on generations past the EOS token it tries to output, but at least you can *stop* the generation instead of having to restart GPT4All due to the hang.

***

The changelog is not merged yet, but the entry for this PR should be under "Fixed" and read:
```md
- Fix crash/hang when certain models finish generation by printing special tokens in output ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
```