### PR TITLE
llamamodel: add DeepSeek-V2 to whitelist

### DIFF
--- a/gpt4all-backend/llamamodel.cpp
+++ b/gpt4all-backend/llamamodel.cpp
@@ -81,7 +81,7 @@ static const std::vector<const char *> KNOWN_ARCHES {
     "olmo",
     "openelm",
     // "arctic", -- 10B+128x3.66B parameters
-    // "deepseek2", -- excessive VRAM requirements
+    "deepseek2",
     "chatglm",
     // "bitnet", -- tensor not within file bounds?
     // "t5", -- seq2seq model


### PR DESCRIPTION
This model actually works fine. I tried it with llama-cli before, but was thrown off by its huge default context size. With GPT4All's context size of 2K, this model works fine with CUDA. It doesn't work with Kompute due to the lack of MoE support.

***

The changelog is not merged yet, but this patch should be applied:
```diff
diff --git a/gpt4all-chat/CHANGELOG.md b/gpt4all-chat/CHANGELOG.md
index b56b993c..bc75cb6c 100644
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -28,8 +28,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Support translation of settings choices ([#2667](https://github.com/nomic-ai/gpt4all/pull/2667), [#2690](https://github.com/nomic-ai/gpt4all/pull/2690))
 - Improve LocalDocs view's error message (by @cosmic-snow in [#2679](https://github.com/nomic-ai/gpt4all/pull/2679))
 - Ignore case of LocalDocs file extensions ([#2642](https://github.com/nomic-ai/gpt4all/pull/2642), [#2684](https://github.com/nomic-ai/gpt4all/pull/2684))
-- Update llama.cpp to commit 87e397d00 from July 19th ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
+- Update llama.cpp to commit 87e397d00 from July 19th ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694), [#2702](https://github.com/nomic-ai/gpt4all/pull/2702))
   - Add support for GPT-NeoX, Gemma 2, OpenELM, ChatGLM, and Jais architectures (all with Vulkan support)
+  - Add support for DeepSeek-V2 architecture (no Vulkan support)
   - Enable Vulkan support for StarCoder2, XVERSE, Command R, and OLMo
 - Show scrollbar in chat collections list as needed (by [@cosmic-snow](https://github.com/cosmic-snow) in [#2691](https://github.com/nomic-ai/gpt4all/pull/2691))
 
```