### PR TITLE
chat: translation tweaks

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -33,7 +33,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(GPT4ALL_TRANSLATIONS "Build with translations" ON)
+option(GPT4ALL_TRANSLATIONS "Build with translations" OFF)
 option(GPT4ALL_LOCALHOST "Build installer for localhost repo" OFF)
 option(GPT4ALL_OFFLINE_INSTALLER "Build an offline installer" OFF)
 option(GPT4ALL_SIGN_INSTALL "Sign installed binaries and installers (requires signing identities)" OFF)

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -33,8 +33,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-option(GPT4ALL_TRANSLATIONS OFF "Build with translations")
-option(GPT4ALL_LOCALHOST OFF "Build installer for localhost repo")
+option(GPT4ALL_TRANSLATIONS "Build with translations" ON)
+option(GPT4ALL_LOCALHOST "Build installer for localhost repo" OFF)
 option(GPT4ALL_OFFLINE_INSTALLER "Build an offline installer" OFF)
 option(GPT4ALL_SIGN_INSTALL "Sign installed binaries and installers (requires signing identities)" OFF)
 

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -232,7 +232,7 @@ qt_add_qml_module(chat
 if (GPT4ALL_TRANSLATIONS)
     qt_add_translations(chat
         TS_FILES
-        ${CMAKE_SOURCE_DIR}/translations/gpt4all_en.ts
+        ${CMAKE_SOURCE_DIR}/translations/gpt4all_en_US.ts
         ${CMAKE_SOURCE_DIR}/translations/gpt4all_es_MX.ts
         ${CMAKE_SOURCE_DIR}/translations/gpt4all_zh_CN.ts
         ${CMAKE_SOURCE_DIR}/translations/gpt4all_zh_TW.ts

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -604,18 +604,18 @@ QString MySettings::filePathForLocale(const QLocale &locale)
     // rather than having to recompile all of GPT4All
     QString directory = modelPath();
     for (const QString &bcp47Name : uiLanguages) {
-        QString filePath = QString("%1/gpt4all_%2.qm").arg(directory).arg(bcp47Name);
+        QString filePath = u"%1/gpt4all_%2.qm"_s.arg(directory, bcp47Name);
         QFileInfo filePathInfo(filePath);
         if (filePathInfo.exists()) return filePath;
     }
 
     // Now scan the internal built-in translations
     for (QString bcp47Name : uiLanguages) {
-        QString filePath = QString(":/i18n/gpt4all_%1.qm").arg(bcp47Name);
+        QString filePath = u":/i18n/gpt4all_%1.qm"_s.arg(bcp47Name);
         QFileInfo filePathInfo(filePath);
         if (filePathInfo.exists()) return filePath;
     }
-    return QString(":/i18n/gpt4all_en_US.qm");
+    return u":/i18n/gpt4all_en_US.qm"_s;
 }
 
 void MySettings::setLanguageAndLocale(const QString &bcp47Name)
@@ -634,11 +634,10 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
 
     // If we previously installed a translator, then remove it
     if (m_translator) {
-        if (!qGuiApp->removeTranslator(m_translator)) {
+        if (!qGuiApp->removeTranslator(m_translator.get())) {
             qDebug() << "ERROR: Failed to remove the previous translator";
         } else {
-            delete m_translator;
-            m_translator = nullptr;
+            m_translator.reset();
         }
     }
 
@@ -650,20 +649,18 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
     // different from the ones stored in the binary
     if (!m_translator && !filePath.endsWith("en_US.qm")) {
         // Create a new translator object on the heap
-        m_translator = new QTranslator(this);
+        m_translator = std::make_unique<QTranslator>(this);
         bool success = m_translator->load(filePath);
         Q_ASSERT(success);
         if (!success) {
             qDebug() << "ERROR: Failed to load translation file:" << filePath;
-            delete m_translator;
-            m_translator = nullptr;
+            m_translator.reset();
         }
 
         // If we've successfully loaded it, then try and install it
-        if (!qGuiApp->installTranslator(m_translator)) {
+        if (!qGuiApp->installTranslator(m_translator.get())) {
             qDebug() << "ERROR: Failed to install the translator:" << filePath;
-            delete m_translator;
-            m_translator = nullptr;
+            m_translator.reset();
         }
     }
 

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -645,9 +645,7 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
     Q_ASSERT(!m_translator);
 
     const QString filePath = filePathForLocale(locale);
-    // Installing the default gpt4all_en_US.qm fails presumably because it has no strings that are
-    // different from the ones stored in the binary
-    if (!m_translator && !filePath.endsWith("en_US.qm")) {
+    if (!m_translator) {
         // Create a new translator object on the heap
         m_translator = std::make_unique<QTranslator>(this);
         bool success = m_translator->load(filePath);

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -593,7 +593,7 @@ QString MySettings::languageAndLocale() const
 QString MySettings::filePathForLocale(const QLocale &locale)
 {
     // Check and see if we have a translation for the chosen locale and set it if possible otherwise
-    // we return the filepath for the 'en' translation
+    // we return the filepath for the 'en_US' translation
     QStringList uiLanguages = locale.uiLanguages();
     for (int i = 0; i < uiLanguages.size(); ++i)
         uiLanguages[i].replace('-', '_');
@@ -615,7 +615,7 @@ QString MySettings::filePathForLocale(const QLocale &locale)
         QFileInfo filePathInfo(filePath);
         if (filePathInfo.exists()) return filePath;
     }
-    return QString(":/i18n/gpt4all_en.qm");
+    return QString(":/i18n/gpt4all_en_US.qm");
 }
 
 void MySettings::setLanguageAndLocale(const QString &bcp47Name)
@@ -646,9 +646,9 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
     Q_ASSERT(!m_translator);
 
     const QString filePath = filePathForLocale(locale);
-    // Installing the default gpt4all_en.qm fails presumably because it has no strings that are
+    // Installing the default gpt4all_en_US.qm fails presumably because it has no strings that are
     // different from the ones stored in the binary
-    if (!m_translator && !filePath.endsWith("en.qm")) {
+    if (!m_translator && !filePath.endsWith("en_US.qm")) {
         // Create a new translator object on the heap
         m_translator = new QTranslator(this);
         bool success = m_translator->load(filePath);

--- a/gpt4all-chat/mysettings.h
+++ b/gpt4all-chat/mysettings.h
@@ -11,6 +11,7 @@
 #include <QVector>
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 namespace MySettingsEnums {
@@ -245,7 +246,7 @@ private:
     const QStringList m_deviceList;
     const QStringList m_embeddingsDeviceList;
     const QStringList m_uiLanguages;
-    QTranslator *m_translator = nullptr;
+    std::unique_ptr<QTranslator> m_translator;
 
 private:
     explicit MySettings();

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="en">
+<TS version="2.1" language="en_US">
 <context>
     <name>AddCollectionView</name>
     <message>

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -1267,18 +1267,18 @@ model to get started</source>
         <location filename="../qml/CollectionsDrawer.qml" line="87"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n file(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n file</numerusform>
+            <numerusform>%n files</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../qml/CollectionsDrawer.qml" line="87"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n word(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n word</numerusform>
+            <numerusform>%n words</numerusform>
         </translation>
     </message>
     <message>
@@ -1722,18 +1722,18 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="337"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n file(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n file</numerusform>
+            <numerusform>%n files</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../qml/LocalDocsView.qml" line="337"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n word(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n word</numerusform>
+            <numerusform>%n words</numerusform>
         </translation>
     </message>
     <message>


### PR DESCRIPTION
This PR fixes a few outstanding issues with the translations (such as `%n file(s)` and `%n word(s)` not being transformed into their proper forms via the English translation) and includes them in the build by default.

There are a few outstanding issues, so this is marked as draft:
- "Application default" is still not translated
- Some of the translations are still unfinished, especially after #2690 (which removed some help text that I added&mdash;why?) and #2735.
- Items in the view bar no longer fit once translated into languages such as Spanish. We need to find a way to make it dynamically size to the content.

cc @jstayco @thiagojramos @SINAPSA-IC @supersonictw for translation updates. ~~It would be more organized if those necessary PRs were made into the `enable-translations` branch (this PR) - remember to change the branch target when you submit the PR!~~ I was told that this makes things too complicated. PRs into main would be fine.