### PR TITLE
python: detect Rosetta 2

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -6,6 +6,7 @@ import platform
 import re
 import subprocess
 import sys
+import textwrap
 import threading
 from enum import Enum
 from queue import Queue
@@ -27,6 +28,16 @@ if TYPE_CHECKING:
 
 EmbeddingsType = TypeVar('EmbeddingsType', bound='list[Any]')
 
+
+# Detect Rosetta 2
+if platform.system() == "Darwin" and platform.processor() == "i386":
+    if subprocess.run(
+        "sysctl -n sysctl.proc_translated".split(), check=True, capture_output=True, text=True,
+    ).stdout.strip() == "1":
+        raise RuntimeError(textwrap.dedent("""\
+            Running GPT4All under Rosetta is not supported due to CPU feature requirements.
+            Please install GPT4All in an environment that uses a native ARM64 Python interpreter.
+        """))
 
 # Find CUDA libraries from the official packages
 cuda_found = False

--- a/gpt4all-bindings/python/setup.py
+++ b/gpt4all-bindings/python/setup.py
@@ -68,7 +68,7 @@ def get_long_description():
 
 setup(
     name=package_name,
-    version="3.0.0",
+    version="2.8.0.dev0",
     description="Python bindings for GPT4All",
     long_description=get_long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add explicit Rosetta 2 detection to make it more clear to users when they are trying to do something unsupported.

Related to #2744, in which a user reports a GPT4All issue after seeing the AVX error we typically show in this case. Users will think: "I'm on Apple Silicon, why do I need AVX?" They may not be aware that they are using an emulated x86_64 build of Python (or think there could be a problem with that).

Tested on my M2 MacBook Pro with an x86_64 version of Python. It does detect it as expected without rejecting the standard arm64 version. Intel Macs are still supported (in theory, nobody ever tests them) because we check `sysctl.proc_translated` specifically, which should only be true under Rosetta.