### PR TITLE
chat: fix comparison of prerelease versions

### DIFF
--- a/gpt4all-chat/download.h
+++ b/gpt4all-chat/download.h
@@ -57,6 +57,7 @@ class Download : public QObject
 public:
     static Download *globalInstance();
 
+    static std::strong_ordering compareAppVersions(const QString &a, const QString &b);
     ReleaseInfo releaseInfo() const;
     bool hasNewerRelease() const;
     QString latestNews() const { return m_latestNews; }


### PR DESCRIPTION
Ordering before this PR (not deterministic, but this is one possibility):
```
foo
fooa
foob
2.0
2.0.0 (greater than 2.0)
2.0.99-dev99
2.0.99-blah
2.0.99-dev0
2.0.99-rc20
2.0.99-rc2
2.0.99-rc11
2.0.99-rc10
2.0.99-rc1
2.0.99-post1
2.0.99
2.1.0-rc1
2.1.0
3.0.0-dev0
3.0.0
3.0.1-dev1
3.0.1-dev0
3.0.1
3.1.0
4.1.0
```

Ordering after this PR:
```
foo
fooa
foob
2.0.0
2.0 (equal to 2.0.0)
2.0.99-dev0
2.0.99-dev99
2.0.99-rc1
2.0.99-rc2
2.0.99-rc10
2.0.99-rc11
2.0.99-rc20
2.0.99
2.0.99-blah
2.0.99-post1
2.1.0-rc1
2.1.0
3.0.0-dev0
3.0.0
3.0.1-dev0
3.0.1-dev1
3.0.1
3.1.0
4.1.0
```

The order is now deterministic as it never ignores any part of the version. Pre-release versions compare as *less* than the stable releases that come after. ~~This means we shouldn't use post-release suffixes (e.g. v3.1.1-web_search_beta_2 after v3.1.1) unless we can agree on what pre-release and post-release suffixes look like (maybe -dev and -rc are the only pre-release suffixes?)~~ We agreed to use -devX and -rcX for pre-releases and treat everything else as a post-release.

This PR also fixes an assertion failure caused by the combination of #2759 and #2762.