### PR TITLE
Fix _pyllmodel.py

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -45,7 +45,7 @@ def _load_cuda(rtver: str, blasver: str) -> None:
         cudalib   = f"lib/libcudart.so.{rtver}"
         cublaslib = f"lib/libcublas.so.{blasver}"
     else:  # Windows
-        cudalib   = fr"bin\cudart64_{rtver.replace(".", "")}.dll"
+        cudalib   = fr"bin\cudart64_{rtver.replace('.', '')}.dll"
         cublaslib = fr"bin\cublas64_{blasver}.dll"
 
     # preload the CUDA libs so the backend can find them


### PR DESCRIPTION
## Describe your changes
There's an f-string which uses double quotes in a nested function call. Replace with single quotes.

## Issue ticket number and link
Fixes #2862

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
![image](https://github.com/user-attachments/assets/3045197d-e0cb-4eeb-827e-4eaaed572108)

### Steps to Reproduce
As in the linked issue:
* Windows
* With CUDA libs
* `from gpt4all import GPT4All`

## Notes
I am confident that fixes the error in #2862, ~~but I haven't run it locally yet.~~
