### PR TITLE
chat: fix crash at startup due to missing en_US translation

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -229,6 +229,7 @@ qt_add_qml_module(chat
 )
 
 if (GPT4ALL_TRANSLATIONS)
+    target_compile_definitions(chat PRIVATE GPT4ALL_USE_TRANSLATIONS)
     qt_add_translations(chat
         TS_FILES
         ${CMAKE_SOURCE_DIR}/translations/gpt4all_en_US.ts

--- a/gpt4all-chat/mysettings.cpp
+++ b/gpt4all-chat/mysettings.cpp
@@ -632,6 +632,7 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
     else
         locale = QLocale(l);
 
+#ifdef GPT4ALL_USE_TRANSLATIONS
     // If we previously installed a translator, then remove it
     if (m_translator) {
         if (!qGuiApp->removeTranslator(m_translator.get())) {
@@ -661,6 +662,7 @@ void MySettings::setLanguageAndLocale(const QString &bcp47Name)
             m_translator.reset();
         }
     }
+#endif
 
     // Finally, set the locale whether we have a translation or not
     QLocale::setDefault(locale);


### PR DESCRIPTION
We shouldn't attempt to load the en_US translation unless GPT4All was built with translations included. Otherwise, the default build will hit `Q_ASSERT(success);` when we attempt to install the translator, and fail.

Fixes a regression in #2797