### PR TITLE
Fix LocalDocs file icons in sources display (mixed case)

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1292,11 +1292,11 @@ Rectangle {
                                                                 sourceSize.height: 24
                                                                 mipmap: true
                                                                 source: {
-                                                                    if (modelData.file.endsWith(".txt"))
+                                                                    if (modelData.file.toLowerCase().endsWith(".txt"))
                                                                         return "qrc:/gpt4all/icons/file-txt.svg"
-                                                                    else if (modelData.file.endsWith(".pdf"))
+                                                                    else if (modelData.file.toLowerCase().endsWith(".pdf"))
                                                                         return "qrc:/gpt4all/icons/file-pdf.svg"
-                                                                    else if (modelData.file.endsWith(".md"))
+                                                                    else if (modelData.file.toLowerCase().endsWith(".md"))
                                                                         return "qrc:/gpt4all/icons/file-md.svg"
                                                                     else
                                                                         return "qrc:/gpt4all/icons/file.svg"


### PR DESCRIPTION
## Describe your changes
Minor, cosmetic fix to the file icon which is shown as a LocalDocs source. A recent commit has allowed the file suffixes to be mixed case, this makes the displayed icon consistent, so that e.g. '.PDF' is uses the right icon, as well.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
**After:**
![image](https://github.com/user-attachments/assets/132c396b-c716-4ee3-8b72-f8468454c648)

**Before:**
![image](https://github.com/user-attachments/assets/da226d25-5105-4ce7-9361-9fd3c74dbe29)

### Steps to Reproduce
Have a mixed-case file ending in your LocalDocs collection, e.g. `.PDF`, or as in the example `.pDf`
