### PR TITLE
Don't allow zero as temperature in ModelSettings.qml

### DIFF
--- a/gpt4all-chat/modellist.cpp
+++ b/gpt4all-chat/modellist.cpp
@@ -178,11 +178,13 @@ void ModelInfo::setRecency(const QDateTime &r)
 
 double ModelInfo::temperature() const
 {
-    return MySettings::globalInstance()->modelTemperature(*this);
+    double t = MySettings::globalInstance()->modelTemperature(*this);
+    return t < 0.000001 ? 0.000001 : t;
 }
 
 void ModelInfo::setTemperature(double t)
 {
+    if (t < 0.000001) t = 0.000001;
     if (shouldSaveMetadata()) MySettings::globalInstance()->setModelTemperature(*this, t, true /*force*/);
     m_temperature = t;
 }

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -443,8 +443,15 @@ MySettingsTab {
                             Qt.locale().name, { maximumSignificantDigits: 6 });
                     }
                 }
+                function parseLocaleNumber(text) {
+                    try {
+                        return Number.fromLocaleString(Qt.locale(), text);
+                    } catch (e) {
+                        return Number.NaN;
+                    }
+                }
                 onEditingFinished: {
-                    var val = parseFloat(text)
+                    var val = parseLocaleNumber(text);
                     if (!isNaN(val)) {
                         if (val < 0.000001) {
                             val = 0.000001;

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -432,13 +432,15 @@ MySettingsTab {
                 Connections {
                     target: MySettings
                     function onTemperatureChanged() {
-                        temperatureField.text = root.currentModelInfo.temperature;
+                        temperatureField.text = root.currentModelInfo.temperature.toLocaleString(
+                            Qt.locale().name, { maximumSignificantDigits: 6 });
                     }
                 }
                 Connections {
                     target: root
                     function onCurrentModelInfoChanged() {
-                        temperatureField.text = root.currentModelInfo.temperature;
+                        temperatureField.text = root.currentModelInfo.temperature.toLocaleString(
+                            Qt.locale().name, { maximumSignificantDigits: 6 });
                     }
                 }
                 onEditingFinished: {
@@ -446,6 +448,8 @@ MySettingsTab {
                     if (!isNaN(val)) {
                         if (val < 0.000001) {
                             val = 0.000001;
+                            temperatureField.text = val.toLocaleString(
+                                Qt.locale().name, { maximumSignificantDigits: 6 });
                         }
                         MySettings.setModelTemperature(root.currentModelInfo, val)
                         focus = false

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -418,7 +418,6 @@ MySettingsTab {
 
             MyTextField {
                 id: temperatureField
-                text: root.currentModelInfo.temperature
                 inputMethodHints: Qt.ImhPreferNumbers
                 font.pixelSize: theme.fontSizeLarge
                 color: theme.textColor
@@ -427,27 +426,32 @@ MySettingsTab {
                 Layout.row: 1
                 Layout.column: 3
                 validator: DoubleValidator {
-                    locale: "C"
+                    locale: Qt.locale().name
+                }
+                function toLocaleString(number) {
+                    console.assert(typeof number == 'number', "Number expected");
+                    let numberStr = number.toLocaleString(Qt.locale(), 'f', 6);
+                    const trailingZeroes = /0+$/;
+                    return numberStr.replace(trailingZeroes, '');
+                }
+                function parseLocaleNumber(text) {
+                    console.assert(typeof text == 'string', "String expected");
+                    try {
+                        return Number.fromLocaleString(Qt.locale(), text);
+                    } catch (e) {
+                        return Number.NaN;
+                    }
                 }
                 Connections {
                     target: MySettings
                     function onTemperatureChanged() {
-                        temperatureField.text = root.currentModelInfo.temperature.toLocaleString(
-                            Qt.locale().name, { maximumSignificantDigits: 6 });
+                        temperatureField.text = temperatureField.toLocaleString(root.currentModelInfo.temperature);
                     }
                 }
                 Connections {
                     target: root
                     function onCurrentModelInfoChanged() {
-                        temperatureField.text = root.currentModelInfo.temperature.toLocaleString(
-                            Qt.locale().name, { maximumSignificantDigits: 6 });
-                    }
-                }
-                function parseLocaleNumber(text) {
-                    try {
-                        return Number.fromLocaleString(Qt.locale(), text);
-                    } catch (e) {
-                        return Number.NaN;
+                        temperatureField.text = temperatureField.toLocaleString(root.currentModelInfo.temperature);
                     }
                 }
                 onEditingFinished: {
@@ -455,13 +459,12 @@ MySettingsTab {
                     if (!isNaN(val)) {
                         if (val < 0.000001) {
                             val = 0.000001;
-                            temperatureField.text = val.toLocaleString(
-                                Qt.locale().name, { maximumSignificantDigits: 6 });
+                            temperatureField.text = toLocaleString(val);
                         }
-                        MySettings.setModelTemperature(root.currentModelInfo, val)
-                        focus = false
+                        MySettings.setModelTemperature(root.currentModelInfo, val);
+                        focus = false;
                     } else {
-                        text = root.currentModelInfo.temperature
+                        text = toLocaleString(root.currentModelInfo.temperature);
                     }
                 }
                 Accessible.role: Accessible.EditableText

--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -419,6 +419,7 @@ MySettingsTab {
             MyTextField {
                 id: temperatureField
                 text: root.currentModelInfo.temperature
+                inputMethodHints: Qt.ImhPreferNumbers
                 font.pixelSize: theme.fontSizeLarge
                 color: theme.textColor
                 ToolTip.text: qsTr("Temperature increases the chances of choosing less likely tokens.\nNOTE: Higher temperature gives more creative but less predictable outputs.")
@@ -443,6 +444,9 @@ MySettingsTab {
                 onEditingFinished: {
                     var val = parseFloat(text)
                     if (!isNaN(val)) {
+                        if (val < 0.000001) {
+                            val = 0.000001;
+                        }
                         MySettings.setModelTemperature(root.currentModelInfo, val)
                         focus = false
                     } else {


### PR DESCRIPTION
## Describe your changes
A number lower than 0.000001 is set to that value instead.

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
Editing:
![image](https://github.com/user-attachments/assets/a367adb0-4f87-4783-9922-9eb453097605)

After edit:
![image](https://github.com/user-attachments/assets/99b9f0e6-9bf6-4fda-bf5f-3a050921e623)

### Steps to Reproduce
Right now, setting temperature to zero is allowed, but it shouldn't be.

## Notes
~~This PR is meant to be seen as a suggestion for now.~~

~~I'm setting this as draft~~ for the following reasons:
* Maybe this should be handled in the backend instead, and maybe 0 as temperature should be allowed again.
* ~~I think it prevents setting zero as a value, but it seems to be flaky in the UI regardless (e.g. when I Alt-Tab).~~
* ~~I have not figured out how to get rid of the scientific notation after it corrects itself.~~