### PR TITLE
Models: Add Qwen2-1.5B-Instruct

### DIFF
--- a/gpt4all-chat/metadata/models3.json
+++ b/gpt4all-chat/metadata/models3.json
@@ -386,5 +386,21 @@
     "systemPrompt": "",
     "description": "nomic-embed-text-v1.5",
     "url": "https://gpt4all.io/models/gguf/nomic-embed-text-v1.5.f16.gguf"
+  },
+  {
+    "order": "z",
+    "md5sum": "a8c5a783105f87a481543d4ed7d7586d",
+    "name": "Qwen2-1.5B-Instruct",
+    "filename": "qwen2-1_5b-instruct-q4_0.gguf",
+    "filesize": "937532800",
+    "requires": "3.0",
+    "ramrequired": "4",
+    "parameters": "1.5 billion",
+    "quant": "q4_0",
+    "type": "qwen2",
+    "description": "<ul><li>Very fast responses</li><li>Instruction based model</li><li>Usage of LocalDocs (RAG): Highly recommended</li><li>Trained and finetuned by Qwen (Alibaba Cloud)</li><li>License: <a href=\"https://www.apache.org/licenses/LICENSE-2.0.html/\">Apache 2.0</a></li></ul>",
+    "url": "https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q4_0.gguf",
+    "promptTemplate": "<|im_start|>user\n%1<|im_end|>\n<|im_start|>assistant\n%2<|im_end|>",
+    "systemPrompt": "<|im_start|>system\nBelow is an instruction that describes a task. Write a response that appropriately completes the request.<|im_end|>\n"
   }
 ]

--- a/gpt4all-chat/metadata/models3.json
+++ b/gpt4all-chat/metadata/models3.json
@@ -398,7 +398,7 @@
     "parameters": "1.5 billion",
     "quant": "q4_0",
     "type": "qwen2",
-    "description": "<ul><li>Very fast responses</li><li>Instruction based model</li><li>Usage of LocalDocs (RAG): Highly recommended</li><li>Trained and finetuned by Qwen (Alibaba Cloud)</li><li>License: <a href=\"https://www.apache.org/licenses/LICENSE-2.0.html/\">Apache 2.0</a></li></ul>",
+    "description": "<ul><li>Very fast responses</li><li>Instruction based model</li><li>Usage of LocalDocs (RAG): Highly recommended</li><li>Supports context length of up to 32768</li><li>Trained and finetuned by Qwen (Alibaba Cloud)</li><li>License: <a href=\"https://www.apache.org/licenses/LICENSE-2.0.html/\">Apache 2.0</a></li></ul>",
     "url": "https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF/resolve/main/qwen2-1_5b-instruct-q4_0.gguf",
     "promptTemplate": "<|im_start|>user\n%1<|im_end|>\n<|im_start|>assistant\n%2<|im_end|>",
     "systemPrompt": "<|im_start|>system\nBelow is an instruction that describes a task. Write a response that appropriately completes the request.<|im_end|>\n"


### PR DESCRIPTION
Adds model support for [Qwen2-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2-1.5B-Instruct-GGUF)

### Description of Model

It is a tiny bilingual model and at the date of writing with very strong results in benchmarks (for its parameter size). It supports a context of up to 32768. Because of its model size it has very fast responses, even when doing inference on CPU. This LLM is LITERALLY for all. Since the model fits into 4GB of RAM (just barely, if the Operating System and other apps also need RAM) or alternatively into 3GB of VRAM, this will be the workhorse of the desperate and hardware poor.

- The model was trained/finetuned on English and Chinese language
- License: Apache 2.0

### Personal Impression:
I got the impression the model is very task focused and this is the reason, why I chose  `Below is an instruction that describes a task. Write a response that appropriately completes the request.` as system prompt. Since the model is relatively small, its responses may seem not very coherent or intelligent, but it works surprisingly well with GPT4All's LocalDocs feature. It is like the model was made for RAG. Its long context adds to that. It mainly will appeal to English and Chinese speaking users.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.
