### PR TITLE
Add default CLion build folder pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ CMakeLists.txt.user
 gpt4all-chat/models/*
 build_*
 build-*
+cmake-build-*
 
 # IntelliJ
 .idea/


### PR DESCRIPTION
CLion uses a `cmake-build-` prefix unlike Qt Creator

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
N/A

### Steps to Reproduce
N/A