### PR TITLE
LocalDocsSettings: fix embedding device selection after #2690

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Use greedy sampling when temperature is set to zero ([#2854](https://github.com/nomic-ai/gpt4all/pull/2854))
 
+### Fixed
+- Bring back "Auto" option for Embeddings Device as "Application default," which went missing in v3.1.0 ([#2873](https://github.com/nomic-ai/gpt4all/pull/2873))
+
 ## [3.2.1] - 2024-08-13
 
 ### Fixed

--- a/gpt4all-chat/qml/LocalDocsSettings.qml
+++ b/gpt4all-chat/qml/LocalDocsSettings.qml
@@ -163,7 +163,7 @@ MySettingsTab {
             MySettingsLabel {
                 id: deviceLabel
                 text: qsTr("Embeddings Device")
-                helpText: qsTr('The compute device used for embeddings. "Auto" uses the CPU. Requires restart.')
+                helpText: qsTr('The compute device used for embeddings. Requires restart.')
             }
             MyComboBox {
                 id: deviceBox
@@ -172,11 +172,18 @@ MySettingsTab {
                 Layout.maximumWidth: 400
                 Layout.fillWidth: false
                 Layout.alignment: Qt.AlignRight
-                model: MySettings.embeddingsDeviceList
+                model: ListModel {
+                    ListElement { text: qsTr("Application default") }
+                    Component.onCompleted: {
+                        MySettings.embeddingsDeviceList.forEach(d => append({"text": d}));
+                    }
+                }
                 Accessible.name: deviceLabel.text
                 Accessible.description: deviceLabel.helpText
                 function updateModel() {
-                    deviceBox.currentIndex = deviceBox.indexOfValue(MySettings.localDocsEmbedDevice);
+                    var device = MySettings.localDocsEmbedDevice;
+                    // This usage of 'Auto' should not be translated
+                    deviceBox.currentIndex = device === "Auto" ? 0 : deviceBox.indexOfValue(device);
                 }
                 Component.onCompleted: {
                     deviceBox.updateModel();
@@ -188,7 +195,8 @@ MySettingsTab {
                     }
                 }
                 onActivated: {
-                    MySettings.localDocsEmbedDevice = deviceBox.currentText;
+                    // This usage of 'Auto' should not be translated
+                    MySettings.localDocsEmbedDevice = deviceBox.currentIndex === 0 ? "Auto" : deviceBox.currentText;
                 }
             }
         }

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -1520,7 +1520,7 @@ model to get started</source>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
+        <source>The compute device used for embeddings. Requires restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -115,44 +115,44 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -163,266 +163,266 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
-        <source>Install online model</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
-        <source>ERROR: $API_KEY is empty.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
-        <source>ERROR: $BASE_URL is empty.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
-        <source>enter $BASE_URL</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
-        <source>ERROR: $MODEL_NAME is empty.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
-        <source>enter $MODEL_NAME</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <source>%1 GB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
-        <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="492"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <source>Install online model</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
+        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
+        <source>ERROR: $API_KEY is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
+        <source>ERROR: $BASE_URL is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
+        <source>enter $BASE_URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
+        <source>ERROR: $MODEL_NAME is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
+        <source>enter $MODEL_NAME</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <source>%1 GB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
+        <source>?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -490,238 +490,238 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
-        <source>Save Chat Context</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
-        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
-        <source>Enable Local Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="488"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
-        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
+        <source>Save Chat Context</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
-        <source>API Server Port</source>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
+        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="505"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <source>Enable Local Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
+        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
+        <source>API Server Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1524,62 +1524,68 @@ model to get started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
-        <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="258"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -1487,10 +1487,8 @@ modelo para comenzar
         <translation>Dispositivo de incrustaciones</translation>
     </message>
     <message>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires
-                restart.</source>
-        <translation>El dispositivo de cómputo utilizado para las incrustaciones.
-                &quot;Auto&quot; usa la CPU. Requiere reinicio.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>El dispositivo de cómputo utilizado para las incrustaciones. Requiere reinicio.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="52"/>
@@ -1507,8 +1505,8 @@ modelo para comenzar
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>El dispositivo de cómputo utilizado para las incrustaciones. &quot;Auto&quot; usa la CPU. Requiere reinicio.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>El dispositivo de cómputo utilizado para las incrustaciones. Requiere reinicio.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>

--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -79,346 +79,350 @@
 <context>
     <name>AddModelView</name>
     <message>
-        <location filename="../qml/AddModelView.qml" line="51"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="51"/>
+        <location filename="../qml/AddModelView.qml" line="55"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="55"/>
         <source>← Existing Models</source>
         <translation>← Modelos existentes</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="71"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="71"/>
+        <location filename="../qml/AddModelView.qml" line="75"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="75"/>
         <source>Explore Models</source>
         <translation>Explorar modelos</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="88"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="88"/>
+        <location filename="../qml/AddModelView.qml" line="92"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="92"/>
         <source>Discover and download models by keyword search...</source>
         <translation>Descubre y descarga modelos mediante búsqueda por palabras clave...</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="91"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="91"/>
+        <location filename="../qml/AddModelView.qml" line="95"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="95"/>
         <source>Text field for discovering and filtering downloadable models</source>
         <translation>Campo de texto para descubrir y filtrar modelos descargables</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="167"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="167"/>
+        <location filename="../qml/AddModelView.qml" line="171"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="171"/>
         <source>Initiate model discovery and filtering</source>
         <translation>Iniciar descubrimiento y filtrado de modelos</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="168"/>
+        <location filename="../qml/AddModelView.qml" line="172"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="172"/>
         <source>Triggers discovery and filtering of models</source>
         <translation>Activa el descubrimiento y filtrado de modelos</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="186"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="186"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>Me gusta</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="186"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>Descargas</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="186"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="186"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>Reciente</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="206"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="206"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>Asc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="206"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="206"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>Desc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="234"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="97"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="97"/>
+        <location filename="../qml/AddModelView.qml" line="101"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="101"/>
         <source>Searching · %1</source>
         <translation>Buscando · %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="193"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation>Ordenar por: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="218"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="218"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation>Dirección de ordenamiento: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="254"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="254"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation>Límite: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="287"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="287"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation>Error de red: no se pudo recuperar %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="297"/>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="297"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation>Indicador de ocupado</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="298"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="298"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation>Se muestra cuando la solicitud de modelos está en curso</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="338"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation>Archivo del modelo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="339"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="339"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation>Archivo del modelo a descargar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="362"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="362"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="363"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="363"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation>Descripción del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="396"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="396"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>Reanudar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="396"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="396"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>Descargar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="404"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="404"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation>Detener/reiniciar/iniciar la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="416"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="423"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="423"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation>Eliminar modelo del sistema de archivos</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="437"/>
-        <location filename="../qml/AddModelView.qml" line="446"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="437"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="446"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="447"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="447"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>Instalar modelo en línea</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="457"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado para tu hardware. El modelo requiere más memoria (%1 GB) de la que tu sistema tiene disponible (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="628"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="628"/>
-        <location filename="../qml/AddModelView.qml" line="650"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="650"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="463"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="463"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>Describe un error que ocurrió durante la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="482"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="482"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>Error por hardware incompatible</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="520"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="520"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation>Barra de progreso de descarga</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="521"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation>Muestra el progreso realizado en la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="531"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="531"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>Velocidad de descarga</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="532"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="532"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="553"/>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="553"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation>Si se está calculando el hash del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>Se muestra cuando se está calculando el hash del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="579"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="579"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>ingrese $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="601"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="601"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation>Tamaño del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="623"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="623"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>RAM requerida</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>Parámetros</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="667"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>Cuantificación</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="689"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERROR: $API_KEY está vacío.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
         <translation>ERROR: $BASE_URL está vacío.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>ingrese $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERROR: $MODEL_NAME está vacío.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>ingrese $MODEL_NAME</translation>
     </message>
@@ -442,6 +446,18 @@
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="26"/>
         <source>opt-in to share feedback/conversations</source>
         <translation>optar por compartir comentarios/conversaciones</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="37"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="37"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
+                   to check for updates!&lt;br&gt;&lt;br&gt;
+                   Did you install this application using the online installer? If so,&lt;br&gt;
+                   the MaintenanceTool executable should be located one directory&lt;br&gt;
+                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
+                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
+                   reinstall.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="48"/>
@@ -474,256 +490,252 @@
         <translation>El esquema de colores de la aplicación.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="110"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation>Oscuro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="110"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Claro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="110"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="110"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation>Oscuro legado</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="131"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="131"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation>El tamaño del texto en la aplicación.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="195"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="195"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
         <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or Metal.</source>
-        <translation>El dispositivo de cómputo utilizado para la generación de texto. &quot;Auto&quot; utiliza Vulkan o Metal.</translation>
+        <translation type="vanished">El dispositivo de cómputo utilizado para la generación de texto. &quot;Auto&quot; utiliza Vulkan o Metal.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="144"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>Pequeño</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="144"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="144"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>Mediano</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="144"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="144"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="166"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation>Idioma y configuración regional</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="167"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="167"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation>El idioma y la configuración regional que deseas usar.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="229"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="229"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>Modelo predeterminado</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="230"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="230"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>El modelo preferido para nuevos chats. También se utiliza como respaldo del servidor local.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="262"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="262"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>Modo de sugerencia</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="263"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="263"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>Generar preguntas de seguimiento sugeridas al final de las respuestas.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="274"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation>Al chatear con LocalDocs</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="274"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation>Siempre que sea posible</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="274"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="274"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="286"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="286"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>Ruta de descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="287"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="287"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation>Dónde almacenar los modelos locales y la base de datos de LocalDocs.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="316"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="316"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation>Explorar</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="317"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="317"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation>Elegir dónde guardar los archivos del modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="328"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="328"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation>Habilitar Datalake</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="329"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="329"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>Enviar chats y comentarios al Datalake de código abierto de GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="362"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="362"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="374"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="374"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation>Hilos de CPU</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="375"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="375"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>El número de hilos de CPU utilizados para inferencia e incrustación.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="406"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="406"/>
+        <location filename="../qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
         <source>Save Chat Context</source>
         <translation>Guardar contexto del chat</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="407"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="407"/>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>Guardar el estado del modelo de chat en el disco para una carga más rápida. ADVERTENCIA: Usa ~2GB por chat.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="424"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="424"/>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta en un mayor uso de recursos.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="423"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="423"/>
+        <location filename="../qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local Server</source>
         <translation>Habilitar servidor local</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
                 resource usage.</source>
-        <translation>Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
+        <translation type="vanished">Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
                 en un mayor uso de recursos.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="440"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="440"/>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
         <source>API Server Port</source>
         <translation>Puerto del servidor API</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="441"/>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>El puerto a utilizar para el servidor local. Requiere reinicio.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="493"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="493"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation>Buscar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="494"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="494"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>Buscar manualmente una actualización para GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="503"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="503"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation>Actualizaciones</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>Regional del sistema</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation>El dispositivo de cómputo utilizado para la generación de texto.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>Predeterminado de la aplicación</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="37"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="37"/>
         <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
                        to check for updates!&lt;br&gt;&lt;br&gt;
                        Did you install this application using the online installer? If so,&lt;br&gt;
@@ -731,7 +743,7 @@
                        above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
                        If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
                        reinstall.</source>
-        <translation>ERROR: El sistema de actualización no pudo encontrar la Herramienta de Mantenimiento utilizada&lt;br&gt;
+        <translation type="vanished">ERROR: El sistema de actualización no pudo encontrar la Herramienta de Mantenimiento utilizada&lt;br&gt;
                        para buscar actualizaciones.&lt;br&gt;&lt;br&gt;
                        ¿Instaló esta aplicación utilizando el instalador en línea? Si es así,&lt;br&gt;
                        el ejecutable de la Herramienta de Mantenimiento debería estar ubicado un directorio&lt;br&gt;
@@ -752,6 +764,19 @@
         <location filename="../chat.cpp" line="38"/>
         <source>Server Chat</source>
         <translation>Chat del servidor</translation>
+    </message>
+</context>
+<context>
+    <name>ChatAPIWorker</name>
+    <message>
+        <location filename="../chatapi.cpp" line="230"/>
+        <source>ERROR: Network error occurred while connecting to the API server</source>
+        <translation>ERROR: Ocurrió un error de red al conectar con el servidor API</translation>
+    </message>
+    <message>
+        <location filename="../chatapi.cpp" line="243"/>
+        <source>ChatAPIWorker::handleFinished got HTTP Error %1 %2</source>
+        <translation>ChatAPIWorker::handleFinished obtuvo Error HTTP %1 %2</translation>
     </message>
 </context>
 <context>
@@ -962,9 +987,9 @@
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="549"/>
-        <location filename="../qml/ChatView.qml" line="1307"/>
+        <location filename="../qml/ChatView.qml" line="1313"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1313"/>
         <source>LocalDocs</source>
         <translation>DocumentosLocales</translation>
     </message>
@@ -981,20 +1006,20 @@
         <translation>agregar colecciones de documentos al chat</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="732"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="732"/>
+        <location filename="../qml/ChatView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="738"/>
         <source>Load the default model</source>
         <translation>Cargar el modelo predeterminado</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="733"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="733"/>
+        <location filename="../qml/ChatView.qml" line="739"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="739"/>
         <source>Loads the default model which can be changed in settings</source>
         <translation>Carga el modelo predeterminado que se puede cambiar en la configuración</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="744"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="744"/>
+        <location filename="../qml/ChatView.qml" line="750"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="750"/>
         <source>No Model Installed</source>
         <translation>No hay modelo instalado</translation>
     </message>
@@ -1005,174 +1030,172 @@
         <translation>&lt;h3&gt;Se encontró un error al cargar el modelo:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Los fallos en la carga de modelos pueden ocurrir por varias razones, pero las causas más comunes incluyen un formato de archivo incorrecto, una descarga incompleta o corrupta, un tipo de archivo equivocado, RAM del sistema insuficiente o un tipo de modelo incompatible. Aquí hay algunas sugerencias para resolver el problema:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Asegúrate de que el archivo del modelo tenga un formato y tipo compatibles&lt;li&gt;Verifica que el archivo del modelo esté completo en la carpeta de descargas&lt;li&gt;Puedes encontrar la carpeta de descargas en el diálogo de configuración&lt;li&gt;Si has cargado el modelo manualmente, asegúrate de que el archivo no esté corrupto verificando el md5sum&lt;li&gt;Lee más sobre qué modelos son compatibles en nuestra &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentación&lt;/a&gt; para la interfaz gráfica&lt;li&gt;Visita nuestro &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canal de discord&lt;/a&gt; para obtener ayuda</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="765"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="765"/>
+        <location filename="../qml/ChatView.qml" line="771"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="771"/>
         <source>Install a Model</source>
         <translation>Instalar un modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="770"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="770"/>
+        <location filename="../qml/ChatView.qml" line="776"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="776"/>
         <source>Shows the add model view</source>
         <translation>Muestra la vista de agregar modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="795"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="795"/>
+        <location filename="../qml/ChatView.qml" line="801"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="801"/>
         <source>Conversation with the model</source>
         <translation>Conversación con el modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="796"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="796"/>
+        <location filename="../qml/ChatView.qml" line="802"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="802"/>
         <source>prompt / response pairs from the conversation</source>
         <translation>pares de pregunta / respuesta de la conversación</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="848"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
+        <location filename="../qml/ChatView.qml" line="854"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="854"/>
         <source>GPT4All</source>
         <translation>GPT4All</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="848"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="848"/>
+        <location filename="../qml/ChatView.qml" line="854"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="854"/>
         <source>You</source>
         <translation>Tú</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="870"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="870"/>
         <source>recalculating context ...</source>
-        <translation>recalculando contexto ...</translation>
+        <translation type="vanished">recalculando contexto ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="872"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="872"/>
+        <location filename="../qml/ChatView.qml" line="878"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="878"/>
         <source>response stopped ...</source>
         <translation>respuesta detenida ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="875"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="875"/>
+        <location filename="../qml/ChatView.qml" line="881"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="881"/>
         <source>processing ...</source>
         <translation>procesando ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="876"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="876"/>
+        <location filename="../qml/ChatView.qml" line="882"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="882"/>
         <source>generating response ...</source>
         <translation>generando respuesta ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="877"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="877"/>
+        <location filename="../qml/ChatView.qml" line="883"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="883"/>
         <source>generating questions ...</source>
         <translation>generando preguntas ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="943"/>
-        <location filename="../qml/ChatView.qml" line="1899"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="943"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1899"/>
+        <location filename="../qml/ChatView.qml" line="949"/>
+        <location filename="../qml/ChatView.qml" line="1905"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="949"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1905"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="949"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="949"/>
+        <location filename="../qml/ChatView.qml" line="955"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="955"/>
         <source>Copy Message</source>
         <translation>Copiar mensaje</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="959"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
+        <location filename="../qml/ChatView.qml" line="965"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="965"/>
         <source>Disable markdown</source>
         <translation>Desactivar markdown</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="959"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="959"/>
+        <location filename="../qml/ChatView.qml" line="965"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="965"/>
         <source>Enable markdown</source>
         <translation>Activar markdown</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1049"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1049"/>
+        <location filename="../qml/ChatView.qml" line="1055"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1055"/>
         <source>Thumbs up</source>
         <translation>Me gusta</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1050"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1050"/>
+        <location filename="../qml/ChatView.qml" line="1056"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1056"/>
         <source>Gives a thumbs up to the response</source>
         <translation>Da un me gusta a la respuesta</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1083"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1083"/>
+        <location filename="../qml/ChatView.qml" line="1089"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1089"/>
         <source>Thumbs down</source>
         <translation>No me gusta</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1084"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1084"/>
+        <location filename="../qml/ChatView.qml" line="1090"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1090"/>
         <source>Opens thumbs down dialog</source>
         <translation>Abre el diálogo de no me gusta</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1139"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1139"/>
+        <location filename="../qml/ChatView.qml" line="1145"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1145"/>
         <source>%1 Sources</source>
         <translation>%1 Fuentes</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1383"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1383"/>
+        <location filename="../qml/ChatView.qml" line="1389"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1389"/>
         <source>Suggested follow-ups</source>
         <translation>Seguimientos sugeridos</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1659"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1659"/>
+        <location filename="../qml/ChatView.qml" line="1665"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1665"/>
         <source>Erase and reset chat session</source>
         <translation>Borrar y reiniciar sesión de chat</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1680"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1680"/>
+        <location filename="../qml/ChatView.qml" line="1686"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1686"/>
         <source>Copy chat session to clipboard</source>
         <translation>Copiar sesión de chat al portapapeles</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1706"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1706"/>
+        <location filename="../qml/ChatView.qml" line="1712"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1712"/>
         <source>Redo last chat response</source>
         <translation>Rehacer última respuesta del chat</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1955"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1955"/>
+        <location filename="../qml/ChatView.qml" line="1961"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1961"/>
         <source>Stop generating</source>
         <translation>Detener generación</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1956"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1956"/>
+        <location filename="../qml/ChatView.qml" line="1962"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1962"/>
         <source>Stop the current response generation</source>
         <translation>Detener la generación de la respuesta actual</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1771"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1771"/>
+        <location filename="../qml/ChatView.qml" line="1777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1777"/>
         <source>Reloads the model</source>
         <translation>Recarga el modelo</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="377"/>
-        <location filename="../qml/ChatView.qml" line="1769"/>
+        <location filename="../qml/ChatView.qml" line="1775"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="377"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1769"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1775"/>
         <source>Reload · %1</source>
         <translation>Recargar · %1</translation>
     </message>
@@ -1183,68 +1206,68 @@
         <translation>Cargando · %1</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="708"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="708"/>
+        <location filename="../qml/ChatView.qml" line="714"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="714"/>
         <source>Load · %1 (default) →</source>
         <translation>Cargar · %1 (predeterminado) →</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="873"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="873"/>
+        <location filename="../qml/ChatView.qml" line="879"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="879"/>
         <source>retrieving localdocs: %1 ...</source>
         <translation>recuperando documentos locales: %1 ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="874"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="874"/>
+        <location filename="../qml/ChatView.qml" line="880"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="880"/>
         <source>searching localdocs: %1 ...</source>
         <translation>buscando en documentos locales: %1 ...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1845"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
+        <location filename="../qml/ChatView.qml" line="1851"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1851"/>
         <source>Send a message...</source>
         <translation>Enviar un mensaje...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1845"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1845"/>
+        <location filename="../qml/ChatView.qml" line="1851"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1851"/>
         <source>Load a model to continue...</source>
         <translation>Carga un modelo para continuar...</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1848"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1848"/>
+        <location filename="../qml/ChatView.qml" line="1854"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1854"/>
         <source>Send messages/prompts to the model</source>
         <translation>Enviar mensajes/indicaciones al modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1893"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1893"/>
+        <location filename="../qml/ChatView.qml" line="1899"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1899"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1905"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1905"/>
+        <location filename="../qml/ChatView.qml" line="1911"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1911"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1909"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1909"/>
+        <location filename="../qml/ChatView.qml" line="1915"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1915"/>
         <source>Select All</source>
         <translation>Seleccionar todo</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1979"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1979"/>
+        <location filename="../qml/ChatView.qml" line="1985"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1985"/>
         <source>Send message</source>
         <translation>Enviar mensaje</translation>
     </message>
     <message>
-        <location filename="../qml/ChatView.qml" line="1980"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1980"/>
+        <location filename="../qml/ChatView.qml" line="1986"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1986"/>
         <source>Sends the message/prompt contained in textfield to the model</source>
         <translation>Envía el mensaje/indicación contenido en el campo de texto al modelo</translation>
     </message>
@@ -1267,14 +1290,14 @@ modelo para comenzar
 <context>
     <name>CollectionsDrawer</name>
     <message>
-        <location filename="../qml/CollectionsDrawer.qml" line="72"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="72"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="70"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="70"/>
         <source>Warning: searching collections while indexing can return incomplete results</source>
         <translation>Advertencia: buscar en colecciones mientras se indexan puede devolver resultados incompletos</translation>
     </message>
     <message numerus="yes">
-        <location filename="../qml/CollectionsDrawer.qml" line="89"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="89"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="87"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n file(s)</source>
         <translation>
             <numerusform>%n archivo</numerusform>
@@ -1282,8 +1305,8 @@ modelo para comenzar
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../qml/CollectionsDrawer.qml" line="89"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="89"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="87"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n word(s)</source>
         <translation>
             <numerusform>%n palabra</numerusform>
@@ -1291,22 +1314,60 @@ modelo para comenzar
         </translation>
     </message>
     <message>
-        <location filename="../qml/CollectionsDrawer.qml" line="105"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="105"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="103"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="103"/>
         <source>Updating</source>
         <translation>Actualizando</translation>
     </message>
     <message>
-        <location filename="../qml/CollectionsDrawer.qml" line="130"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="130"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="128"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="128"/>
         <source>＋ Add Docs</source>
         <translation>＋ Agregar documentos</translation>
     </message>
     <message>
-        <location filename="../qml/CollectionsDrawer.qml" line="139"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="139"/>
+        <location filename="../qml/CollectionsDrawer.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="137"/>
         <source>Select a collection to make it available to the chat model.</source>
         <translation>Seleccione una colección para hacerla disponible al modelo de chat.</translation>
+    </message>
+</context>
+<context>
+    <name>Download</name>
+    <message>
+        <location filename="../download.cpp" line="278"/>
+        <source>Model &quot;%1&quot; is installed successfully.</source>
+        <translation>El modelo &quot;%1&quot; se ha instalado correctamente.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="288"/>
+        <source>ERROR: $MODEL_NAME is empty.</source>
+        <translation>ERROR: $MODEL_NAME está vacío.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="294"/>
+        <source>ERROR: $API_KEY is empty.</source>
+        <translation>ERROR: $API_KEY está vacía.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="300"/>
+        <source>ERROR: $BASE_URL is invalid.</source>
+        <translation>ERROR: $BASE_URL no es válida.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="306"/>
+        <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
+        <translation>ERROR: El modelo &quot;%1 (%2)&quot; está en conflicto.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="325"/>
+        <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
+        <translation>El modelo &quot;%1 (%2)&quot; se ha instalado correctamente.</translation>
+    </message>
+    <message>
+        <location filename="../download.cpp" line="349"/>
+        <source>Model &quot;%1&quot; is removed.</source>
+        <translation>El modelo &quot;%1&quot; ha sido eliminado.</translation>
     </message>
 </context>
 <context>
@@ -1449,7 +1510,7 @@ modelo para comenzar
     <message>
         <source>Comma-separated list. LocalDocs will only attempt to process files with these
                 extensions.</source>
-        <translation>Lista separada por comas. DocumentosLocales solo intentará procesar
+        <translation type="vanished">Lista separada por comas. DocumentosLocales solo intentará procesar
                 archivos con estas extensiones.</translation>
     </message>
     <message>
@@ -1467,7 +1528,7 @@ modelo para comenzar
     <message>
         <source>Embed documents using the fast Nomic API instead of a private local model.
                 Requires restart.</source>
-        <translation>Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
+        <translation type="vanished">Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
                 local privado. Requiere reinicio.</translation>
     </message>
     <message>
@@ -1477,6 +1538,8 @@ modelo para comenzar
         <translation>Clave API de Nomic</translation>
     </message>
     <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="131"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="131"/>
         <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;. Requires restart.</source>
         <translation>Clave API para usar con Nomic Embed. Obtén una en la &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;página de claves API&lt;/a&gt; de Atlas. Requiere reinicio.</translation>
     </message>
@@ -1487,6 +1550,8 @@ modelo para comenzar
         <translation>Dispositivo de incrustaciones</translation>
     </message>
     <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
         <source>The compute device used for embeddings. Requires restart.</source>
         <translation>El dispositivo de cómputo utilizado para las incrustaciones. Requiere reinicio.</translation>
     </message>
@@ -1503,73 +1568,73 @@ modelo para comenzar
         <translation>Incrustar documentos usando la API rápida de Nomic en lugar de un modelo local privado. Requiere reinicio.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. Requires restart.</source>
-        <translation>El dispositivo de cómputo utilizado para las incrustaciones. Requiere reinicio.</translation>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>Predeterminado de la aplicación</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>Visualización</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation>Mostrar fuentes</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation>Mostrar las fuentes utilizadas para cada respuesta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
         <translation>Advertencia: Solo para uso avanzado.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Valores demasiado grandes pueden causar fallos en localdocs, respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N caracteres x N fragmentos} se añaden a la ventana de contexto del modelo. Más información &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Número de caracteres por fragmento de documento. Números más grandes aumentan la probabilidad de respuestas verídicas, pero también resultan en una generación más lenta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Máximo de N mejores coincidencias de fragmentos de documentos recuperados para añadir al contexto del prompt. Números más grandes aumentan la probabilidad de respuestas verídicas, pero también resultan en una generación más lenta.</translation>
     </message>
     <message>
         <source> Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.
             </source>
-        <translation> Valores demasiado grandes pueden causar fallos en documentos locales, respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N caracteres x N fragmentos} se agregan a la ventana de contexto del modelo. Más información &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
+        <translation type="vanished"> Valores demasiado grandes pueden causar fallos en documentos locales, respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N caracteres x N fragmentos} se agregan a la ventana de contexto del modelo. Más información &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>Tamaño del fragmento de documento (caracteres)</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>Máximo de fragmentos de documento por indicación</translation>
     </message>
@@ -1595,122 +1660,120 @@ modelo para comenzar
         <translation>＋ Agregar colección</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="86"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="86"/>
         <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation>ERROR: La base de datos de DocumentosLocales no es válida.</translation>
+        <translation type="vanished">ERROR: La base de datos de DocumentosLocales no es válida.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="104"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="104"/>
+        <location filename="../qml/LocalDocsView.qml" line="109"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="109"/>
         <source>No Collections Installed</source>
         <translation>No hay colecciones instaladas</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="113"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="113"/>
+        <location filename="../qml/LocalDocsView.qml" line="118"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="118"/>
         <source>Install a collection of local documents to get started using this feature</source>
         <translation>Instala una colección de documentos locales para comenzar a usar esta función</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="124"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="124"/>
+        <location filename="../qml/LocalDocsView.qml" line="129"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="129"/>
         <source>＋ Add Doc Collection</source>
         <translation>＋ Agregar colección de documentos</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="129"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="129"/>
+        <location filename="../qml/LocalDocsView.qml" line="134"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="134"/>
         <source>Shows the add model view</source>
         <translation>Muestra la vista de agregar modelo</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="226"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="226"/>
+        <location filename="../qml/LocalDocsView.qml" line="231"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="231"/>
         <source>Indexing progressBar</source>
         <translation>Barra de progreso de indexación</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="227"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="227"/>
+        <location filename="../qml/LocalDocsView.qml" line="232"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="232"/>
         <source>Shows the progress made in the indexing</source>
         <translation>Muestra el progreso realizado en la indexación</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="252"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="252"/>
+        <location filename="../qml/LocalDocsView.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="257"/>
         <source>ERROR</source>
         <translation>ERROR</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="256"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="256"/>
+        <location filename="../qml/LocalDocsView.qml" line="261"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="261"/>
         <source>INDEXING</source>
         <translation>INDEXANDO</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="260"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="260"/>
+        <location filename="../qml/LocalDocsView.qml" line="265"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="265"/>
         <source>EMBEDDING</source>
         <translation>INCRUSTANDO</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="263"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="263"/>
+        <location filename="../qml/LocalDocsView.qml" line="268"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="268"/>
         <source>REQUIRES UPDATE</source>
         <translation>REQUIERE ACTUALIZACIÓN</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="266"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="266"/>
+        <location filename="../qml/LocalDocsView.qml" line="271"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="271"/>
         <source>READY</source>
         <translation>LISTO</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="268"/>
+        <location filename="../qml/LocalDocsView.qml" line="273"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="273"/>
         <source>INSTALLING</source>
         <translation>INSTALANDO</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="295"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="295"/>
+        <location filename="../qml/LocalDocsView.qml" line="300"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="300"/>
         <source>Indexing in progress</source>
         <translation>Indexación en progreso</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="298"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="298"/>
+        <location filename="../qml/LocalDocsView.qml" line="303"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="303"/>
         <source>Embedding in progress</source>
         <translation>Incrustación en progreso</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="301"/>
+        <location filename="../qml/LocalDocsView.qml" line="306"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="306"/>
         <source>This collection requires an update after version change</source>
         <translation>Esta colección requiere una actualización después del cambio de versión</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="304"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="304"/>
+        <location filename="../qml/LocalDocsView.qml" line="309"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="309"/>
         <source>Automatically reindexes upon changes to the folder</source>
         <translation>Reindexación automática al cambiar la carpeta</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="306"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="306"/>
+        <location filename="../qml/LocalDocsView.qml" line="311"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="311"/>
         <source>Installation in progress</source>
         <translation>Instalación en progreso</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="320"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="320"/>
+        <location filename="../qml/LocalDocsView.qml" line="325"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="325"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message numerus="yes">
-        <location filename="../qml/LocalDocsView.qml" line="332"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="332"/>
+        <location filename="../qml/LocalDocsView.qml" line="337"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n file(s)</source>
         <translation>
             <numerusform>%n archivo</numerusform>
@@ -1718,8 +1781,8 @@ modelo para comenzar
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../qml/LocalDocsView.qml" line="332"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="332"/>
+        <location filename="../qml/LocalDocsView.qml" line="337"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n word(s)</source>
         <translation>
             <numerusform>%n palabra</numerusform>
@@ -1727,32 +1790,32 @@ modelo para comenzar
         </translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="403"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="403"/>
+        <location filename="../qml/LocalDocsView.qml" line="408"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="408"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="415"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="415"/>
+        <location filename="../qml/LocalDocsView.qml" line="420"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="420"/>
         <source>Rebuild</source>
         <translation>Reconstruir</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="418"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="418"/>
+        <location filename="../qml/LocalDocsView.qml" line="423"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="423"/>
         <source>Reindex this folder from scratch. This is slow and usually not needed.</source>
         <translation>Reindexar esta carpeta desde cero. Esto es lento y generalmente no es necesario.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="425"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="425"/>
+        <location filename="../qml/LocalDocsView.qml" line="430"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="430"/>
         <source>Update</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsView.qml" line="428"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="428"/>
+        <location filename="../qml/LocalDocsView.qml" line="433"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="433"/>
         <source>Update the collection to the new version. This is a slow operation.</source>
         <translation>Actualizar la colección a la nueva versión. Esta es una operación lenta.</translation>
     </message>
@@ -1766,54 +1829,53 @@ modelo para comenzar
 <context>
     <name>ModelList</name>
     <message>
-        <location filename="../modellist.cpp" line="1575"/>
+        <location filename="../modellist.cpp" line="1559"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal OpenAI API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Requiere clave API personal de OpenAI.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a OpenAI!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con OpenAI&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aquí.&lt;/a&gt;&lt;/li&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1594"/>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
                 %1</source>
-        <translation>&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
+        <translation type="vanished">&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
                 OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1567"/>
+        <location filename="../modellist.cpp" line="1578"/>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1580"/>
+        <location filename="../modellist.cpp" line="1591"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does not guarantee API key access. Contact OpenAI for more info.</source>
         <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Aunque pagues a OpenAI por ChatGPT-4, esto no garantiza el acceso a la clave API. Contacta a OpenAI para más información.</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1595"/>
+        <location filename="../modellist.cpp" line="1606"/>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt; %1 %2</source>
         <translation>&lt;strong&gt;Modelo ChatGPT GPT-4 de OpenAI&lt;/strong&gt;&lt;br&gt; %1 %2</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1607"/>
+        <location filename="../modellist.cpp" line="1618"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Requiere una clave API personal de Mistral.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará tus chats a Mistral!&lt;/li&gt;&lt;li&gt;Tu clave API se almacenará en el disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con Mistral&lt;/li&gt;&lt;li&gt;Puedes solicitar una clave API &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aquí&lt;/a&gt;.&lt;/li&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1626"/>
+        <location filename="../modellist.cpp" line="1637"/>
         <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Modelo Mistral Tiny&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1651"/>
+        <location filename="../modellist.cpp" line="1662"/>
         <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Modelo Mistral Small&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1677"/>
+        <location filename="../modellist.cpp" line="1688"/>
         <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Modelo Mistral Medium&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="2092"/>
+        <location filename="../modellist.cpp" line="2131"/>
         <source>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
         <translation>&lt;strong&gt;Creado por %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicado el %2.&lt;li&gt;Este modelo tiene %3 me gusta.&lt;li&gt;Este modelo tiene %4 descargas.&lt;li&gt;Más información puede encontrarse &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aquí.&lt;/a&gt;&lt;/ul&gt;</translation>
     </message>
@@ -1828,12 +1890,12 @@ modelo para comenzar
         <translation>&lt;strong&gt;Modelo de API compatible con OpenAI&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Clave API: %1&lt;/li&gt;&lt;li&gt;URL base: %2&lt;/li&gt;&lt;li&gt;Nombre del modelo: %3&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1716"/>
+        <location filename="../modellist.cpp" line="1700"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal API key and the API base URL.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to the OpenAI-compatible API Server you specified!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with the OpenAI-compatible API Server&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Requiere una clave API personal y la URL base de la API.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats al servidor de API compatible con OpenAI que especificó!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el disco&lt;/li&gt;&lt;li&gt;Solo se utilizará para comunicarse con el servidor de API compatible con OpenAI&lt;/li&gt;</translation>
     </message>
     <message>
-        <location filename="../modellist.cpp" line="1733"/>
+        <location filename="../modellist.cpp" line="1717"/>
         <source>&lt;strong&gt;Connect to OpenAI-compatible API server&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Conectar al servidor de API compatible con OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
@@ -1883,7 +1945,8 @@ modelo para comenzar
         <translation>Indicación del sistema</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="298"/>
+        <location filename="../qml/ModelSettings.qml" line="159"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="159"/>
         <source>Prefixed at the beginning of every conversation. Must contain the appropriate framing tokens.</source>
         <translation>Prefijado al inicio de cada conversación. Debe contener los tokens de encuadre apropiados.</translation>
     </message>
@@ -1900,7 +1963,8 @@ modelo para comenzar
         <translation>La plantilla que envuelve cada indicación.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="299"/>
+        <location filename="../qml/ModelSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="210"/>
         <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s input.</source>
         <translation>Debe contener la cadena &quot;%1&quot; para ser reemplazada con la entrada del usuario.</translation>
     </message>
@@ -1917,175 +1981,176 @@ modelo para comenzar
         <translation>Indicación utilizada para generar automáticamente nombres de chat.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="283"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="283"/>
+        <location filename="../qml/ModelSettings.qml" line="298"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="298"/>
         <source>Suggested FollowUp Prompt</source>
         <translation>Indicación de seguimiento sugerida</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="284"/>
+        <location filename="../qml/ModelSettings.qml" line="299"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="299"/>
         <source>Prompt used to generate suggested follow-up questions.</source>
         <translation>Indicación utilizada para generar preguntas de seguimiento sugeridas.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="322"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="322"/>
+        <location filename="../qml/ModelSettings.qml" line="352"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="352"/>
         <source>Context Length</source>
         <translation>Longitud del contexto</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="323"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="323"/>
+        <location filename="../qml/ModelSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="353"/>
         <source>Number of input and output tokens the model sees.</source>
         <translation>Número de tokens de entrada y salida que el modelo ve.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="352"/>
         <source>Maximum combined prompt/response tokens before information is lost. Using more context than the model was trained on will yield poor results.
 NOTE: Does not take effect until you reload the model.</source>
-        <translation>Máximo de tokens combinados de indicación/respuesta antes de que se pierda información. Usar más contexto del que se utilizó para entrenar el modelo producirá resultados pobres.
+        <translation type="vanished">Máximo de tokens combinados de indicación/respuesta antes de que se pierda información. Usar más contexto del que se utilizó para entrenar el modelo producirá resultados pobres.
 NOTA: No tiene efecto hasta que recargues el modelo.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="382"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="382"/>
+        <location filename="../qml/ModelSettings.qml" line="412"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="412"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="383"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="383"/>
+        <location filename="../qml/ModelSettings.qml" line="413"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="413"/>
         <source>Randomness of model output. Higher -&gt; more variation.</source>
         <translation>Aleatoriedad de la salida del modelo. Mayor -&gt; más variación.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="353"/>
+        <location filename="../qml/ModelSettings.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="424"/>
         <source>Temperature increases the chances of choosing less likely tokens.
 NOTE: Higher temperature gives more creative but less predictable outputs.</source>
         <translation>La temperatura aumenta las probabilidades de elegir tokens menos probables.
 NOTA: Una temperatura más alta da resultados más creativos pero menos predecibles.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="428"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="428"/>
+        <location filename="../qml/ModelSettings.qml" line="458"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="458"/>
         <source>Top-P</source>
         <translation>Top-P</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="429"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="429"/>
+        <location filename="../qml/ModelSettings.qml" line="459"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="459"/>
         <source>Nucleus Sampling factor. Lower -&gt; more predicatable.</source>
         <translation>Factor de muestreo de núcleo. Menor -&gt; más predecible.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="374"/>
+        <location filename="../qml/ModelSettings.qml" line="469"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="469"/>
         <source>Only the most likely tokens up to a total probability of top_p can be chosen.
 NOTE: Prevents choosing highly unlikely tokens.</source>
         <translation>Solo se pueden elegir los tokens más probables hasta una probabilidad total de top_p.
 NOTA: Evita elegir tokens altamente improbables.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="473"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="473"/>
+        <location filename="../qml/ModelSettings.qml" line="503"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="503"/>
         <source>Min-P</source>
         <translation>Min-P</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="474"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="474"/>
+        <location filename="../qml/ModelSettings.qml" line="504"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="504"/>
         <source>Minimum token probability. Higher -&gt; more predictable.</source>
         <translation>Probabilidad mínima del token. Mayor -&gt; más predecible.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="484"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="484"/>
+        <location filename="../qml/ModelSettings.qml" line="514"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="514"/>
         <source>Sets the minimum relative probability for a token to be considered.</source>
         <translation>Establece la probabilidad relativa mínima para que un token sea considerado.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="520"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="520"/>
+        <location filename="../qml/ModelSettings.qml" line="550"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="550"/>
         <source>Top-K</source>
         <translation>Top-K</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="521"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="521"/>
+        <location filename="../qml/ModelSettings.qml" line="551"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="551"/>
         <source>Size of selection pool for tokens.</source>
         <translation>Tamaño del grupo de selección para tokens.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="532"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="532"/>
+        <location filename="../qml/ModelSettings.qml" line="562"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="562"/>
         <source>Only the top K most likely tokens will be chosen from.</source>
         <translation>Solo se elegirán los K tokens más probables.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="567"/>
+        <location filename="../qml/ModelSettings.qml" line="597"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="597"/>
         <source>Max Length</source>
         <translation>Longitud máxima</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="568"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="568"/>
+        <location filename="../qml/ModelSettings.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="598"/>
         <source>Maximum response length, in tokens.</source>
         <translation>Longitud máxima de respuesta, en tokens.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="613"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="613"/>
+        <location filename="../qml/ModelSettings.qml" line="643"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="643"/>
         <source>Prompt Batch Size</source>
         <translation>Tamaño del lote de indicaciones</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="614"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="614"/>
+        <location filename="../qml/ModelSettings.qml" line="644"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="644"/>
         <source>The batch size used for prompt processing.</source>
         <translation>El tamaño del lote utilizado para el procesamiento de indicaciones.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="625"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="625"/>
+        <location filename="../qml/ModelSettings.qml" line="655"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="655"/>
         <source>Amount of prompt tokens to process at once.
 NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
         <translation>Cantidad de tokens de prompt a procesar de una vez.
 NOTA: Valores más altos pueden acelerar la lectura de prompts, pero usarán más RAM.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="660"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="660"/>
+        <location filename="../qml/ModelSettings.qml" line="690"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="690"/>
         <source>Repeat Penalty</source>
         <translation>Penalización por repetición</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="661"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="661"/>
+        <location filename="../qml/ModelSettings.qml" line="691"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="691"/>
         <source>Repetition penalty factor. Set to 1 to disable.</source>
         <translation>Factor de penalización por repetición. Establecer a 1 para desactivar.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="705"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="705"/>
+        <location filename="../qml/ModelSettings.qml" line="735"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="735"/>
         <source>Repeat Penalty Tokens</source>
         <translation>Tokens de penalización por repetición</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="706"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="706"/>
+        <location filename="../qml/ModelSettings.qml" line="736"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="736"/>
         <source>Number of previous tokens used for penalty.</source>
         <translation>Número de tokens anteriores utilizados para la penalización.</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="751"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="751"/>
+        <location filename="../qml/ModelSettings.qml" line="781"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="781"/>
         <source>GPU Layers</source>
         <translation>Capas de GPU</translation>
     </message>
     <message>
-        <location filename="../qml/ModelSettings.qml" line="752"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="752"/>
+        <location filename="../qml/ModelSettings.qml" line="782"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="782"/>
         <source>Number of model layers to load into VRAM.</source>
         <translation>Número de capas del modelo a cargar en la VRAM.</translation>
     </message>
@@ -2113,228 +2178,234 @@ NOTA: No surte efecto hasta que recargue el modelo.</translation>
 <context>
     <name>ModelsView</name>
     <message>
-        <location filename="../qml/ModelsView.qml" line="36"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="36"/>
+        <location filename="../qml/ModelsView.qml" line="40"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="40"/>
         <source>No Models Installed</source>
         <translation>No hay modelos instalados</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="45"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="45"/>
+        <location filename="../qml/ModelsView.qml" line="49"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="49"/>
         <source>Install a model to get started using GPT4All</source>
         <translation>Instala un modelo para empezar a usar GPT4All</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="56"/>
-        <location filename="../qml/ModelsView.qml" line="98"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="56"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="98"/>
+        <location filename="../qml/ModelsView.qml" line="60"/>
+        <location filename="../qml/ModelsView.qml" line="102"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="60"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="102"/>
         <source>＋ Add Model</source>
         <translation>＋ Agregar modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="61"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="61"/>
+        <location filename="../qml/ModelsView.qml" line="65"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="65"/>
         <source>Shows the add model view</source>
         <translation>Muestra la vista de agregar modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="79"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="79"/>
+        <location filename="../qml/ModelsView.qml" line="83"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="83"/>
         <source>Installed Models</source>
         <translation>Modelos instalados</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="85"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="85"/>
+        <location filename="../qml/ModelsView.qml" line="89"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="89"/>
         <source>Locally installed chat models</source>
         <translation>Modelos de chat instalados localmente</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="143"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="143"/>
+        <location filename="../qml/ModelsView.qml" line="147"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="147"/>
         <source>Model file</source>
         <translation>Archivo del modelo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="144"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="144"/>
+        <location filename="../qml/ModelsView.qml" line="148"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="148"/>
         <source>Model file to be downloaded</source>
         <translation>Archivo del modelo a descargar</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="166"/>
+        <location filename="../qml/ModelsView.qml" line="170"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="170"/>
         <source>Description</source>
         <translation>Descripción</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="167"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="167"/>
+        <location filename="../qml/ModelsView.qml" line="171"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="171"/>
         <source>File description</source>
         <translation>Descripción del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="192"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="192"/>
+        <location filename="../qml/ModelsView.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="196"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="192"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="192"/>
+        <location filename="../qml/ModelsView.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="196"/>
         <source>Resume</source>
         <translation>Reanudar</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="200"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="200"/>
+        <location filename="../qml/ModelsView.qml" line="204"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="204"/>
         <source>Stop/restart/start the download</source>
         <translation>Detener/reiniciar/iniciar la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="212"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="212"/>
+        <location filename="../qml/ModelsView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="216"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="219"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="219"/>
+        <location filename="../qml/ModelsView.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="223"/>
         <source>Remove model from filesystem</source>
         <translation>Eliminar modelo del sistema de archivos</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="233"/>
-        <location filename="../qml/ModelsView.qml" line="242"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="242"/>
+        <location filename="../qml/ModelsView.qml" line="237"/>
+        <location filename="../qml/ModelsView.qml" line="271"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="237"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="271"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="243"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="243"/>
+        <location filename="../qml/ModelsView.qml" line="272"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="272"/>
         <source>Install online model</source>
         <translation>Instalar modelo en línea</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="40"/>
+        <location filename="../qml/ModelsView.qml" line="282"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="282"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="49"/>
+        <location filename="../qml/ModelsView.qml" line="301"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="301"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ADVERTENCIA: No recomendado para su hardware. El modelo requiere más memoria (%1 GB) de la que su sistema tiene disponible (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="424"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <location filename="../qml/ModelsView.qml" line="496"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="496"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="424"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="424"/>
+        <location filename="../qml/ModelsView.qml" line="496"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="496"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="259"/>
+        <location filename="../qml/ModelsView.qml" line="288"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="288"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>Describe un error que ocurrió durante la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="278"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="278"/>
+        <location filename="../qml/ModelsView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="307"/>
         <source>Error for incompatible hardware</source>
         <translation>Error por hardware incompatible</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="316"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="316"/>
+        <location filename="../qml/ModelsView.qml" line="345"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="345"/>
         <source>Download progressBar</source>
         <translation>Barra de progreso de descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="317"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="317"/>
+        <location filename="../qml/ModelsView.qml" line="346"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="346"/>
         <source>Shows the progress made in the download</source>
         <translation>Muestra el progreso realizado en la descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="327"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="327"/>
+        <location filename="../qml/ModelsView.qml" line="356"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="356"/>
         <source>Download speed</source>
         <translation>Velocidad de descarga</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="328"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="328"/>
+        <location filename="../qml/ModelsView.qml" line="357"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="357"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>Velocidad de descarga en bytes/kilobytes/megabytes por segundo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="345"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="345"/>
+        <location filename="../qml/ModelsView.qml" line="374"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="374"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="349"/>
         <location filename="../qml/ModelsView.qml" line="378"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="349"/>
+        <location filename="../qml/ModelsView.qml" line="408"/>
+        <location filename="../qml/ModelsView.qml" line="429"/>
+        <location filename="../qml/ModelsView.qml" line="450"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="378"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="408"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="429"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="450"/>
         <source>Whether the file hash is being calculated</source>
         <translation>Si se está calculando el hash del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="356"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="356"/>
+        <location filename="../qml/ModelsView.qml" line="385"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="385"/>
         <source>Busy indicator</source>
         <translation>Indicador de ocupado</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="357"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="357"/>
+        <location filename="../qml/ModelsView.qml" line="386"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="386"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>Se muestra cuando se está calculando el hash del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="375"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="375"/>
+        <location filename="../qml/ModelsView.qml" line="405"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="405"/>
         <source>enter $API_KEY</source>
         <translation>ingrese $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="397"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="397"/>
+        <location filename="../qml/ModelsView.qml" line="469"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="469"/>
         <source>File size</source>
         <translation>Tamaño del archivo</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="419"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="419"/>
+        <location filename="../qml/ModelsView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="491"/>
         <source>RAM required</source>
         <translation>RAM requerida</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="441"/>
+        <location filename="../qml/ModelsView.qml" line="513"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="513"/>
         <source>Parameters</source>
         <translation>Parámetros</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="463"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="463"/>
+        <location filename="../qml/ModelsView.qml" line="535"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="535"/>
         <source>Quant</source>
         <translation>Cuantificación</translation>
     </message>
     <message>
-        <location filename="../qml/ModelsView.qml" line="485"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="485"/>
+        <location filename="../qml/ModelsView.qml" line="557"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="557"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
@@ -2425,7 +2496,7 @@ response. If you dislike a response, you can suggest an alternative response. Th
 data will be collected and aggregated in the GPT4All Datalake.
 
 NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
-        <translation>Al habilitar esta función, podrá participar en el proceso democrático de entrenamiento de un modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo. Cuando un modelo GPT4All le responda y usted haya aceptado, su conversación se enviará al Datalake de código abierto de GPT4All. Además, puede dar me gusta/no me gusta a su respuesta. Si no le gusta una respuesta, puede sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
+        <translation type="vanished">Al habilitar esta función, podrá participar en el proceso democrático de entrenamiento de un modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo. Cuando un modelo GPT4All le responda y usted haya aceptado, su conversación se enviará al Datalake de código abierto de GPT4All. Además, puede dar me gusta/no me gusta a su respuesta. Si no le gusta una respuesta, puede sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
                 
 NOTA: Al activar esta función, enviará sus datos al Datalake de código abierto de GPT4All. No debe esperar privacidad en el chat cuando esta función esté habilitada. Sin embargo, puede esperar una atribución opcional si lo desea. Sus datos de chat estarán disponibles abiertamente para que cualquiera los descargue y serán utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará toda la información de atribución adjunta a sus datos y se le acreditará como contribuyente en cualquier lanzamiento de modelo GPT4All que utilice sus datos.</translation>
     </message>
@@ -2543,9 +2614,8 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../mysettings.cpp" line="119"/>
         <source>Default</source>
-        <translation>Predeterminado</translation>
+        <translation type="vanished">Predeterminado</translation>
     </message>
 </context>
 <context>
@@ -2604,26 +2674,22 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
         <translation>Notas de la versión para esta versión</translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="67"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="67"/>
         <source>### Release notes
 %1### Contributors
 %2
             </source>
-        <translation>### Notas de la versión
+        <translation type="vanished">### Notas de la versión
 %1### Colaboradores
 %2
             </translation>
     </message>
     <message>
-        <location filename="../qml/StartupDialog.qml" line="87"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="87"/>
         <source>### Opt-ins for anonymous usage analytics and datalake By enabling these features, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
                 
 When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
 
 NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
-        <translation>### Autorización para análisis de uso anónimo y datalake Al habilitar estas funciones, podrás participar en el proceso democrático de entrenar un modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo. Cuando un modelo GPT4All te responda y hayas aceptado participar, tu conversación se enviará al Datalake de Código Abierto de GPT4All. Además, podrás indicar si te gusta o no su respuesta. Si no te gusta una respuesta, puedes sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
+        <translation type="vanished">### Autorización para análisis de uso anónimo y datalake Al habilitar estas funciones, podrás participar en el proceso democrático de entrenar un modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo. Cuando un modelo GPT4All te responda y hayas aceptado participar, tu conversación se enviará al Datalake de Código Abierto de GPT4All. Además, podrás indicar si te gusta o no su respuesta. Si no te gusta una respuesta, puedes sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
                 
 NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Código Abierto de GPT4All. No debes esperar privacidad en el chat cuando esta función esté habilitada. Sin embargo, puedes esperar una atribución opcional si lo deseas. Tus datos de chat estarán disponibles abiertamente para que cualquiera los descargue y serán utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará toda la información de atribución adjunta a tus datos y se te acreditará como colaborador en cualquier lanzamiento de modelo GPT4All que utilice tus datos.
             </translation>
@@ -2763,7 +2829,7 @@ lanzamiento de modelo GPT4All que utilice sus datos.</translation>
     <message>
         <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
                 conversation. Do you wish to continue?</source>
-        <translation>&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
+        <translation type="vanished">&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
                 actual. ¿Desea continuar?</translation>
     </message>
     <message>
@@ -2985,57 +3051,6 @@ Locales</translation>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="641"/>
         <source>View of installed models</source>
         <translation>Vista de modelos instalados</translation>
-    </message>
-</context>
-<context>
-    <name>ChatAPIWorker</name>
-    <message>
-        <location filename="../chatapi.cpp" line="230"/>
-        <source>ERROR: Network error occurred while connecting to the API server</source>
-        <translation>ERROR: Ocurrió un error de red al conectar con el servidor API</translation>
-    </message>
-    <message>
-        <location filename="../chatapi.cpp" line="243"/>
-        <source>ChatAPIWorker::handleFinished got HTTP Error %1 %2</source>
-        <translation>ChatAPIWorker::handleFinished obtuvo Error HTTP %1 %2</translation>
-    </message>
-</context>
-<context>
-    <name>Download</name>
-    <message>
-        <location filename="../download.cpp" line="240"/>
-        <source>Model &quot;%1&quot; is installed successfully.</source>
-        <translation>El modelo &quot;%1&quot; se ha instalado correctamente.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="250"/>
-        <source>ERROR: $MODEL_NAME is empty.</source>
-        <translation>ERROR: $MODEL_NAME está vacío.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="256"/>
-        <source>ERROR: $API_KEY is empty.</source>
-        <translation>ERROR: $API_KEY está vacía.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="262"/>
-        <source>ERROR: $BASE_URL is invalid.</source>
-        <translation>ERROR: $BASE_URL no es válida.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="268"/>
-        <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
-        <translation>ERROR: El modelo &quot;%1 (%2)&quot; está en conflicto.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="287"/>
-        <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
-        <translation>El modelo &quot;%1 (%2)&quot; se ha instalado correctamente.</translation>
-    </message>
-    <message>
-        <location filename="../download.cpp" line="311"/>
-        <source>Model &quot;%1&quot; is removed.</source>
-        <translation>El modelo &quot;%1&quot; ha sido eliminado.</translation>
     </message>
 </context>
 </TS>

--- a/gpt4all-chat/translations/gpt4all_it_IT.ts
+++ b/gpt4all-chat/translations/gpt4all_it_IT.ts
@@ -1531,8 +1531,8 @@ modello per iniziare</translation>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>Il dispositivo di calcolo utilizzato per gli incorporamenti. &quot;Auto&quot; utilizza la CPU. Richiede il riavvio.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>Il dispositivo di calcolo utilizzato per gli incorporamenti. Richiede il riavvio.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>

--- a/gpt4all-chat/translations/gpt4all_it_IT.ts
+++ b/gpt4all-chat/translations/gpt4all_it_IT.ts
@@ -115,44 +115,44 @@
         <translation>Attiva la scoperta e il filtraggio dei modelli</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>Predefinito</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>Mi piace</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>Scaricamenti</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>Recenti</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>Asc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>Disc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>Niente</translation>
     </message>
@@ -163,266 +163,266 @@
         <translation>Ricerca · %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation>Ordina per: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation>Direzione ordinamento: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation>Limite: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation>Errore di rete: impossibile recuperare %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation>Indicatore di occupato</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation>Visualizzato quando la richiesta dei modelli è in corso</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation>File del modello</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation>File del modello da scaricare</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation>Descrizione del file</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>Riprendi</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>Scarica</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation>Arresta/riavvia/avvia il download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation>Rimuovi il modello dal sistema dei file</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>Installa</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>Installa il modello online</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;AVVERTENZA: non consigliato per il tuo hardware. Il modello richiede più memoria (%1 GB) di quella disponibile nel sistema (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERRORE: $API_KEY è vuoto.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
         <translation>ERRORE: $BASE_URL non è valido.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>inserisci $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERRORE: $MODEL_NAME è vuoto.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>inserisci $MODEL_NAME</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>Descrive un errore che si è verificato durante lo scaricamento</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Errore&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>Errore per hardware incompatibile</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation>Barra di avanzamento dello scaricamento</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation>Mostra lo stato di avanzamento dello scaricamento</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>Velocità di scaricamento</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>Velocità di scaricamento in byte/kilobyte/megabyte al secondo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>Calcolo in corso...</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation>Se viene calcolato l&apos;hash del file</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>Visualizzato durante il calcolo dell&apos;hash del file</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>Inserire $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation>Dimensione del file</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>RAM richiesta</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>Quant</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
@@ -490,74 +490,74 @@
         <translation>La combinazione di colori dell&apos;applicazione.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation>Scuro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Chiaro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation>Scuro Legacy</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>Dimensioni del Font</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation>La dimensione del testo nell&apos;applicazione.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>Piccolo</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>Medio</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation>Lingua e settaggi locali</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation>La lingua e i settaggi locali che vuoi utilizzare.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>Settaggi locali del sistema</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
@@ -566,167 +566,167 @@
         <translation type="vanished">Il dispositivo di calcolo utilizzato per la generazione del testo. &quot;Auto&quot; utilizza Vulkan o Metal.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation>Il dispositivo di calcolo utilizzato per la generazione del testo.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>Applicazione predefinita</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>Modello predefinito</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>Il modello preferito per le nuove chat. Utilizzato anche come ripiego del server locale.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>Modalità suggerimento</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>Genera le domande di approfondimento suggerite alla fine delle risposte.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation>Quando chatti con LocalDocs</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation>Quando possibile</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation>Mai</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>Percorso di scarico</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation>Dove archiviare i modelli locali e il database LocalDocs.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation>Esplora</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation>Scegli dove salvare i file del modello</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation>Abilita Datalake</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>Invia chat e commenti al Datalake Open Source GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translatorcomment>Thread della CPU</translatorcomment>
         <translation>Tread CPU</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>Il numero di thread della CPU utilizzati per l&apos;inferenza e l&apos;incorporamento.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
+        <location filename="../qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
         <source>Save Chat Context</source>
         <translation>Salva il contesto della chat</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>Salva lo stato del modello di chat su disco per un caricamento più rapido. ATTENZIONE: utilizza circa 2 GB per chat.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
+        <location filename="../qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local Server</source>
         <translation>Abilita server locale</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="488"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>Esporre un server compatibile con OpenAI a localhost. ATTENZIONE: comporta un maggiore utilizzo delle risorse.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
         <source>API Server Port</source>
         <translation>Porta del server API</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>La porta da utilizzare per il server locale. Richiede il riavvio.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation>Controlla gli aggiornamenti</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>Verifica manualmente l&apos;aggiornamento di GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation>Aggiornamenti</translation>
     </message>
@@ -1535,62 +1535,68 @@ modello per iniziare</translation>
         <translation>Il dispositivo di calcolo utilizzato per gli incorporamenti. Richiede il riavvio.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>Applicazione predefinita</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation>Mostra le fonti</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation>Visualizza le fonti utilizzate per ciascuna risposta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>Avanzate</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
         <translation>Avvertenza: solo per uso avanzato.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Valori troppo grandi possono causare errori di Localdocs, risposte estremamente lente o l&apos;impossibilità di rispondere. In parole povere, {N caratteri x N frammenti} vengono aggiunti alla finestra di contesto del modello. Maggiori informazioni &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;qui&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>Dimensioni del frammento di documento (caratteri)</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Numero di caratteri per frammento di documento. Numeri più grandi aumentano la probabilità di risposte basate sui fatti, ma comportano anche una generazione più lenta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>Numero massimo di frammenti di documento per prompt</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Numero massimo di N corrispondenze migliori di frammenti di documento recuperati da aggiungere al contesto del prompt. Numeri più grandi aumentano la probabilità di risposte basate sui fatti, ma comportano anche una generazione più lenta.</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_pt_BR.ts
+++ b/gpt4all-chat/translations/gpt4all_pt_BR.ts
@@ -115,44 +115,44 @@
         <translation>Aciona a descoberta e filtragem de modelos</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>Curtidas</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>Recentes</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>Asc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>Desc</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>Nenhum</translation>
     </message>
@@ -163,266 +163,266 @@
         <translation>Pesquisando · %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation>Ordenar por: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation>Ordenar diretório: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation>Limite: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation>Erro de rede: não foi possível obter %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation>Indicador de processamento</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation>xibido enquanto os modelos estão sendo carregados</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation>Arquivo do modelo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation>Arquivo do modelo a ser baixado</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>Descrição</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation>Descrição do arquivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>Retomar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>Baixar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation>Parar/reiniciar/iniciar o download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation>Remover modelo do sistema</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>Instalar</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>Instalar modelo online</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENÇÃO: Este modelo não é recomendado para seu hardware. Ele exige mais memória (%1 GB) do que seu sistema possui (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERRO: A $API_KEY está vazia.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
         <translation>ERRO: A $BASE_URL está vazia.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>inserir a $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERRO: O $MODEL_NAME está vazio.</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>inserir o $MODEL_NAME</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>Mostra informações sobre o erro no download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Erro&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>Aviso: Hardware não compatível</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation>Progresso do download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation>Mostra o progresso do download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>Velocidade de download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>Velocidade de download em bytes/kilobytes/megabytes por segundo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation>Quando o hash do arquivo está sendo calculado</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>Exibido durante o cálculo do hash do arquivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>inserir $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation>Tamanho do arquivo</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>RAM necessária</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>Parâmetros</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>Quant</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
@@ -496,240 +496,240 @@
         <translation>Esquema de cores.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation>Modo Escuro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Modo Claro</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation>Modo escuro (legado)</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>Tamanho da Fonte</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation>Tamanho do texto.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>Pequeno</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>Médio</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation>Idioma e Região</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation>Selecione seu idioma e região.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>Local do Sistema</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>Processador</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translatorcomment>I chose to use &quot;Processador&quot; instead of &quot;Dispositivo&quot; (Device) or &quot;Dispositivo de Computação&quot; (Compute Device) to simplify the terminology and make it more straightforward and understandable. &quot;Dispositivo&quot; can be vague and could refer to various types of hardware, whereas &quot;Processador&quot; clearly and specifically indicates the component responsible for processing tasks. This improves usability by avoiding the ambiguity that might arise from using more generic terms like &quot;Dispositivo.&quot;</translatorcomment>
         <translation>Processador usado para gerar texto.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>Aplicativo padrão</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>Modelo Padrão</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>Modelo padrão para novos chats e em caso de falha do modelo principal.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>Modo de sugestões</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>Sugerir perguntas após as respostas.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation>Ao conversar com o LocalDocs</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation>Sempre que possível</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>Diretório de Download</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation>Pasta para modelos e banco de dados do LocalDocs.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation>Procurar</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation>Local para armazenar os modelos</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation>Habilitar Datalake</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>Contribua para o Datalake de código aberto do GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>Avançado</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation>Threads de CPU</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>Quantidade de núcleos (threads) do processador usados para processar e responder às suas perguntas.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
+        <location filename="../qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
         <source>Save Chat Context</source>
         <translatorcomment>I used &quot;Histórico do Chat&quot; (Chat History) instead of &quot;Contexto do Chat&quot; (Chat Context) to clearly convey that it refers to saving past messages, making it more intuitive and avoiding potential confusion with abstract terms.</translatorcomment>
         <translation>Salvar Histórico do Chat</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>Salvar histórico do chat para carregamento mais rápido. (Usa aprox. 2GB por chat).</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
+        <location filename="../qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local Server</source>
         <translation>Ativar Servidor Local</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="488"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>Ativar servidor local compatível com OpenAI (uso de recursos elevado).</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
         <source>API Server Port</source>
         <translation>Porta da API</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>Porta de acesso ao servidor local. (requer reinicialização).</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation>Procurar por Atualizações</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>Verifica se há novas atualizações para o GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation>Atualizações</translation>
     </message>
@@ -1537,63 +1537,69 @@ modelo instalado para funcionar</translation>
         <translation>Dispositivo usado para processar as incorporações. Requer reinicialização.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>Aplicativo padrão</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>Exibir</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation>Mostrar Fontes</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation>Mostra as fontes usadas para cada resposta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>Apenas para usuários avançados</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
         <translation>Atenção: Apenas para usuários avançados.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation>Valores muito altos podem causar falhas no LocalDocs, respostas extremamente lentas ou até mesmo nenhuma resposta. De forma geral, o valor {Número de Caracteres x Número de Trechos} é adicionado à janela de contexto do modelo. Clique &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aqui&lt;/a&gt; para mais informações.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translatorcomment>I translated &quot;snippet&quot; as &quot;trecho&quot; to make the term feel more natural and understandable in Portuguese. &quot;Trecho&quot; effectively conveys the idea of a portion or section of a document, fitting well within the context, whereas a more literal translation might sound less intuitive or awkward for users.</translatorcomment>
         <translation>Tamanho do trecho de documento (caracteres)</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Número de caracteres por trecho de documento. Valores maiores aumentam a chance de respostas factuais, mas também tornam a geração mais lenta.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>Máximo de Trechos de Documento por Prompt</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>Número máximo de trechos de documentos a serem adicionados ao contexto do prompt. Valores maiores aumentam a chance de respostas factuais, mas também tornam a geração mais lenta.</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_pt_BR.ts
+++ b/gpt4all-chat/translations/gpt4all_pt_BR.ts
@@ -1533,8 +1533,8 @@ modelo instalado para funcionar</translation>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>Dispositivo usado para processar as incorporações. &quot;Automático&quot; utiliza a CPU. Requer reinicialização.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>Dispositivo usado para processar as incorporações. Requer reinicialização.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>

--- a/gpt4all-chat/translations/gpt4all_ro_RO.ts
+++ b/gpt4all-chat/translations/gpt4all_ro_RO.ts
@@ -7,30 +7,30 @@
         <location filename="../qml/AddCollectionView.qml" line="45"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="45"/>
         <source>← Existing Collections</source>
-        <translation>← Colec&#355;iile curente</translation>
+        <translation>← Colecţiile curente</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="68"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="68"/>
         <source>Add Document Collection</source>
-        <translation>Adaug&#259; o Colec&#355;ie de documente</translation>
+        <translation>Adaugă o Colecţie de documente</translation>
     </message>
     <message>
         <source>Add a folder containing plain text files, PDFs, or Markdown. Configure
                 additional extensions in Settings.</source>
-        <translation type="vanished">Adaug&#259; un folder care con&#355;ine fi&#351;iere &#238;n cu text-simplu, PDF sau Markdown. Extensii suplimentare pot fi specificate &#238;n Configurare.</translation>
+        <translation type="vanished">Adaugă un folder care conţine fişiere în cu text-simplu, PDF sau Markdown. Extensii suplimentare pot fi specificate în Configurare.</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="78"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="78"/>
         <source>Add a folder containing plain text files, PDFs, or Markdown. Configure additional extensions in Settings.</source>
-        <translation>Adaug&#259; un folder cu fi&#351;iere &#238;n format text, PDF sau Markdown. Alte extensii pot fi ad&#259;ugate &#238;n Configurare.</translation>
+        <translation>Adaugă un folder cu fişiere în format text, PDF sau Markdown. Alte extensii pot fi adăugate în Configurare.</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="94"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="94"/>
         <source>Please choose a directory</source>
-        <translation>Selecteaz&#259; un folder/director</translation>
+        <translation>Selectează un folder/director</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="106"/>
@@ -42,13 +42,13 @@
         <location filename="../qml/AddCollectionView.qml" line="121"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="121"/>
         <source>Collection name...</source>
-        <translation>Denumirea Colec&#355;iei...</translation>
+        <translation>Denumirea Colecţiei...</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="123"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="123"/>
         <source>Name of the collection to add (Required)</source>
-        <translation>Denumirea Colec&#355;iei de ad&#259;ugat (necesar)</translation>
+        <translation>Denumirea Colecţiei de adăugat (necesar)</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="139"/>
@@ -72,13 +72,13 @@
         <location filename="../qml/AddCollectionView.qml" line="171"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="171"/>
         <source>Browse</source>
-        <translation>C&#259;utare</translation>
+        <translation>Căutare</translation>
     </message>
     <message>
         <location filename="../qml/AddCollectionView.qml" line="184"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddCollectionView.qml" line="184"/>
         <source>Create Collection</source>
-        <translation>Creeaz&#259; o Colec&#355;ie</translation>
+        <translation>Creează o Colecţie</translation>
     </message>
 </context>
 <context>
@@ -93,71 +93,71 @@
         <location filename="../qml/AddModelView.qml" line="75"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="75"/>
         <source>Explore Models</source>
-        <translation>Caut&#259; modele</translation>
+        <translation>Caută modele</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="92"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="92"/>
         <source>Discover and download models by keyword search...</source>
-        <translation>Caut&#259; &#351;i descarc&#259; modele dup&#259; un cuv&#226;nt-cheie...</translation>
+        <translation>Caută şi descarcă modele după un cuvânt-cheie...</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="95"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="95"/>
         <source>Text field for discovering and filtering downloadable models</source>
-        <translation>C&#226;mp pentru c&#259;utarea &#351;i filtrarea modelelor ce pot fi desc&#259;rcate</translation>
+        <translation>Câmp pentru căutarea şi filtrarea modelelor ce pot fi descărcate</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="171"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="171"/>
         <source>Initiate model discovery and filtering</source>
-        <translation>Ini&#355;iaz&#259; c&#259;utarea &#351;i filtrarea modelelor</translation>
+        <translation>Iniţiază căutarea şi filtrarea modelelor</translation>
     </message>
     <message>
         <location filename="../qml/AddModelView.qml" line="172"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="172"/>
         <source>Triggers discovery and filtering of models</source>
-        <translation>Activeaz&#259; c&#259;utarea &#351;i filtrarea modelelor</translation>
+        <translation>Activează căutarea şi filtrarea modelelor</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>Likes</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>Download-uri</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>Recent/e</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>Asc. (A-&gt;Z)</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>Desc. (Z-&gt;A)</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>Niciunul</translation>
     </message>
@@ -165,158 +165,158 @@
         <location filename="../qml/AddModelView.qml" line="101"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="101"/>
         <source>Searching · %1</source>
-        <translation>C&#259;utare · %1</translation>
+        <translation>Căutare · %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
-        <translation>Ordonare dup&#259;: %1</translation>
+        <translation>Ordonare după: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
-        <translation>Sensul ordon&#259;rii: %1</translation>
+        <translation>Sensul ordonării: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
-        <translation>Límit&#259;: %1</translation>
+        <translation>Límită: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
-        <translation>Eroare de re&#355;ea: nu se poate prelua %1</translation>
+        <translation>Eroare de reţea: nu se poate prelua %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation>Indicator de activitate</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
-        <translation>Afi&#351;at &#238;n timpul solicit&#259;rii modelului</translation>
+        <translation>Afişat în timpul solicitării modelului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
-        <translation>Fi&#351;ierul modelului</translation>
+        <translation>Fişierul modelului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
-        <translation>Fi&#351;ierul modelului de desc&#259;rcat</translation>
+        <translation>Fişierul modelului de descărcat</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>Descriere</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
-        <translation>Descrierea fi&#351;ierului</translation>
+        <translation>Descrierea fişierului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>Continuare</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
-        <translation>Opre&#351;te/Reporne&#351;te/&#206;ncepe desc&#259;rcarea</translation>
+        <translation>Opreşte/Reporneşte/Începe descărcarea</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
-        <translation>&#351;terge</translation>
+        <translation>şterge</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
-        <translation>&#351;terge modelul din sistemul de fi&#351;iere</translation>
+        <translation>şterge modelul din sistemul de fişiere</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>Instalare</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>Instalez un model din online</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Eroare&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATEN&#354;IE: Nerecomandat pentru acest hardware. Modelul necesit&#259; mai mult&#259; memorie (%1 GB) dec&#226;t are acest sistem
+        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENŢIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are acest sistem
                 (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
                 hardware. Model requires more memory (%1 GB) than your system has available
                 (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATEN&#355;IE: Nerecomandat pentru acest hardware. Modelul necesit&#259; mai mult&#259; memorie (%1 GB) dec&#226;t cea disponibil&#259; &#238;n sistem (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENţIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât cea disponibilă în sistem (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
-        <translation>Descrie eroarea ap&#259;rut&#259; &#238;n timpul desc&#259;rc&#259;rii</translation>
+        <translation>Descrie eroarea apărută în timpul descărcării</translation>
     </message>
     <message>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
@@ -324,122 +324,122 @@
         <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#eroare&quot;&gt;Eroare&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>Eroare: hardware incompatibil</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
-        <translation>Progresia desc&#259;rc&#259;rii</translation>
+        <translation>Progresia descărcării</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
-        <translation>Afi&#351;eaz&#259; progresia desc&#259;rc&#259;rii</translation>
+        <translation>Afişează progresia descărcării</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>Viteza de download</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
-        <translation>Viteza de download &#238;n bytes/kilobytes/megabytes pe secund&#259;</translation>
+        <translation>Viteza de download în bytes/kilobytes/megabytes pe secundă</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>Calculare...</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
-        <translation>Dac&#259; se calculeaz&#259; hash-ul fi&#351;ierului</translation>
+        <translation>Dacă se calculează hash-ul fişierului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
-        <translation>Se afi&#351;eaz&#259; c&#226;nd se calculeaz&#259; hash-ul fi&#351;ierului</translation>
+        <translation>Se afişează când se calculează hash-ul fişierului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
-        <translation>EROARE: $API_KEY absent&#259;</translation>
+        <translation>EROARE: $API_KEY absentă</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>introdu cheia $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
-        <translation>EROARE: $BASE_URL absent&#259;</translation>
+        <translation>EROARE: $BASE_URL absentă</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>introdu $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>EROARE: $MODEL_NAME absent</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>introdu $MODEL_NAME</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
-        <translation>Dimensiunea fi&#351;ierului</translation>
+        <translation>Dimensiunea fişierului</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
-        <translation>RAM necesar&#259;</translation>
+        <translation>RAM necesară</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>Quant(ificare)</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
@@ -450,13 +450,13 @@
         <location filename="../qml/ApplicationSettings.qml" line="16"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="16"/>
         <source>Application</source>
-        <translation>Aplica&#355;ie/Program</translation>
+        <translation>Aplicaţie/Program</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="25"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="25"/>
         <source>Network dialog</source>
-        <translation>Re&#355;ea</translation>
+        <translation>Reţea</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="26"/>
@@ -473,7 +473,7 @@
                 If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have
                 to&lt;br&gt;
                 reinstall.</source>
-        <translation type="vanished">EROARE: Sistemul de actualizare nu poate g&#259;si componenta MaintenanceTool&lt;br&gt; necesar&#259; c&#259;ut&#259;rii de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dac&#259; da,&lt;br&gt; atunci MaintenanceTool trebuie s&#259; fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dac&#259; nu poate fi lansat&#259; manual, atunci programul trebuie reinstalat.</translation>
+        <translation type="vanished">EROARE: Sistemul de actualizare nu poate găsi componenta MaintenanceTool&lt;br&gt; necesară căutării de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dacă da,&lt;br&gt; atunci MaintenanceTool trebuie să fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dacă nu poate fi lansată manual, atunci programul trebuie reinstalat.</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="48"/>
@@ -497,7 +497,7 @@
         <location filename="../qml/ApplicationSettings.qml" line="97"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="97"/>
         <source>Theme</source>
-        <translation>Tema pentru interfa&#355;&#259;</translation>
+        <translation>Tema pentru interfaţă</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="98"/>
@@ -506,38 +506,38 @@
         <translation>Schema de culori a programului.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
-        <translation>&#206;ntunecat</translation>
+        <translation>Întunecat</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Luminos</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
-        <translation>&#206;ntunecat-vechi</translation>
+        <translation>Întunecat-vechi</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>Dimensiunea textului</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
-        <translation>Dimensiunea textului &#238;n program.</translation>
+        <translation>Dimensiunea textului în program.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>Dispozitiv/Device</translation>
     </message>
@@ -545,7 +545,7 @@
         <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or
                 Metal.</source>
         <translation type="vanished">Dispozitivul de calcul utilizat pentru generarea de text.
-                &quot;Auto&quot; apeleaz&#259; la Vulkan sau la Metal.</translation>
+                &quot;Auto&quot; apelează la Vulkan sau la Metal.</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="37"/>
@@ -557,217 +557,217 @@
                    above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
                    If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
                    reinstall.</source>
-        <translation>EROARE: Sistemul de Update nu poate g&#259;si componenta MaintenanceTool&lt;br&gt; necesar&#259; c&#259;ut&#259;rii de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dac&#259; da,&lt;br&gt; atunci MaintenanceTool trebuie s&#259; fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dac&#259; nu poate fi lansat&#259; manual, atunci programul trebuie reinstalat.</translation>
+        <translation>EROARE: Sistemul de Update nu poate găsi componenta MaintenanceTool&lt;br&gt; necesară căutării de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dacă da,&lt;br&gt; atunci MaintenanceTool trebuie să fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dacă nu poate fi lansată manual, atunci programul trebuie reinstalat.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>Mic</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>Mediu</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>Mare</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
-        <translation>Limb&#259; &#351;i Localizare</translation>
+        <translation>Limbă şi Localizare</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
-        <translation>Limba &#351;i Localizarea de utilizat</translation>
+        <translation>Limba şi Localizarea de utilizat</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>Localizare</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation>Dispozitivul de calcul utilizat pentru generarea de text.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>Modelul implicit</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
-        <translation>Modelul preferat pentru noile conversa&#355;ii. Va fi folosit drept rezerv&#259; pentru serverul local.</translation>
+        <translation>Modelul preferat pentru noile conversaţii. Va fi folosit drept rezervă pentru serverul local.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>Modul de sugerare</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
-        <translation>Generarea de &#206;ntreb&#259;ri pentru continuare, la finalul replicilor.</translation>
+        <translation>Generarea de Întrebări pentru continuare, la finalul replicilor.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
-        <translation>C&#226;nd se discut&#259; cu LocalDocs</translation>
+        <translation>Când se discută cu LocalDocs</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
-        <translation>Oric&#226;nd e posibil</translation>
+        <translation>Oricând e posibil</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
-        <translation>Niciodat&#259;</translation>
+        <translation>Niciodată</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>Calea pentru download</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
-        <translation>Unde s&#259; fie plasate modelele &#351;i baza de date LocalDocs.</translation>
+        <translation>Unde să fie plasate modelele şi baza de date LocalDocs.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
-        <translation>C&#259;utare</translation>
+        <translation>Căutare</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
-        <translation>Selecteaz&#259; locul unde vor fi plasate fi&#351;ierele modelelor</translation>
+        <translation>Selectează locul unde vor fi plasate fişierele modelelor</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
-        <translation>Activeaz&#259; DataLake</translation>
+        <translation>Activează DataLake</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
-        <translation>Trimite conversa&#355;ii &#351;i comentarii c&#259;tre componenta Open-source DataLake a GPT4All.</translation>
+        <translation>Trimite conversaţii şi comentarii către componenta Open-source DataLake a GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>Avansate</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation>Thread-uri CPU</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
-        <translation>Num&#259;rul de thread-uri CPU utilizate pentru inferen&#355;&#259; &#351;i embedding.</translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
-        <source>Save Chat Context</source>
-        <translation>Salvarea contextului conversa&#355;iei</translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
-        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
-        <translation>Salveaz&#259; pe disc starea modelului pentru &#238;nc&#259;rcare mai rapid&#259;. ATEN&#354;IE: Consum&#259; ~2GB/conversa&#355;ie.</translation>
+        <translation>Numărul de thread-uri CPU utilizate pentru inferenţă şi embedding.</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="488"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
+        <source>Save Chat Context</source>
+        <translation>Salvarea contextului conversaţiei</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
+        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
+        <translation>Salvează pe disc starea modelului pentru încărcare mai rapidă. ATENŢIE: Consumă ~2GB/conversaţie.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
-        <translation>Activeaz&#259; pe localhost un Server compatibil cu Open-AI. ATEN&#354;IE: Cre&#351;te consumul de resurse.</translation>
+        <translation>Activează pe localhost un Server compatibil cu Open-AI. ATENŢIE: Creşte consumul de resurse.</translation>
     </message>
     <message>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB
                 per chat.</source>
-        <translation type="vanished">Salveaz&#259; pe disc starea modelului pentru &#206;nc&#259;rcare mai rapid&#259;. ATEN&#355;IE: Consum&#259; ~2GB/conversa&#355;ie.</translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
-        <source>Enable Local Server</source>
-        <translation>Activeaz&#259; Serverul local</translation>
-    </message>
-    <message>
-        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
-                resource usage.</source>
-        <translation type="vanished">Activeaz&#259; pe localhost un Server compatibil cu Open-AI. ATEN&#355;IE: Cre&#351;te consumul de resurse.</translation>
-    </message>
-    <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
-        <source>API Server Port</source>
-        <translation>Portul Serverului API</translation>
+        <translation type="vanished">Salvează pe disc starea modelului pentru Încărcare mai rapidă. ATENţIE: Consumă ~2GB/conversaţie.</translation>
     </message>
     <message>
         <location filename="../qml/ApplicationSettings.qml" line="505"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <source>Enable Local Server</source>
+        <translation>Activează Serverul local</translation>
+    </message>
+    <message>
+        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
+                resource usage.</source>
+        <translation type="vanished">Activează pe localhost un Server compatibil cu Open-AI. ATENţIE: Creşte consumul de resurse.</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
+        <source>API Server Port</source>
+        <translation>Portul Serverului API</translation>
+    </message>
+    <message>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
-        <translation>Portul utilizat pentru Serverul local. Necesit&#259; repornirea programului.</translation>
+        <translation>Portul utilizat pentru Serverul local. Necesită repornirea programului.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
-        <translation>Caut&#259; update-uri</translation>
+        <translation>Caută update-uri</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
-        <translation>Caut&#259; manual update-uri pentru GPT4All.</translation>
+        <translation>Caută manual update-uri pentru GPT4All.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
-        <translation>Update-uri/Actualiz&#259;ri</translation>
+        <translation>Update-uri/Actualizări</translation>
     </message>
 </context>
 <context>
@@ -776,12 +776,12 @@
         <location filename="../chat.h" line="72"/>
         <location filename="../chat.cpp" line="25"/>
         <source>New Chat</source>
-        <translation>Chat/Conversa&#355;ie Nou&#259;</translation>
+        <translation>Chat/Conversaţie Nouă</translation>
     </message>
     <message>
         <location filename="../chat.cpp" line="38"/>
         <source>Server Chat</source>
-        <translation>Conversa&#355;ie cu Serverul</translation>
+        <translation>Conversaţie cu Serverul</translation>
     </message>
 </context>
 <context>
@@ -789,7 +789,7 @@
     <message>
         <location filename="../chatapi.cpp" line="230"/>
         <source>ERROR: Network error occurred while connecting to the API server</source>
-        <translation>EROARE: Eroare de re&#355;ea - conectarea la serverul API</translation>
+        <translation>EROARE: Eroare de reţea - conectarea la serverul API</translation>
     </message>
     <message>
         <location filename="../chatapi.cpp" line="243"/>
@@ -815,61 +815,61 @@
         <location filename="../qml/ChatDrawer.qml" line="49"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="49"/>
         <source>＋ New Chat</source>
-        <translation>＋ Conversa&#355;ie nou&#259;</translation>
+        <translation>＋ Conversaţie nouă</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="50"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="50"/>
         <source>Create a new chat</source>
-        <translation>Creeaz&#259; o Conversa&#355;ie nou&#259;</translation>
+        <translation>Creează o Conversaţie nouă</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="199"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="199"/>
         <source>Select the current chat or edit the chat when in edit mode</source>
-        <translation>Selecteaz&#259; conversa&#355;ia curent&#259; sau editeaz-o c&#226;nd e&#351;ti &#238;n modul editare</translation>
+        <translation>Selectează conversaţia curentă sau editeaz-o când eşti în modul editare</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="216"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="216"/>
         <source>Edit chat name</source>
-        <translation>Editeaz&#259; denumirea conversa&#355;iei</translation>
+        <translation>Editează denumirea conversaţiei</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="229"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="229"/>
         <source>Save chat name</source>
-        <translation>Salveaz&#259;a denumirea conversa&#355;iei</translation>
+        <translation>Salveazăa denumirea conversaţiei</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="246"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="246"/>
         <source>Delete chat</source>
-        <translation>&#351;terge conversa&#355;ia</translation>
+        <translation>şterge conversaţia</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="283"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="283"/>
         <source>Confirm chat deletion</source>
-        <translation>CONFIRM&#259; &#351;tergerea conversa&#355;iei</translation>
+        <translation>CONFIRMă ştergerea conversaţiei</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="305"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="305"/>
         <source>Cancel chat deletion</source>
-        <translation>ANULEAZ&#259; &#351;tergerea conversa&#355;iei</translation>
+        <translation>ANULEAZă ştergerea conversaţiei</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="317"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="317"/>
         <source>List of chats</source>
-        <translation>Lista conversa&#355;iilor</translation>
+        <translation>Lista conversaţiilor</translation>
     </message>
     <message>
         <location filename="../qml/ChatDrawer.qml" line="318"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatDrawer.qml" line="318"/>
         <source>List of chats in the drawer dialog</source>
-        <translation>Lista conversa&#355;iilor &#238;n sec&#355;iunea-sertar</translation>
+        <translation>Lista conversaţiilor în secţiunea-sertar</translation>
     </message>
 </context>
 <context>
@@ -877,12 +877,12 @@
     <message>
         <location filename="../chatlistmodel.h" line="86"/>
         <source>TODAY</source>
-        <translation>AST&#259;ZI</translation>
+        <translation>ASTăZI</translation>
     </message>
     <message>
         <location filename="../chatlistmodel.h" line="88"/>
         <source>THIS WEEK</source>
-        <translation>S&#259;PT&#259;M&#226;NA ACEASTA</translation>
+        <translation>SăPTăMâNA ACEASTA</translation>
     </message>
     <message>
         <location filename="../chatlistmodel.h" line="90"/>
@@ -892,7 +892,7 @@
     <message>
         <location filename="../chatlistmodel.h" line="92"/>
         <source>LAST SIX MONTHS</source>
-        <translation>ULTIMELE &#351;ASE LUNI</translation>
+        <translation>ULTIMELE şASE LUNI</translation>
     </message>
     <message>
         <location filename="../chatlistmodel.h" line="94"/>
@@ -911,7 +911,7 @@
         <location filename="../qml/ChatView.qml" line="77"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="77"/>
         <source>&lt;h3&gt;Warning&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</source>
-        <translation>&lt;h3&gt;Aten&#355;ie&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
+        <translation>&lt;h3&gt;Atenţie&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="86"/>
@@ -923,43 +923,43 @@
         <location filename="../qml/ChatView.qml" line="87"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="87"/>
         <source>Warn the user if they switch models, then context will be erased</source>
-        <translation>Avertizeaz&#259; utilizatorul c&#259; la schimbarea modelului va fi &#351;ters contextul</translation>
+        <translation>Avertizează utilizatorul că la schimbarea modelului va fi şters contextul</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="94"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="94"/>
         <source>Conversation copied to clipboard.</source>
-        <translation>Conversa&#355;ia a fost plasat&#259; &#238;n Clipboard.</translation>
+        <translation>Conversaţia a fost plasată în Clipboard.</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="101"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="101"/>
         <source>Code copied to clipboard.</source>
-        <translation>Codul a fost plasat &#238;n Clipboard.</translation>
+        <translation>Codul a fost plasat în Clipboard.</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="231"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="231"/>
         <source>Chat panel</source>
-        <translation>Sec&#355;iunea de chat</translation>
+        <translation>Secţiunea de chat</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="232"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="232"/>
         <source>Chat panel with options</source>
-        <translation>Sec&#355;iunea de chat cu op&#355;iuni</translation>
+        <translation>Secţiunea de chat cu opţiuni</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="339"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="339"/>
         <source>Reload the currently loaded model</source>
-        <translation>Re&#206;ncarc&#259; modelul curent</translation>
+        <translation>ReÎncarcă modelul curent</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="353"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="353"/>
         <source>Eject the currently loaded model</source>
-        <translation>Ejecteaz&#259; modelul curent</translation>
+        <translation>Ejectează modelul curent</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="365"/>
@@ -971,25 +971,25 @@
         <location filename="../qml/ChatView.qml" line="367"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="367"/>
         <source>Model loading error.</source>
-        <translation>Eroare la &#206;nc&#259;rcarea modelului.</translation>
+        <translation>Eroare la Încărcarea modelului.</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="369"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="369"/>
         <source>Waiting for model...</source>
-        <translation>Se a&#351;teapt&#259; modelul...</translation>
+        <translation>Se aşteaptă modelul...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="371"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="371"/>
         <source>Switching context...</source>
-        <translation>Se schimb&#259; contextul...</translation>
+        <translation>Se schimbă contextul...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="373"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="373"/>
         <source>Choose a model...</source>
-        <translation>Selecteaz&#259; un model...</translation>
+        <translation>Selectează un model...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="375"/>
@@ -1021,19 +1021,19 @@
         <location filename="../qml/ChatView.qml" line="568"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="568"/>
         <source>add collections of documents to the chat</source>
-        <translation>adaug&#259; Colec&#355;ii de documente la conversa&#355;ie</translation>
+        <translation>adaugă Colecţii de documente la conversaţie</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="738"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="738"/>
         <source>Load the default model</source>
-        <translation>&#206;ncarc&#259; modelul implicit</translation>
+        <translation>Încarcă modelul implicit</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="739"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="739"/>
         <source>Loads the default model which can be changed in settings</source>
-        <translation>&#206;ncarc&#259; modelul implicit care poate fi stabilit &#238;n Configurare</translation>
+        <translation>Încarcă modelul implicit care poate fi stabilit în Configurare</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="750"/>
@@ -1044,60 +1044,60 @@
     <message>
         <source>GPT4All requires that you install at least one
                 model to get started</source>
-        <translation type="vanished">GPT4All necesit&#259; cel pu&#355;in un
+        <translation type="vanished">GPT4All necesită cel puţin un
                 model pentru a putea porni</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="58"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="58"/>
         <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
-        <translation>&lt;h3&gt;EROARE la &#238;nc&#259;rcarea
+        <translation>&lt;h3&gt;EROARE la încărcarea
                 modelului:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Astfel
-                de erori pot ap&#259;rea din mai multe cauze, dintre care cele mai comune
-                includ un format inadecvat al fi&#351;ierului, un download incomplet sau &#238;ntrerupt,
-                un tip inadecvat de fi&#351;ier, RAM insuficient&#259;, sau un tip incompatibil de model.
-                Sugestii pentru rezolvarea problemei: verific&#259; dac&#259; fi&#351;ierul modelului are
-                un format &#351;i un tip compatibile; verific&#259; dac&#259; fi&#351;ierul modelului este complet
-                &#238;n folderul dedicat - acest folder este afi&#351;at &#238;n sec&#355;iunea Configurare; 
-                dac&#259; ai desc&#259;rcat modelul dinafara programului, asigur&#259;-te c&#259; fi&#351;ierul nu e corupt
-                dup&#259; ce &#238;i verifici amprenta MD5 (md5sum)&lt;li&gt;Afl&#259; mai mult despre modelele compatibile
-                &#238;n pagina unde am plasat &lt;a
-                href=&quot;https://docs.gpt4all.io/&quot;&gt;documenta&#355;ia&lt;/a&gt; pentru
-                interfa&#355;a gráfic&#259;&lt;li&gt;po&#355;i g&#259;si &lt;a
+                de erori pot apărea din mai multe cauze, dintre care cele mai comune
+                includ un format inadecvat al fişierului, un download incomplet sau întrerupt,
+                un tip inadecvat de fişier, RAM insuficientă, sau un tip incompatibil de model.
+                Sugestii pentru rezolvarea problemei: verifică dacă fişierul modelului are
+                un format şi un tip compatibile; verifică dacă fişierul modelului este complet
+                în folderul dedicat - acest folder este afişat în secţiunea Configurare; 
+                dacă ai descărcat modelul dinafara programului, asigură-te că fişierul nu e corupt
+                după ce îi verifici amprenta MD5 (md5sum)&lt;li&gt;Află mai mult despre modelele compatibile
+                în pagina unde am plasat &lt;a
+                href=&quot;https://docs.gpt4all.io/&quot;&gt;documentaţia&lt;/a&gt; pentru
+                interfaţa gráfică&lt;li&gt;poţi găsi &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canalul nostru Discord&lt;/a&gt; unde
-                se ofer&#259; ajutor</translation>
+                se oferă ajutor</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="759"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="759"/>
         <source>GPT4All requires that you install at least one
 model to get started</source>
-        <translation>GPT4All necesit&#259; cel pu&#355;in un
+        <translation>GPT4All necesită cel puţin un
                 model pentru a putea rula</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="771"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="771"/>
         <source>Install a Model</source>
-        <translation>Instaleaz&#259; un model</translation>
+        <translation>Instalează un model</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="776"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="776"/>
         <source>Shows the add model view</source>
-        <translation>Afiseaz&#259; sec&#355;iunea de ad&#259;ugare a unui model</translation>
+        <translation>Afisează secţiunea de adăugare a unui model</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="801"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="801"/>
         <source>Conversation with the model</source>
-        <translation>Conversa&#355;ie cu modelul</translation>
+        <translation>Conversaţie cu modelul</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="802"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="802"/>
         <source>prompt / response pairs from the conversation</source>
-        <translation>perechi prompt/replic&#259; din conversa&#355;ie</translation>
+        <translation>perechi prompt/replică din conversaţie</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="854"/>
@@ -1113,13 +1113,13 @@ model to get started</source>
     </message>
     <message>
         <source>recalculating context ...</source>
-        <translation type="vanished">se recalculeaz&#259; contextul...</translation>
+        <translation type="vanished">se recalculează contextul...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="878"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="878"/>
         <source>response stopped ...</source>
-        <translation>replic&#259; &#206;ntrerupt&#259;...</translation>
+        <translation>replică Întreruptă...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="881"/>
@@ -1131,13 +1131,13 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="882"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="882"/>
         <source>generating response ...</source>
-        <translation>se genereaz&#259; replica...</translation>
+        <translation>se generează replica...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="883"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="883"/>
         <source>generating questions ...</source>
-        <translation>se genereaz&#259; &#206;ntreb&#259;ri...</translation>
+        <translation>se generează Întrebări...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="949"/>
@@ -1175,7 +1175,7 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="1056"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1056"/>
         <source>Gives a thumbs up to the response</source>
-        <translation>D&#259; un Bravo acestei replici</translation>
+        <translation>Dă un Bravo acestei replici</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1089"/>
@@ -1187,7 +1187,7 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="1090"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1090"/>
         <source>Opens thumbs down dialog</source>
-        <translation>Deschide reac&#355;ia Aiurea</translation>
+        <translation>Deschide reacţia Aiurea</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1145"/>
@@ -1199,43 +1199,43 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="1389"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1389"/>
         <source>Suggested follow-ups</source>
-        <translation>Continu&#259;ri sugerate</translation>
+        <translation>Continuări sugerate</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1665"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1665"/>
         <source>Erase and reset chat session</source>
-        <translation>&#351;terge &#351;i reseteaz&#259; sesiunea de chat</translation>
+        <translation>şterge şi resetează sesiunea de chat</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1686"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1686"/>
         <source>Copy chat session to clipboard</source>
-        <translation>Copiez sesiunea de chat &#238;n Clipboard</translation>
+        <translation>Copiez sesiunea de chat în Clipboard</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1712"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1712"/>
         <source>Redo last chat response</source>
-        <translation>Reface ultima replic&#259;</translation>
+        <translation>Reface ultima replică</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1961"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1961"/>
         <source>Stop generating</source>
-        <translation>Opre&#351;te generarea</translation>
+        <translation>Opreşte generarea</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1962"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1962"/>
         <source>Stop the current response generation</source>
-        <translation>Opre&#351;te generarea replicii curente</translation>
+        <translation>Opreşte generarea replicii curente</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1777"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1777"/>
         <source>Reloads the model</source>
-        <translation>Re&#206;ncarc modelul</translation>
+        <translation>ReÎncarc modelul</translation>
     </message>
     <message>
         <source>&lt;h3&gt;Encountered an error loading
@@ -1251,21 +1251,21 @@ model to get started</source>
                 href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the
                 gui&lt;li&gt;Check out our &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
-        <translation type="vanished">&lt;h3&gt;EROARE la &#206;nc&#259;rcarea
+        <translation type="vanished">&lt;h3&gt;EROARE la Încărcarea
                 modelului:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Astfel
-                de erori pot ap&#259;rea din mai multe cauze, dintre care cele mai comune
-                includ un format inadecvat al fi&#351;ierului, un download incomplet sau &#206;ntrerupt,
-                un tip inadecvat de fi&#351;ier, RAM insuficient&#259;, sau un tip incompatibil de model.
-                Sugestii pentru rezolvarea problemei: verific&#259; dac&#259; fi&#351;ierul modelului are
-                un format si un tip compatibile; verific&#259; dac&#259; fi&#351;ierul modelului este complet
-                &#238;n folderul dedicat - acest folder este afi&#351;at &#238;n sec&#355;iunea Configurare; 
-                dac&#259; ai desc&#259;rcat modelul dinafara programului, asigur&#259;-te c&#259; fi&#351;ierul nu e corupt
-                dup&#259; ce &#238;i verifici amprenta MD5 (md5sum)&lt;li&gt;Afl&#259; mai multe despre care modele sunt compatibile
-                &#238;n pagina unde am plasat &lt;a
-                href=&quot;https://docs.gpt4all.io/&quot;&gt;documenta&#355;ia&lt;/a&gt; pentru
-                interfa&#355;a gráfic&#259;&lt;li&gt;po&#355;i parcurge &lt;a
+                de erori pot apărea din mai multe cauze, dintre care cele mai comune
+                includ un format inadecvat al fişierului, un download incomplet sau Întrerupt,
+                un tip inadecvat de fişier, RAM insuficientă, sau un tip incompatibil de model.
+                Sugestii pentru rezolvarea problemei: verifică dacă fişierul modelului are
+                un format si un tip compatibile; verifică dacă fişierul modelului este complet
+                în folderul dedicat - acest folder este afişat în secţiunea Configurare; 
+                dacă ai descărcat modelul dinafara programului, asigură-te că fişierul nu e corupt
+                după ce îi verifici amprenta MD5 (md5sum)&lt;li&gt;Află mai multe despre care modele sunt compatibile
+                în pagina unde am plasat &lt;a
+                href=&quot;https://docs.gpt4all.io/&quot;&gt;documentaţia&lt;/a&gt; pentru
+                interfaţa gráfică&lt;li&gt;poţi parcurge &lt;a
                 href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;canalul nostru Discord&lt;/a&gt; unde
-                se ofer&#259; ajutor</translation>
+                se oferă ajutor</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="377"/>
@@ -1273,19 +1273,19 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="377"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1775"/>
         <source>Reload · %1</source>
-        <translation>Re&#238;nc&#259;rcare · %1</translation>
+        <translation>Reîncărcare · %1</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="379"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="379"/>
         <source>Loading · %1</source>
-        <translation>&#206;nc&#259;rcare · %1</translation>
+        <translation>Încărcare · %1</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="714"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="714"/>
         <source>Load · %1 (default) →</source>
-        <translation>&#206;ncarc&#259; · %1 (implicit) →</translation>
+        <translation>Încarcă · %1 (implicit) →</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="876"/>
@@ -1303,7 +1303,7 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="880"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="880"/>
         <source>searching localdocs: %1 ...</source>
-        <translation>se caut&#259; &#238;n LocalDocs: %1 ...</translation>
+        <translation>se caută în LocalDocs: %1 ...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1851"/>
@@ -1315,13 +1315,13 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="1851"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1851"/>
         <source>Load a model to continue...</source>
-        <translation>&#206;ncarc&#259; un model pentru a continua...</translation>
+        <translation>Încarcă un model pentru a continua...</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1854"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1854"/>
         <source>Send messages/prompts to the model</source>
-        <translation>Trimite mesaje/prompt-uri c&#259;tre model</translation>
+        <translation>Trimite mesaje/prompt-uri către model</translation>
     </message>
     <message>
         <location filename="../qml/ChatView.qml" line="1899"/>
@@ -1351,7 +1351,7 @@ model to get started</source>
         <location filename="../qml/ChatView.qml" line="1986"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ChatView.qml" line="1986"/>
         <source>Sends the message/prompt contained in textfield to the model</source>
-        <translation>Trimite modelului mesajul/prompt-ul din c&#226;mpul-text</translation>
+        <translation>Trimite modelului mesajul/prompt-ul din câmpul-text</translation>
     </message>
 </context>
 <context>
@@ -1360,16 +1360,16 @@ model to get started</source>
         <location filename="../qml/CollectionsDrawer.qml" line="70"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="70"/>
         <source>Warning: searching collections while indexing can return incomplete results</source>
-        <translation>Aten&#355;ie: c&#259;utarea &#238;n Colec&#355;ii &#238;n timp ce sunt Indexate poate &#238;ntoarce rezultate incomplete</translation>
+        <translation>Atenţie: căutarea în Colecţii în timp ce sunt Indexate poate întoarce rezultate incomplete</translation>
     </message>
     <message numerus="yes">
         <location filename="../qml/CollectionsDrawer.qml" line="87"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n file(s)</source>
         <translation>
-            <numerusform>%n fi&#351;ier</numerusform>
-            <numerusform>%n fi&#351;iere</numerusform>
-            <numerusform>%n fi&#351;iere</numerusform>
+            <numerusform>%n fişier</numerusform>
+            <numerusform>%n fişiere</numerusform>
+            <numerusform>%n fişiere</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1377,7 +1377,7 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="87"/>
         <source>%n word(s)</source>
         <translation>
-            <numerusform>%n cuv&#226;nt</numerusform>
+            <numerusform>%n cuvânt</numerusform>
             <numerusform>%n cuvinte</numerusform>
             <numerusform>%n cuvinte</numerusform>
         </translation>
@@ -1398,7 +1398,7 @@ model to get started</source>
         <location filename="../qml/CollectionsDrawer.qml" line="137"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/CollectionsDrawer.qml" line="137"/>
         <source>Select a collection to make it available to the chat model.</source>
-        <translation>Selecteaz&#259; o Colec&#355;ie pentru ca modelul s&#259; o poat&#259; accesa.</translation>
+        <translation>Selectează o Colecţie pentru ca modelul să o poată accesa.</translation>
     </message>
 </context>
 <context>
@@ -1416,7 +1416,7 @@ model to get started</source>
     <message>
         <location filename="../download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
-        <translation>EROARE: $API_KEY absent&#259;</translation>
+        <translation>EROARE: $API_KEY absentă</translation>
     </message>
     <message>
         <location filename="../download.cpp" line="300"/>
@@ -1436,7 +1436,7 @@ model to get started</source>
     <message>
         <location filename="../download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
-        <translation>Modelul &quot;%1&quot; - &#238;ndep&#259;rtat</translation>
+        <translation>Modelul &quot;%1&quot; - îndepărtat</translation>
     </message>
 </context>
 <context>
@@ -1445,31 +1445,31 @@ model to get started</source>
         <location filename="../qml/HomeView.qml" line="49"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="49"/>
         <source>Welcome to GPT4All</source>
-        <translation>Bun venit &#238;n GPT4All</translation>
+        <translation>Bun venit în GPT4All</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="56"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="56"/>
         <source>The privacy-first LLM chat application</source>
-        <translation>Programul ce prioritizeaz&#259; confiden&#355;ialitatea (privacy)</translation>
+        <translation>Programul ce prioritizează confidenţialitatea (privacy)</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="66"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="66"/>
         <source>Start chatting</source>
-        <translation>&#206;ncepe o conversa&#355;ie</translation>
+        <translation>Începe o conversaţie</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="81"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="81"/>
         <source>Start Chatting</source>
-        <translation>&#206;ncepe o conversa&#355;ie</translation>
+        <translation>Începe o conversaţie</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="82"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="82"/>
         <source>Chat with any LLM</source>
-        <translation>Dialogheaz&#259; cu orice LLM</translation>
+        <translation>Dialoghează cu orice LLM</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="92"/>
@@ -1481,43 +1481,43 @@ model to get started</source>
         <location filename="../qml/HomeView.qml" line="93"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="93"/>
         <source>Chat with your local files</source>
-        <translation>Dialogheaz&#259; cu fi&#351;iere locale</translation>
+        <translation>Dialoghează cu fişiere locale</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="103"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="103"/>
         <source>Find Models</source>
-        <translation>Caut&#259; modele</translation>
+        <translation>Caută modele</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="104"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="104"/>
         <source>Explore and download models</source>
-        <translation>Exploreaz&#259; &#351;i descarc&#259; modele</translation>
+        <translation>Explorează şi descarcă modele</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="190"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="190"/>
         <source>Latest news</source>
-        <translation>Ultimele &#351;tiri</translation>
+        <translation>Ultimele ştiri</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="191"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="191"/>
         <source>Latest news from GPT4All</source>
-        <translation>Ultimele &#351;tiri de la GPT4All</translation>
+        <translation>Ultimele ştiri de la GPT4All</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="222"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="222"/>
         <source>Release Notes</source>
-        <translation>Despre aceast&#259; versiune</translation>
+        <translation>Despre această versiune</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="228"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="228"/>
         <source>Documentation</source>
-        <translation>Documenta&#355;ie</translation>
+        <translation>Documentaţie</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="234"/>
@@ -1534,8 +1534,12 @@ model to get started</source>
     <message>
         <location filename="../qml/HomeView.qml" line="246"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/HomeView.qml" line="246"/>
+        <source>Github</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>GitHub</source>
-        <translation>GitHub</translation>
+        <translation type="vanished">GitHub</translation>
     </message>
     <message>
         <location filename="../qml/HomeView.qml" line="257"/>
@@ -1574,13 +1578,13 @@ model to get started</source>
         <location filename="../qml/LocalDocsSettings.qml" line="51"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="51"/>
         <source>Allowed File Extensions</source>
-        <translation>Extensii compatibile de fi&#351;ier</translation>
+        <translation>Extensii compatibile de fişier</translation>
     </message>
     <message>
         <source>Comma-separated list. LocalDocs will only attempt to process files with these
                 extensions.</source>
-        <translation type="vanished">Extensiile, separate prin virgul&#259;. LocalDocs va &#206;ncerca procesarea
-                numai a fi&#351;ierelor cu aceste extensii.</translation>
+        <translation type="vanished">Extensiile, separate prin virgulă. LocalDocs va Încerca procesarea
+                numai a fişierelor cu aceste extensii.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="100"/>
@@ -1597,7 +1601,7 @@ model to get started</source>
     <message>
         <source>Embed documents using the fast Nomic API instead of a private local model.
                 Requires restart.</source>
-        <translation type="vanished">Embedding pe documente folosind API de la Nomic &#238;n locul unui model local. Necesit&#259; repornire.</translation>
+        <translation type="vanished">Embedding pe documente folosind API de la Nomic în locul unui model local. Necesită repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="130"/>
@@ -1609,7 +1613,7 @@ model to get started</source>
         <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a
                 href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;.
                 Requires restart.</source>
-        <translation type="vanished">Cheia API de utilizat cu Nomic Embed. Ob&#355;ine o cheie prin Atlas: &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;pagina cheilor API&lt;/a&gt; Necesit&#259; repornire.</translation>
+        <translation type="vanished">Cheia API de utilizat cu Nomic Embed. Obţine o cheie prin Atlas: &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;pagina cheilor API&lt;/a&gt; Necesită repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="165"/>
@@ -1618,80 +1622,82 @@ model to get started</source>
         <translation>Dispozitivul pentru Embeddings</translation>
     </message>
     <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="166"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
         <source>The compute device used for embeddings. Requires restart.</source>
-        <translation type="vanished">Dispozitivul pentru Embeddings. Necesit&#259; repornire.</translation>
+        <translation>Dispozitivul pentru Embeddings. Necesită repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="52"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="52"/>
         <source>Comma-separated list. LocalDocs will only attempt to process files with these extensions.</source>
-        <translation>Extensiile, separate prin virgul&#259;. LocalDocs va &#238;ncerca procesarea numai a fi&#351;ierelor cu aceste extensii.</translation>
+        <translation>Extensiile, separate prin virgulă. LocalDocs va încerca procesarea numai a fişierelor cu aceste extensii.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="113"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="113"/>
         <source>Embed documents using the fast Nomic API instead of a private local model. Requires restart.</source>
-        <translation>Embedding pe documente folosind API de la Nomic &#238;n locul unui model local. Necesit&#259; repornire.</translation>
+        <translation>Embedding pe documente folosind API de la Nomic în locul unui model local. Necesită repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="131"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="131"/>
         <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;. Requires restart.</source>
-        <translation>Cheia API de utilizat cu Nomic Embed. Ob&#355;ine o cheie prin Atlas: &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;pagina cheilor API&lt;/a&gt; Necesit&#259; repornire.</translation>
+        <translation>Cheia API de utilizat cu Nomic Embed. Obţine o cheie prin Atlas: &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;pagina cheilor API&lt;/a&gt; Necesită repornire.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="166"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. Requires restart.</source>
-        <translation>Dispozitivul pentru Embeddings. Necesit&#259; repornire.</translation>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>Implicit</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>Vizualizare</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
-        <translation>Afi&#351;area Surselor</translation>
+        <translation>Afişarea Surselor</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
-        <translation>Afi&#351;eaz&#259; Sursele utilizate pentru fiecare replic&#259;.</translation>
+        <translation>Afişează Sursele utilizate pentru fiecare replică.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>Avansate</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
-        <translation>Aten&#355;ie: Numai pentru utilizare avansat&#259;.</translation>
+        <translation>Atenţie: Numai pentru utilizare avansată.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
-        <translation>Valori prea mari pot cauza erori cu LocalDocs, replici foarte lente sau chiar absen&#355;a lor. &#206;n mare, num&#259;rul {N caractere x N citate} este ad&#259;ugat la Context Window/Size/Length a modelului. Mai multe informa&#355;ii: &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aici&lt;/a&gt;.</translation>
+        <translation>Valori prea mari pot cauza erori cu LocalDocs, replici foarte lente sau chiar absenţa lor. În mare, numărul {N caractere x N citate} este adăugat la Context Window/Size/Length a modelului. Mai multe informaţii: &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aici&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
-        <translation>Num&#259;rul caracterelor din fiecare citat. Numere mari amplific&#259; probabilitatea unor replici corecte, dar de asemenea cauzeaz&#259; generare lent&#259;.</translation>
+        <translation>Numărul caracterelor din fiecare citat. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea cauzează generare lentă.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
-        <translation>Num&#259;rul maxim al citatelor ce corespund &#351;i care vor fi ad&#259;ugate la contextul pentru prompt. Numere mari amplific&#259; probabilitatea unor replici corecte, dar de asemenea cauzeaz&#259; generare lent&#259;.</translation>
+        <translation>Numărul maxim al citatelor ce corespund şi care vor fi adăugate la contextul pentru prompt. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea cauzează generare lentă.</translation>
     </message>
     <message>
         <source>
@@ -1700,30 +1706,30 @@ model to get started</source>
                 the model&apos;s context window. More info &lt;a
                 href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation type="vanished">
-                Valori prea mari pot cauza erori cu LocalDocs, replici lente sau absen&#355;a lor complet&#259;. &#238;n mare, num&#259;rul {N caractere x N citate} este ad&#259;ugat la Context Window/Size/Length a modelului. Mai multe informa&#355;ii: &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aici&lt;/a&gt;.</translation>
+                Valori prea mari pot cauza erori cu LocalDocs, replici lente sau absenţa lor completă. în mare, numărul {N caractere x N citate} este adăugat la Context Window/Size/Length a modelului. Mai multe informaţii: &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aici&lt;/a&gt;.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
-        <translation>Lungimea (&#238;n caractere) a citatelor din documente</translation>
+        <translation>Lungimea (în caractere) a citatelor din documente</translation>
     </message>
     <message>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of
                 factual responses, but also result in slower generation.</source>
-        <translation type="vanished">num&#259;rul caracterelor din fiecare citat. Numere mari amplific&#259; probabilitatea unor replici corecte, dar de asemenea pot cauza generare lent&#259;.</translation>
+        <translation type="vanished">numărul caracterelor din fiecare citat. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea pot cauza generare lentă.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
-        <translation>Num&#259;rul maxim de citate per prompt</translation>
+        <translation>Numărul maxim de citate per prompt</translation>
     </message>
     <message>
         <source>Max best N matches of retrieved document snippets to add to the context for
                 prompt. Larger numbers increase likelihood of factual responses, but also result in
                 slower generation.</source>
-        <translation type="vanished">Num&#259;rul maxim al citatelor ce corespund &#351;i care vor fi ad&#259;ugate la contextul pentru prompt. Numere mari amplific&#259; probabilitatea unor replici corecte, dar de asemenea pot cauza generare lent&#259;.</translation>
+        <translation type="vanished">Numărul maxim al citatelor ce corespund şi care vor fi adăugate la contextul pentru prompt. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea pot cauza generare lentă.</translation>
     </message>
 </context>
 <context>
@@ -1738,59 +1744,59 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="58"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="58"/>
         <source>Chat with your local files</source>
-        <translation>Dialogheaz&#259; cu fi&#351;iere locale</translation>
+        <translation>Dialoghează cu fişiere locale</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="71"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="71"/>
         <source>＋ Add Collection</source>
-        <translation>＋ Adaug&#259; o Colec&#355;ie</translation>
+        <translation>＋ Adaugă o Colecţie</translation>
     </message>
     <message>
         <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">EROARE: Baza de date LocalDocs nu e valid&#259;.</translation>
+        <translation type="vanished">EROARE: Baza de date LocalDocs nu e validă.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="85"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="85"/>
         <source>&lt;h3&gt;ERROR: The LocalDocs database cannot be accessed or is not valid.&lt;/h3&gt;&lt;br&gt;&lt;i&gt;Note: You will need to restart after trying any of the following suggested fixes.&lt;/i&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Make sure that the folder set as &lt;b&gt;Download Path&lt;/b&gt; exists on the file system.&lt;/li&gt;&lt;li&gt;Check ownership as well as read and write permissions of the &lt;b&gt;Download Path&lt;/b&gt;.&lt;/li&gt;&lt;li&gt;If there is a &lt;b&gt;localdocs_v2.db&lt;/b&gt; file, check its ownership and read/write permissions, too.&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;If the problem persists and there are any &apos;localdocs_v*.db&apos; files present, as a last resort you can&lt;br&gt;try backing them up and removing them. You will have to recreate your collections, however.</source>
-        <translation>EROARE: Baza de date LocalDocs nu poate fi accesat&#259; sau nu e valid&#259;. Programul trebuie repornit dup&#259; ce se &#238;ncearc&#259; oricare din urm&#259;toarele remedii sugerate.&lt;/i&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Asigur&#259;-te c&#259; folderul pentru &lt;b&gt;Download Path&lt;/b&gt; exist&#259; &#238;n sistemul de fi&#351;iere.&lt;/li&gt;&lt;li&gt;Verific&#259; permisiunile &#351;i apartenen&#355;a folderului pentru &lt;b&gt;Download Path&lt;/b&gt;.&lt;/li&gt;&lt;li&gt;Dac&#259; exist&#259; fi&#351;ierul &lt;b&gt;localdocs_v2.db&lt;/b&gt;, verific&#259;-i apartenen&#355;a &#351;i permisiunile citire/scriere (read/write).&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;Dac&#259; problema persist&#259; &#351;i exist&#259; vreun fi&#351;ier &apos;localdocs_v*.db&apos;, ca ultim&#259; solu&#355;ie po&#355;i&lt;br&gt;&#238;ncerca duplicarea (backup) &#351;i apoi &#351;tergerea lor. Oricum, va trebui s&#259; re-creezi Colec&#355;iile.</translation>
+        <translation>EROARE: Baza de date LocalDocs nu poate fi accesată sau nu e validă. Programul trebuie repornit după ce se încearcă oricare din următoarele remedii sugerate.&lt;/i&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Asigură-te că folderul pentru &lt;b&gt;Download Path&lt;/b&gt; există în sistemul de fişiere.&lt;/li&gt;&lt;li&gt;Verifică permisiunile şi apartenenţa folderului pentru &lt;b&gt;Download Path&lt;/b&gt;.&lt;/li&gt;&lt;li&gt;Dacă există fişierul &lt;b&gt;localdocs_v2.db&lt;/b&gt;, verifică-i apartenenţa şi permisiunile citire/scriere (read/write).&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;Dacă problema persistă şi există vreun fişier &apos;localdocs_v*.db&apos;, ca ultimă soluţie poţi&lt;br&gt;încerca duplicarea (backup) şi apoi ştergerea lor. Oricum, va trebui să re-creezi Colecţiile.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="109"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="109"/>
         <source>No Collections Installed</source>
-        <translation>Nu exist&#259; Colec&#355;ii instalate</translation>
+        <translation>Nu există Colecţii instalate</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="118"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="118"/>
         <source>Install a collection of local documents to get started using this feature</source>
-        <translation>Instaleaz&#259; o Colec&#355;ie de documente pentru a putea utiliza func&#355;ionalitatea aceasta</translation>
+        <translation>Instalează o Colecţie de documente pentru a putea utiliza funcţionalitatea aceasta</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="129"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="129"/>
         <source>＋ Add Doc Collection</source>
-        <translation>＋ Adaug&#259; o Colec&#355;ie de documente</translation>
+        <translation>＋ Adaugă o Colecţie de documente</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="134"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="134"/>
         <source>Shows the add model view</source>
-        <translation>Afi&#351;eaz&#259; sec&#355;iunea de ad&#259;ugare a unui model</translation>
+        <translation>Afişează secţiunea de adăugare a unui model</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="231"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="231"/>
         <source>Indexing progressBar</source>
-        <translation>Bara de progresie a Index&#259;rii</translation>
+        <translation>Bara de progresie a Indexării</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="232"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="232"/>
         <source>Shows the progress made in the indexing</source>
-        <translation>Afi&#351;eaz&#259; progresia Index&#259;rii</translation>
+        <translation>Afişează progresia Indexării</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="257"/>
@@ -1802,7 +1808,7 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="261"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="261"/>
         <source>INDEXING</source>
-        <translation>...SE INDEXEAZ&#259;...</translation>
+        <translation>...SE INDEXEAZă...</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="265"/>
@@ -1814,7 +1820,7 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="268"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="268"/>
         <source>REQUIRES UPDATE</source>
-        <translation>NECESIT&#259; UPDATE</translation>
+        <translation>NECESITă UPDATE</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="271"/>
@@ -1832,31 +1838,31 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="300"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="300"/>
         <source>Indexing in progress</source>
-        <translation>Se Indexeaz&#259;...</translation>
+        <translation>Se Indexează...</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="303"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="303"/>
         <source>Embedding in progress</source>
-        <translation>...Se calculeaz&#259; Embeddings...</translation>
+        <translation>...Se calculează Embeddings...</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="306"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="306"/>
         <source>This collection requires an update after version change</source>
-        <translation>Aceast&#259; Colec&#355;ie necesit&#259; update dup&#259; schimbarea versiunii</translation>
+        <translation>Această Colecţie necesită update după schimbarea versiunii</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="309"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="309"/>
         <source>Automatically reindexes upon changes to the folder</source>
-        <translation>Se reindexeaz&#259; automat dup&#259; schimb&#259;ri ale folderului</translation>
+        <translation>Se reindexează automat după schimbări ale folderului</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="311"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="311"/>
         <source>Installation in progress</source>
-        <translation>...Instalare &#238;n curs...</translation>
+        <translation>...Instalare în curs...</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="325"/>
@@ -1869,9 +1875,9 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n file(s)</source>
         <translation>
-            <numerusform>%n fi&#351;ier</numerusform>
-            <numerusform>%n fi&#351;iere</numerusform>
-            <numerusform>%n fi&#351;iere</numerusform>
+            <numerusform>%n fişier</numerusform>
+            <numerusform>%n fişiere</numerusform>
+            <numerusform>%n fişiere</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1879,7 +1885,7 @@ model to get started</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="337"/>
         <source>%n word(s)</source>
         <translation>
-            <numerusform>%n cuv&#226;nt</numerusform>
+            <numerusform>%n cuvânt</numerusform>
             <numerusform>%n cuvinte</numerusform>
             <numerusform>%n cuvinte</numerusform>
         </translation>
@@ -1888,19 +1894,19 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="408"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="408"/>
         <source>Remove</source>
-        <translation>&#350;terg</translation>
+        <translation>Şterg</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="420"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="420"/>
         <source>Rebuild</source>
-        <translation>Reconstruc&#355;ie</translation>
+        <translation>Reconstrucţie</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="423"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="423"/>
         <source>Reindex this folder from scratch. This is slow and usually not needed.</source>
-        <translation>Reindexeaz&#259; de la zero acest folder. Procesul e lent &#351;i de obicei inutil.</translation>
+        <translation>Reindexează de la zero acest folder. Procesul e lent şi de obicei inutil.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsView.qml" line="430"/>
@@ -1912,7 +1918,7 @@ model to get started</source>
         <location filename="../qml/LocalDocsView.qml" line="433"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="433"/>
         <source>Update the collection to the new version. This is a slow operation.</source>
-        <translation>Actualizeaz&#259; Colec&#355;ia la noua versiune. Aceast&#259; procedur&#259; e lent&#259;.</translation>
+        <translation>Actualizează Colecţia la noua versiune. Această procedură e lentă.</translation>
     </message>
 </context>
 <context>
@@ -1926,7 +1932,7 @@ model to get started</source>
                 OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
                 href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
         <translation type="vanished">
-                &lt;ul&gt;&lt;li&gt;Necesit&#259; o cheie API OpenAI personal&#259;. &lt;/li&gt;&lt;li&gt;ATEN&#355;IE: Conversa&#355;iile tale vor fi trimise la OpenAI! &lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocat&#259; pe disc (local) &lt;/li&gt;&lt;li&gt;Va fi utilizat&#259; numai pentru comunicarea cu OpenAI&lt;/li&gt;&lt;li&gt;Po&#355;i solicita o cheie API aici: &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aici.&lt;/a&gt;&lt;/li&gt;</translation>
+                &lt;ul&gt;&lt;li&gt;Necesită o cheie API OpenAI personală. &lt;/li&gt;&lt;li&gt;ATENţIE: Conversaţiile tale vor fi trimise la OpenAI! &lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local) &lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu OpenAI&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aici.&lt;/a&gt;&lt;/li&gt;</translation>
     </message>
     <message>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
@@ -1946,7 +1952,7 @@ model to get started</source>
     <message>
         <location filename="../modellist.cpp" line="1559"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal OpenAI API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
-        <translation>&lt;ul&gt;&lt;li&gt;Necesit&#259; o cheie API OpenAI personal&#259;. &lt;/li&gt;&lt;li&gt;ATEN&#354;IE: Conversa&#355;iile tale vor fi trimise la OpenAI!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocat&#259; pe disc (local) &lt;/li&gt;&lt;li&gt;Va fi utilizat&#259; numai pentru comunicarea cu OpenAI&lt;/li&gt;&lt;li&gt;Po&#355;i solicita o cheie API aici: &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aici.&lt;/a&gt;&lt;/li&gt;</translation>
+        <translation>&lt;ul&gt;&lt;li&gt;Necesită o cheie API OpenAI personală. &lt;/li&gt;&lt;li&gt;ATENŢIE: Conversaţiile tale vor fi trimise la OpenAI!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local) &lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu OpenAI&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aici.&lt;/a&gt;&lt;/li&gt;</translation>
     </message>
     <message>
         <location filename="../modellist.cpp" line="1578"/>
@@ -1956,7 +1962,7 @@ model to get started</source>
     <message>
         <location filename="../modellist.cpp" line="1591"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does not guarantee API key access. Contact OpenAI for more info.</source>
-        <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Chiar dac&#259; pl&#259;te&#351;ti la OpenAI pentru ChatGPT-4, aceasta nu garanteaz&#259; accesul la cheia API. Contacteaz&#259; OpenAI pentru mai multe informa&#355;ii.</translation>
+        <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Chiar dacă plăteşti la OpenAI pentru ChatGPT-4, aceasta nu garantează accesul la cheia API. Contactează OpenAI pentru mai multe informaţii.</translation>
     </message>
     <message>
         <location filename="../modellist.cpp" line="1606"/>
@@ -1966,7 +1972,7 @@ model to get started</source>
     <message>
         <location filename="../modellist.cpp" line="1618"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
-        <translation>&lt;ul&gt;&lt;li&gt;Necesit&#259; cheia personal&#259; Mistral API. &lt;/li&gt;&lt;li&gt;ATEN&#354;IE: Conversa&#355;iile tale vor fi trimise la Mistral!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocat&#259; pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizat&#259; numai pentru comunicarea cu Mistral&lt;/li&gt;&lt;li&gt;Po&#355;i solicita o cheie API aici: &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aici&lt;/a&gt;.&lt;/li&gt;</translation>
+        <translation>&lt;ul&gt;&lt;li&gt;Necesită cheia personală Mistral API. &lt;/li&gt;&lt;li&gt;ATENŢIE: Conversaţiile tale vor fi trimise la Mistral!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu Mistral&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aici&lt;/a&gt;.&lt;/li&gt;</translation>
     </message>
     <message>
         <location filename="../modellist.cpp" line="1637"/>
@@ -1986,7 +1992,7 @@ model to get started</source>
     <message>
         <location filename="../modellist.cpp" line="1700"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal API key and the API base URL.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to the OpenAI-compatible API Server you specified!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with the OpenAI-compatible API Server&lt;/li&gt;</source>
-        <translation>&lt;ul&gt;&lt;li&gt;Necesit&#259; cheia personal&#259; API si base-URL a API.&lt;/li&gt;&lt;li&gt;ATEN&#354;IE: Conversa&#355;iile tale vor fi trimise la serverul API compatibil cu OpenAI specificat!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocat&#259; pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizat&#259; numai pentru comunicarea cu serverul API compatibil cu OpenAI&lt;/li&gt;</translation>
+        <translation>&lt;ul&gt;&lt;li&gt;Necesită cheia personală API si base-URL a API.&lt;/li&gt;&lt;li&gt;ATENŢIE: Conversaţiile tale vor fi trimise la serverul API compatibil cu OpenAI specificat!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu serverul API compatibil cu OpenAI&lt;/li&gt;</translation>
     </message>
     <message>
         <location filename="../modellist.cpp" line="1717"/>
@@ -1996,12 +2002,12 @@ model to get started</source>
     <message>
         <location filename="../modellist.cpp" line="2131"/>
         <source>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
-        <translation>&lt;strong&gt;Creat de c&#259;tre %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informa&#355;ii pot fi g&#259;site la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
+        <translation>&lt;strong&gt;Creat de către %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informaţii pot fi găsite la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
         <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does
                 not guarantee API key access. Contact OpenAI for more info.</source>
-        <translation type="vanished">&lt;br&gt;&lt;br&gt;&lt;i&gt;* Chiar dac&#259; pl&#259;te&#351;ti la OpenAI pentru ChatGPT-4, aceasta nu garanteaz&#259; accesul la cheia API. Contacteaz&#259; OpenAI pentru mai multe informa&#355;ii.</translation>
+        <translation type="vanished">&lt;br&gt;&lt;br&gt;&lt;i&gt;* Chiar dacă plăteşti la OpenAI pentru ChatGPT-4, aceasta nu garantează accesul la cheia API. Contactează OpenAI pentru mai multe informaţii.</translation>
     </message>
     <message>
         <source>
@@ -2012,14 +2018,14 @@ model to get started</source>
                 Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
                 href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
         <translation type="vanished">
-                &lt;ul&gt;&lt;li&gt;Necesit&#259; cheia personal&#259; Mistral API. &lt;/li&gt;&lt;li&gt;ATEN&#355;IE: Conversa&#355;iile tale vor fi trimise la Mistral!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocat&#259; pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizat&#259; numai pentru comunicarea cu Mistral&lt;/li&gt;&lt;li&gt;Po&#355;i solicita o cheie API aici: &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aici&lt;/a&gt;.&lt;/li&gt;</translation>
+                &lt;ul&gt;&lt;li&gt;Necesită cheia personală Mistral API. &lt;/li&gt;&lt;li&gt;ATENţIE: Conversaţiile tale vor fi trimise la Mistral!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu Mistral&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aici&lt;/a&gt;.&lt;/li&gt;</translation>
     </message>
     <message>
         <source>&lt;strong&gt;Created by
                 %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model
                 has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found
                 &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
-        <translation type="vanished">&lt;strong&gt;Creat de c&#259;tre %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informa&#355;ii pot fi g&#259;site la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;Creat de către %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informaţii pot fi găsite la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
     </message>
 </context>
 <context>
@@ -2046,7 +2052,7 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="93"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="93"/>
         <source>Remove</source>
-        <translation>&#350;terg</translation>
+        <translation>Şterg</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="107"/>
@@ -2058,7 +2064,7 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="140"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="140"/>
         <source>Model File</source>
-        <translation>Fi&#351;ierul modelului</translation>
+        <translation>Fişierul modelului</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="158"/>
@@ -2069,7 +2075,7 @@ model to get started</source>
     <message>
         <source>Prefixed at the beginning of every conversation. Must contain the appropriate
                 framing tokens.</source>
-        <translation type="vanished">Plasat la &#206;nceputul fiec&#259;rei conversa&#355;ii. Trebuie s&#259; con&#355;in&#259; token-uri(le) adecvate de &#206;ncadrare.</translation>
+        <translation type="vanished">Plasat la Începutul fiecărei conversaţii. Trebuie să conţină token-uri(le) adecvate de Încadrare.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="205"/>
@@ -2081,24 +2087,24 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="206"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="206"/>
         <source>The template that wraps every prompt.</source>
-        <translation>Standardul de formulare a fiec&#259;rui prompt.</translation>
+        <translation>Standardul de formulare a fiecărui prompt.</translation>
     </message>
     <message>
         <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s
                 input.</source>
-        <translation type="vanished">Trebuie s&#259; con&#355;in&#259; textul &quot;%1&quot; care va fi &#206;nlocuit cu ceea ce scrie utilizatorul.</translation>
+        <translation type="vanished">Trebuie să conţină textul &quot;%1&quot; care va fi Înlocuit cu ceea ce scrie utilizatorul.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="255"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="255"/>
         <source>Chat Name Prompt</source>
-        <translation>Denumirea conversa&#355;iei</translation>
+        <translation>Denumirea conversaţiei</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="256"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="256"/>
         <source>Prompt used to automatically generate chat names.</source>
-        <translation>Standardul de formulare a denumirii conversa&#355;iilor.</translation>
+        <translation>Standardul de formulare a denumirii conversaţiilor.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="298"/>
@@ -2110,7 +2116,7 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="299"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="299"/>
         <source>Prompt used to generate suggested follow-up questions.</source>
-        <translation>Prompt-ul folosit pentru generarea &#206;ntreb&#259;rilor de continuare.</translation>
+        <translation>Prompt-ul folosit pentru generarea Întrebărilor de continuare.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="352"/>
@@ -2122,13 +2128,13 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="353"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="353"/>
         <source>Number of input and output tokens the model sees.</source>
-        <translation>Num&#259;rul token-urilor de input &#351;i de output v&#259;zute de model.</translation>
+        <translation>Numărul token-urilor de input şi de output văzute de model.</translation>
     </message>
     <message>
         <source>Maximum combined prompt/response tokens before information is lost.
                 Using more context than the model was trained on will yield poor results.
                 NOTE: Does not take effect until you reload the model.</source>
-        <translation type="vanished">Num&#259;rul maxim combinat al token-urilor &#238;n prompt+replic&#259; &#206;nainte de a se pierde informa&#355;ie. Utilizarea unui context mai mare dec&#226;t cel cu care a fost instruit modelul va &#238;ntoarce rezultate mai slabe. NOT&#259;: Nu are efect p&#226;n&#259; la reinc&#259;rcarea modelului.</translation>
+        <translation type="vanished">Numărul maxim combinat al token-urilor în prompt+replică Înainte de a se pierde informaţie. Utilizarea unui context mai mare decât cel cu care a fost instruit modelul va întoarce rezultate mai slabe. NOTă: Nu are efect până la reincărcarea modelului.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="412"/>
@@ -2140,12 +2146,12 @@ model to get started</source>
         <location filename="../qml/ModelSettings.qml" line="413"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="413"/>
         <source>Randomness of model output. Higher -&gt; more variation.</source>
-        <translation>Libertatea/Confuzia din replica modelului. Mai mare -&gt; mai mult&#259; libertate.</translation>
+        <translation>Libertatea/Confuzia din replica modelului. Mai mare -&gt; mai multă libertate.</translation>
     </message>
     <message>
         <source>Temperature increases the chances of choosing less likely tokens.
                 NOTE: Higher temperature gives more creative but less predictable outputs.</source>
-        <translation type="vanished">Temperatura cre&#351;te probabilitatea de alegere a unor token-uri pu&#355;in probabile. NOT&#259;: O temperatur&#259; tot mai &#206;nalt&#259; determin&#206; replici tot mai creative &#351;i mai pu&#355;in predictibile.</translation>
+        <translation type="vanished">Temperatura creşte probabilitatea de alegere a unor token-uri puţin probabile. NOTă: O temperatură tot mai Înaltă determinÎ replici tot mai creative şi mai puţin predictibile.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="458"/>
@@ -2162,19 +2168,19 @@ model to get started</source>
     <message>
         <source>Only the most likely tokens up to a total probability of top_p can be chosen.
                 NOTE: Prevents choosing highly unlikely tokens.</source>
-        <translation type="vanished">Pot fi alese numai cele mai probabile token-uri a c&#259;ror probabilitate total&#259; este Top-P. NOT&#259;: Se evit&#259; selectarea token-urilor foarte improbabile.</translation>
+        <translation type="vanished">Pot fi alese numai cele mai probabile token-uri a căror probabilitate totală este Top-P. NOTă: Se evită selectarea token-urilor foarte improbabile.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="159"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="159"/>
         <source>Prefixed at the beginning of every conversation. Must contain the appropriate framing tokens.</source>
-        <translation>Plasat la &#238;nceputul fiec&#259;rei conversa&#355;ii. Trebuie s&#259; con&#355;in&#259; token-uri(le) adecvate de &#238;ncadrare.</translation>
+        <translation>Plasat la începutul fiecărei conversaţii. Trebuie să conţină token-uri(le) adecvate de încadrare.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="210"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="210"/>
         <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s input.</source>
-        <translation>Trebuie s&#259; con&#355;in&#259; textul &quot;%1&quot; care va fi &#238;nlocuit cu ceea ce scrie utilizatorul.</translation>
+        <translation>Trebuie să conţină textul &quot;%1&quot; care va fi înlocuit cu ceea ce scrie utilizatorul.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="374"/>
@@ -2182,21 +2188,21 @@ model to get started</source>
         <source>Maximum combined prompt/response tokens before information is lost.
 Using more context than the model was trained on will yield poor results.
 NOTE: Does not take effect until you reload the model.</source>
-        <translation>Num&#259;rul maxim combinat al token-urilor &#238;n prompt+replic&#259; &#238;nainte de a se pierde informa&#355;ie. Utilizarea unui context mai mare dec&#226;t cel cu care a fost instruit modelul va &#238;ntoarce rezultate mai slabe. NOT&#258;: Nu are efect p&#226;n&#259; la re&#238;nc&#259;rcarea modelului.</translation>
+        <translation>Numărul maxim combinat al token-urilor în prompt+replică înainte de a se pierde informaţie. Utilizarea unui context mai mare decât cel cu care a fost instruit modelul va întoarce rezultate mai slabe. NOTĂ: Nu are efect până la reîncărcarea modelului.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="424"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="424"/>
         <source>Temperature increases the chances of choosing less likely tokens.
 NOTE: Higher temperature gives more creative but less predictable outputs.</source>
-        <translation>Temperatura cre&#351;te probabilitatea de alegere a unor token-uri pu&#355;in probabile. NOT&#258;: O temperatur&#259; tot mai &#238;nalt&#259; determin&#238; replici tot mai creative &#351;i mai pu&#355;in predictibile.</translation>
+        <translation>Temperatura creşte probabilitatea de alegere a unor token-uri puţin probabile. NOTĂ: O temperatură tot mai înaltă determinî replici tot mai creative şi mai puţin predictibile.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="469"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="469"/>
         <source>Only the most likely tokens up to a total probability of top_p can be chosen.
 NOTE: Prevents choosing highly unlikely tokens.</source>
-        <translation>Pot fi alese numai cele mai probabile token-uri a c&#259;ror probabilitate total&#259; este Top-P. NOT&#258;: Se evit&#259; selectarea token-urilor foarte improbabile.</translation>
+        <translation>Pot fi alese numai cele mai probabile token-uri a căror probabilitate totală este Top-P. NOTĂ: Se evită selectarea token-urilor foarte improbabile.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="503"/>
@@ -2208,13 +2214,13 @@ NOTE: Prevents choosing highly unlikely tokens.</source>
         <location filename="../qml/ModelSettings.qml" line="504"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="504"/>
         <source>Minimum token probability. Higher -&gt; more predictable.</source>
-        <translation>Probabilitatea mínim&#259; a unui token. Mai mare -&gt; mai predictibil.</translation>
+        <translation>Probabilitatea mínimă a unui token. Mai mare -&gt; mai predictibil.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="514"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="514"/>
         <source>Sets the minimum relative probability for a token to be considered.</source>
-        <translation>Stabile&#351;te probabilitatea minim&#259; relativ&#259; a unui token de luat &#238;n considerare.</translation>
+        <translation>Stabileşte probabilitatea minimă relativă a unui token de luat în considerare.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="550"/>
@@ -2238,13 +2244,13 @@ NOTE: Prevents choosing highly unlikely tokens.</source>
         <location filename="../qml/ModelSettings.qml" line="597"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="597"/>
         <source>Max Length</source>
-        <translation>Lungimea maxim&#259;</translation>
+        <translation>Lungimea maximă</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="598"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="598"/>
         <source>Maximum response length, in tokens.</source>
-        <translation>Lungimea maxim&#259; - &#238;n token-uri - a replicii.</translation>
+        <translation>Lungimea maximă - în token-uri - a replicii.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="643"/>
@@ -2263,7 +2269,7 @@ NOTE: Prevents choosing highly unlikely tokens.</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="655"/>
         <source>Amount of prompt tokens to process at once.
 NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
-        <translation>Num&#259;rul token-urilor procesate simultan. NOT&#258;: Valori tot mai mari pot accelera citirea prompt-urilor, dar &#351;i utiliza mai mult&#259; RAM.</translation>
+        <translation>Numărul token-urilor procesate simultan. NOTĂ: Valori tot mai mari pot accelera citirea prompt-urilor, dar şi utiliza mai multă RAM.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="793"/>
@@ -2271,12 +2277,12 @@ NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
         <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of VRAM while loading this model.
 Lower values increase CPU load and RAM usage, and make inference slower.
 NOTE: Does not take effect until you reload the model.</source>
-        <translation>C&#226;t de multe layere ale modelului s&#259; fie &#238;nc&#259;rcate &#238;n VRAM. Valori mici trebuie folosite dac&#259; GPT4All r&#259;m&#226;ne f&#259;r&#259; VRAM &#238;n timp ce &#238;ncarc&#259; modelul. Valorile tot mai mici cresc utilizarea CPU &#351;i a RAM &#351;i &#238;ncetinesc inferen&#355;a. NOT&#258;: Nu are efect p&#226;n&#259; la re&#238;nc&#259;rcarea modelului.</translation>
+        <translation>Cât de multe layere ale modelului să fie încărcate în VRAM. Valori mici trebuie folosite dacă GPT4All rămâne fără VRAM în timp ce încarcă modelul. Valorile tot mai mici cresc utilizarea CPU şi a RAM şi încetinesc inferenţa. NOTĂ: Nu are efect până la reîncărcarea modelului.</translation>
     </message>
     <message>
         <source>Amount of prompt tokens to process at once.
                 NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
-        <translation type="vanished">num&#259;rul token-urilor procesate simultan. NOT&#259;: Valori tot mai mari pot accelera citirea prompt-urilor, dar &#351;i utiliza mai mult&#259; RAM.</translation>
+        <translation type="vanished">numărul token-urilor procesate simultan. NOTă: Valori tot mai mari pot accelera citirea prompt-urilor, dar şi utiliza mai multă RAM.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="690"/>
@@ -2288,38 +2294,38 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelSettings.qml" line="691"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="691"/>
         <source>Repetition penalty factor. Set to 1 to disable.</source>
-        <translation>Factorul de penalizare a repet&#259;rii ce se dezactiveaz&#259; cu valoarea 1.</translation>
+        <translation>Factorul de penalizare a repetării ce se dezactivează cu valoarea 1.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="735"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="735"/>
         <source>Repeat Penalty Tokens</source>
-        <translation>Token-uri pentru penalzare a repet&#259;rii</translation>
+        <translation>Token-uri pentru penalzare a repetării</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="736"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="736"/>
         <source>Number of previous tokens used for penalty.</source>
-        <translation>Num&#259;rul token-urilor anterioare considerate pentru penalizare.</translation>
+        <translation>Numărul token-urilor anterioare considerate pentru penalizare.</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="781"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="781"/>
         <source>GPU Layers</source>
-        <translation>Layere &#238;n GPU</translation>
+        <translation>Layere în GPU</translation>
     </message>
     <message>
         <location filename="../qml/ModelSettings.qml" line="782"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelSettings.qml" line="782"/>
         <source>Number of model layers to load into VRAM.</source>
-        <translation>Num&#259;rul layerelor modelului ce vor fi &#206;nc&#259;rcate &#238;n VRAM.</translation>
+        <translation>Numărul layerelor modelului ce vor fi Încărcate în VRAM.</translation>
     </message>
     <message>
         <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of
                 VRAM while loading this model.
                 Lower values increase CPU load and RAM usage, and make inference slower.
                 NOTE: Does not take effect until you reload the model.</source>
-        <translation type="vanished">C&#226;t de multe layere ale modelului s&#259; fie &#206;nc&#259;rcate &#238;n VRAM. Valori mici trebuie folosite dac&#259; GPT4All r&#259;m&#226;ne f&#259;r&#259; VRAM &#238;n timp ce &#206;ncarc&#259; modelul. Valorile tot mai mici cresc utilizarea CPU &#351;i a RAM &#351;i &#206;ncetinesc inferen&#355;a. NOT&#259;: Nu are efect p&#226;n&#259; la re&#206;nc&#259;rcarea modelului.</translation>
+        <translation type="vanished">Cât de multe layere ale modelului să fie Încărcate în VRAM. Valori mici trebuie folosite dacă GPT4All rămâne fără VRAM în timp ce Încarcă modelul. Valorile tot mai mici cresc utilizarea CPU şi a RAM şi Încetinesc inferenţa. NOTă: Nu are efect până la reÎncărcarea modelului.</translation>
     </message>
 </context>
 <context>
@@ -2328,13 +2334,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="40"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="40"/>
         <source>No Models Installed</source>
-        <translation>Nu exist&#259; modele instalate</translation>
+        <translation>Nu există modele instalate</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="49"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="49"/>
         <source>Install a model to get started using GPT4All</source>
-        <translation>Instaleaz&#259; un model pentru a &#206;ncepe s&#259; folose&#351;ti GPT4All</translation>
+        <translation>Instalează un model pentru a Începe să foloseşti GPT4All</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="60"/>
@@ -2342,13 +2348,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="60"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="102"/>
         <source>＋ Add Model</source>
-        <translation>＋ Adaug&#259; un model</translation>
+        <translation>＋ Adaugă un model</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="65"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="65"/>
         <source>Shows the add model view</source>
-        <translation>Afi&#351;eaz&#259; sec&#355;iunea de ad&#259;ugare a unui model</translation>
+        <translation>Afişează secţiunea de adăugare a unui model</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="83"/>
@@ -2360,19 +2366,19 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="89"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="89"/>
         <source>Locally installed chat models</source>
-        <translation>Modele conversa&#355;ionale instalate local</translation>
+        <translation>Modele conversaţionale instalate local</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="147"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="147"/>
         <source>Model file</source>
-        <translation>Fi&#351;ierul modelului</translation>
+        <translation>Fişierul modelului</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="148"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="148"/>
         <source>Model file to be downloaded</source>
-        <translation>Fi&#351;ierul modelului ce va fi desc&#259;rcat</translation>
+        <translation>Fişierul modelului ce va fi descărcat</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="170"/>
@@ -2384,7 +2390,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="171"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="171"/>
         <source>File description</source>
-        <translation>Descrierea fi&#351;ierului</translation>
+        <translation>Descrierea fişierului</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="196"/>
@@ -2402,19 +2408,19 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="204"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="204"/>
         <source>Stop/restart/start the download</source>
-        <translation>Oprirea/Repornirea/Initierea desc&#259;rc&#259;rii</translation>
+        <translation>Oprirea/Repornirea/Initierea descărcării</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="216"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="216"/>
         <source>Remove</source>
-        <translation>&#350;terg</translation>
+        <translation>Şterg</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="223"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="223"/>
         <source>Remove model from filesystem</source>
-        <translation>&#350;terg modelul din sistemul de fi&#351;iere</translation>
+        <translation>Şterg modelul din sistemul de fişiere</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="237"/>
@@ -2422,7 +2428,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="237"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="271"/>
         <source>Install</source>
-        <translation>Instaleaz&#259;</translation>
+        <translation>Instalează</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="272"/>
@@ -2439,7 +2445,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
                 hardware. Model requires more memory (%1 GB) than your system has available
                 (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATEN&#355;IE: Nerecomandat pentru acest hardware. Modelul necesit&#259; mai mult&#259; memorie (%1 GB) dec&#226;t are sistemul t&#259;u(%2).&lt;/strong&gt;&lt;/font&gt;</translation>
+        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENţIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are sistemul tău(%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="496"/>
@@ -2457,7 +2463,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="288"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="288"/>
         <source>Describes an error that occurred when downloading</source>
-        <translation>Descrie o eroare ap&#259;rut&#259; la download</translation>
+        <translation>Descrie o eroare apărută la download</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="282"/>
@@ -2469,7 +2475,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="301"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="301"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATEN&#354;IE: Nerecomandat pentru acest hardware. Modelul necesit&#259; mai mult&#259; memorie (%1 GB) dec&#226;t are sistemul t&#259;u(%2).&lt;/strong&gt;&lt;/font&gt;</translation>
+        <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENŢIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are sistemul tău(%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="307"/>
@@ -2481,13 +2487,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="345"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="345"/>
         <source>Download progressBar</source>
-        <translation>Bara de progresie a desc&#259;rc&#259;rii</translation>
+        <translation>Bara de progresie a descărcării</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="346"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="346"/>
         <source>Shows the progress made in the download</source>
-        <translation>Afi&#351;eaz&#259; progresia desc&#259;rc&#259;rii</translation>
+        <translation>Afişează progresia descărcării</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="356"/>
@@ -2499,13 +2505,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="357"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="357"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
-        <translation>Viteza de download &#238;n bytes/kilobytes/megabytes pe secund&#259;</translation>
+        <translation>Viteza de download în bytes/kilobytes/megabytes pe secundă</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="374"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="374"/>
         <source>Calculating...</source>
-        <translation>...Se calculeaz&#259;...</translation>
+        <translation>...Se calculează...</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="378"/>
@@ -2517,7 +2523,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="429"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="450"/>
         <source>Whether the file hash is being calculated</source>
-        <translation>Dac&#259; se va calcula hash-ul fi&#351;ierului</translation>
+        <translation>Dacă se va calcula hash-ul fişierului</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="385"/>
@@ -2529,13 +2535,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="386"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="386"/>
         <source>Displayed when the file hash is being calculated</source>
-        <translation>Afi&#351;at c&#226;nd se calculeaz&#259; hash-ul unui fi&#351;ier</translation>
+        <translation>Afişat când se calculează hash-ul unui fişier</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="399"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="399"/>
         <source>ERROR: $API_KEY is empty.</source>
-        <translation>EROARE: $API_KEY absent&#259;.</translation>
+        <translation>EROARE: $API_KEY absentă.</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="405"/>
@@ -2547,7 +2553,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="420"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="420"/>
         <source>ERROR: $BASE_URL is empty.</source>
-        <translation>EROARE: $BASE_URL absent&#259;.</translation>
+        <translation>EROARE: $BASE_URL absentă.</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="426"/>
@@ -2571,13 +2577,13 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/ModelsView.qml" line="469"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="469"/>
         <source>File size</source>
-        <translation>Dimensiunea fi&#351;ierului</translation>
+        <translation>Dimensiunea fişierului</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="491"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ModelsView.qml" line="491"/>
         <source>RAM required</source>
-        <translation>RAM necesar&#259;</translation>
+        <translation>RAM necesară</translation>
     </message>
     <message>
         <location filename="../qml/ModelsView.qml" line="513"/>
@@ -2619,7 +2625,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/MySettingsStack.qml" line="66"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsStack.qml" line="66"/>
         <source>Please choose a directory</source>
-        <translation>Selecteaz&#259; un director (folder)</translation>
+        <translation>Selectează un director (folder)</translation>
     </message>
 </context>
 <context>
@@ -2634,7 +2640,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/MySettingsTab.qml" line="66"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/MySettingsTab.qml" line="66"/>
         <source>Restores settings dialog to a default state</source>
-        <translation>Restaurez sec&#355;iunea de configurare la starea sa implicit&#259;</translation>
+        <translation>Restaurez secţiunea de configurare la starea sa implicită</translation>
     </message>
 </context>
 <context>
@@ -2643,7 +2649,7 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../qml/NetworkDialog.qml" line="39"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="39"/>
         <source>Contribute data to the GPT4All Opensource Datalake.</source>
-        <translation>Contribuie cu date/informa&#355;ii la componenta Open-source DataLake a GPT4All.</translation>
+        <translation>Contribuie cu date/informaţii la componenta Open-source DataLake a GPT4All.</translation>
     </message>
     <message>
         <source>By enabling this feature, you will be able to participate in the democratic
@@ -2662,21 +2668,21 @@ NOTE: Does not take effect until you reload the model.</source>
                 used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
                 attribution information attached to your data and you will be credited as a
                 contributor to any GPT4All model release that uses your data!</source>
-        <translation type="vanished">Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei participa la procesul democratic
-                de instruire a unui model LLM prin contribu&#355;ia ta cu date la &#238;mbun&#259;t&#259;&#355;irea modelului.
+        <translation type="vanished">Dacă activezi această funcţionalitate, vei participa la procesul democratic
+                de instruire a unui model LLM prin contribuţia ta cu date la îmbunătăţirea modelului.
 
-                C&#226;nd un model &#238;n GPT4All &#206;&#355;i r&#259;spunde &#351;i &#238;i accep&#355;i replica, atunci conversa&#355;ia va fi
-                trimis&#259; la componenta Open-source DataLake a GPT4All. Mai mult - &#238;i po&#355;i aprecia replica,
-                Dac&#259; r&#259;spunsul Nu &#206;ti Place, po&#355;i sugera unul alternativ. 
-                Aceste date vor fi colectate &#351;i agregate &#238;n componenta DataLake a GPT4All.
+                Când un model în GPT4All Îţi răspunde şi îi accepţi replica, atunci conversaţia va fi
+                trimisă la componenta Open-source DataLake a GPT4All. Mai mult - îi poţi aprecia replica,
+                Dacă răspunsul Nu Îti Place, poţi sugera unul alternativ. 
+                Aceste date vor fi colectate şi agregate în componenta DataLake a GPT4All.
 
-                NOT&#259;: Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei trimite datele tale la componenta
-                DataLake a GPT4All. Atunci nu te vei putea a&#351;tepta la intimitatea (privacy) conversa&#355;iei dac&#259; activezi
-                aceast&#259; func&#355;ionalitate. Totu&#351;i, te po&#355;i a&#351;tepta la a beneficia de apreciere - op&#355;ional, dac&#259; dore&#351;ti.
-                Datele din conversa&#355;ie vor fi disponibile pentru oricine vrea s&#259; le descarce &#351;i vor fi
-                utilizate de c&#259;tre Nomic AI pentru a &#238;mbun&#259;t&#259;&#355;i modele viitoare &#238;n GPT4All. Nomic AI va p&#259;stra
-                toate informa&#355;iile despre atribuire asociate datelor tale &#351;i vei fi men&#355;ionat ca
-                participant contribuitor la orice lansare a unui model GPT4All care folose&#351;te datele tale!</translation>
+                NOTă: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta
+                DataLake a GPT4All. Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi
+                această funcţionalitate. Totuşi, te poţi aştepta la a beneficia de apreciere - opţional, dacă doreşti.
+                Datele din conversaţie vor fi disponibile pentru oricine vrea să le descarce şi vor fi
+                utilizate de către Nomic AI pentru a îmbunătăţi modele viitoare în GPT4All. Nomic AI va păstra
+                toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
+                participant contribuitor la orice lansare a unui model GPT4All care foloseşte datele tale!</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="55"/>
@@ -2686,21 +2692,21 @@ NOTE: Does not take effect until you reload the model.</source>
 When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
 
 NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
-        <translation>Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei participa la procesul democratic
-                de instruire a unui model LLM prin contribu&#355;ia ta cu date la &#238;mbun&#259;t&#259;&#355;irea modelului.
+        <translation>Dacă activezi această funcţionalitate, vei participa la procesul democratic
+                de instruire a unui model LLM prin contribuţia ta cu date la îmbunătăţirea modelului.
 
-                C&#226;nd un model &#238;n GPT4All &#238;&#355;i r&#259;spunde &#351;i &#238;i accep&#355;i replica, atunci conversa&#355;ia va fi
-                trimis&#259; la componenta Open-source DataLake a GPT4All. Mai mult - &#238;i po&#355;i aprecia replica,
-                Dac&#259; r&#259;spunsul Nu &#206;ti Place, po&#355;i sugera unul alternativ. 
-                Aceste date vor fi colectate &#351;i agregate &#238;n componenta DataLake a GPT4All.
+                Când un model în GPT4All îţi răspunde şi îi accepţi replica, atunci conversaţia va fi
+                trimisă la componenta Open-source DataLake a GPT4All. Mai mult - îi poţi aprecia replica,
+                Dacă răspunsul Nu Îti Place, poţi sugera unul alternativ. 
+                Aceste date vor fi colectate şi agregate în componenta DataLake a GPT4All.
 
-                NOT&#258;: Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei trimite datele tale la componenta
-                DataLake a GPT4All. Atunci nu te vei putea a&#351;tepta la intimitatea (privacy) conversa&#355;iei dac&#259; activezi
-                aceast&#259; func&#355;ionalitate. Totu&#351;i, te po&#355;i a&#351;tepta la a beneficia de apreciere - op&#355;ional, dac&#259; dore&#351;ti.
-                Datele din conversa&#355;ie vor fi disponibile pentru oricine vrea s&#259; le descarce &#351;i vor fi
-                utilizate de c&#259;tre Nomic AI pentru a &#238;mbun&#259;t&#259;&#355;i modele viitoare &#238;n GPT4All. Nomic AI va p&#259;stra
-                toate informa&#355;iile despre atribuire asociate datelor tale &#351;i vei fi men&#355;ionat ca
-                participant contribuitor la orice lansare a unui model GPT4All care folose&#351;te datele tale!</translation>
+                NOTĂ: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta
+                DataLake a GPT4All. Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi
+                această funcţionalitate. Totuşi, te poţi aştepta la a beneficia de apreciere - opţional, dacă doreşti.
+                Datele din conversaţie vor fi disponibile pentru oricine vrea să le descarce şi vor fi
+                utilizate de către Nomic AI pentru a îmbunătăţi modele viitoare în GPT4All. Nomic AI va păstra
+                toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
+                participant contribuitor la orice lansare a unui model GPT4All care foloseşte datele tale!</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="63"/>
@@ -2712,37 +2718,37 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/NetworkDialog.qml" line="64"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="64"/>
         <source>Describes what will happen when you opt-in</source>
-        <translation>Descrie ce se &#206;nt&#226;mpl&#259; c&#226;nd participi</translation>
+        <translation>Descrie ce se Întâmplă când participi</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="72"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="72"/>
         <source>Please provide a name for attribution (optional)</source>
-        <translation>Specific&#259; o denumire pentru aceast&#259; apreciere (optional)</translation>
+        <translation>Specifică o denumire pentru această apreciere (optional)</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="74"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="74"/>
         <source>Attribution (optional)</source>
-        <translation>Apreciere (op&#355;ional)</translation>
+        <translation>Apreciere (opţional)</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="75"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="75"/>
         <source>Provide attribution</source>
-        <translation>Apreciaz&#259;</translation>
+        <translation>Apreciază</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="88"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="88"/>
         <source>Enable</source>
-        <translation>Activeaz&#259;</translation>
+        <translation>Activează</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="89"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="89"/>
         <source>Enable opt-in</source>
-        <translation>Activeaz&#259; participarea</translation>
+        <translation>Activează participarea</translation>
     </message>
     <message>
         <location filename="../qml/NetworkDialog.qml" line="93"/>
@@ -2754,7 +2760,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/NetworkDialog.qml" line="94"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NetworkDialog.qml" line="94"/>
         <source>Cancel opt-in</source>
-        <translation>Anuleaz&#259; participarea</translation>
+        <translation>Anulează participarea</translation>
     </message>
 </context>
 <context>
@@ -2763,7 +2769,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/NewVersionDialog.qml" line="34"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml" line="34"/>
         <source>New version is available</source>
-        <translation>O nou&#259; versiune disponibil&#259;!</translation>
+        <translation>O nouă versiune disponibilă!</translation>
     </message>
     <message>
         <location filename="../qml/NewVersionDialog.qml" line="46"/>
@@ -2775,7 +2781,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/NewVersionDialog.qml" line="48"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/NewVersionDialog.qml" line="48"/>
         <source>Update to new version</source>
-        <translation>Actualizeaz&#259; la noua versiune</translation>
+        <translation>Actualizează la noua versiune</translation>
     </message>
 </context>
 <context>
@@ -2784,7 +2790,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/PopupDialog.qml" line="38"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml" line="38"/>
         <source>Reveals a shortlived help balloon</source>
-        <translation>Afiseaz&#259; un mesaj scurt de asisten&#355;&#259;</translation>
+        <translation>Afisează un mesaj scurt de asistenţă</translation>
     </message>
     <message>
         <location filename="../qml/PopupDialog.qml" line="48"/>
@@ -2796,7 +2802,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/PopupDialog.qml" line="49"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/PopupDialog.qml" line="49"/>
         <source>Displayed when the popup is showing busy</source>
-        <translation>Se afi&#351;eaz&#259; c&#226;nd procedura este &#238;n desf&#259;&#351;urare</translation>
+        <translation>Se afişează când procedura este în desfăşurare</translation>
     </message>
 </context>
 <context>
@@ -2813,7 +2819,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/SettingsView.qml" line="23"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SettingsView.qml" line="23"/>
         <source>Contains various application settings</source>
-        <translation>Con&#355;ine set&#259;ri ale programului</translation>
+        <translation>Conţine setări ale programului</translation>
     </message>
     <message>
         <location filename="../qml/SettingsView.qml" line="29"/>
@@ -2860,7 +2866,7 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../qml/StartupDialog.qml" line="72"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="72"/>
         <source>Release notes for this version</source>
-        <translation>Despre aceast&#259; versiune</translation>
+        <translation>Despre această versiune</translation>
     </message>
     <message>
         <source>### Opt-ins for anonymous usage analytics and datalake
@@ -2886,28 +2892,28 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
                 attribution information attached to your data and you will be credited as a
                 contributor to any GPT4All
                 model release that uses your data!</source>
-        <translation type="vanished">### Acceptul pentru analizarea utiliz&#259;rii anonime &#351;i pentru DataLake
-                Activ&#226;nd aceste functionalit&#259;&#355;i vei putea participa la procesul democratic
+        <translation type="vanished">### Acceptul pentru analizarea utilizării anonime şi pentru DataLake
+                Activând aceste functionalităţi vei putea participa la procesul democratic
                 de instruire a unui
-                model conversa&#355;ional prin contribuirea cu date/informa&#355;ii pentru &#238;mbun&#259;t&#259;&#355;irea unor modele.
-                C&#226;nd un model &#238;n GPT4All &#206;&#355;i r&#259;spunde &#351;i &#238;i accep&#355;i r&#259;spunsul, conversa&#355;ia este
-                trimis&#259; la componenta
-                Open-source DataLake a GPT4All. Mai mult - po&#355;i aprecia (Like/Dislike) r&#259;spunsul. Dac&#259;
-                un r&#259;spuns Nu &#206;&#355;i Place. po&#355;i
-                sugera un r&#259;spuns alternativ. Aceste date vor fi colectate &#351;i agregate &#206;n
+                model conversaţional prin contribuirea cu date/informaţii pentru îmbunătăţirea unor modele.
+                Când un model în GPT4All Îţi răspunde şi îi accepţi răspunsul, conversaţia este
+                trimisă la componenta
+                Open-source DataLake a GPT4All. Mai mult - poţi aprecia (Like/Dislike) răspunsul. Dacă
+                un răspuns Nu Îţi Place. poţi
+                sugera un răspuns alternativ. Aceste date vor fi colectate şi agregate În
                 componenta DataLake a GPT4All.
 
-                NOT&#259;: Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei trimite datele tale la componenta
+                NOTă: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta
                 DataLake a GPT4All.
-                Atunci nu te vei putea a&#351;tepta la intimitatea (privacy) conversa&#355;iei dac&#259; activezi aceast&#259; func&#355;ionalitate.
-                Totu&#351;i, te po&#355;i a&#351;tepta la a beneficia de apreciere - 
-                op&#355;ional, dac&#259; dore&#351;ti. Datele din conversa&#355;ie vor fi disponibile 
-                pentru oricine vrea s&#259; le descarce &#351;i vor fi utilizate de c&#259;tre Nomic AI
-                pentru a &#238;mbun&#259;t&#259;&#355;i modele viitoare &#238;n GPT4All.
-                Nomic AI va p&#259;stra 
-                toate informa&#355;iile despre atribuire asociate datelor tale &#351;i vei fi men&#355;ionat ca
+                Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi această funcţionalitate.
+                Totuşi, te poţi aştepta la a beneficia de apreciere - 
+                opţional, dacă doreşti. Datele din conversaţie vor fi disponibile 
+                pentru oricine vrea să le descarce şi vor fi utilizate de către Nomic AI
+                pentru a îmbunătăţi modele viitoare în GPT4All.
+                Nomic AI va păstra 
+                toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
                 participant contribuitor la orice lansare a unui model GPT4All
-                care folose&#351;te datele tale!</translation>
+                care foloseşte datele tale!</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="67"/>
@@ -2936,25 +2942,25 @@ an expectation of an optional attribution if you wish. Your chat data will be op
 to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
 attribution information attached to your data and you will be credited as a contributor to any GPT4All
 model release that uses your data!</source>
-        <translation>### Acordul pentru analizarea utiliz&#259;rii anonime &#351;i pentru DataLake
-                Activ&#226;nd aceste functionalit&#259;&#355;i vei putea participa la procesul democratic de instruire 
-a unui model conversa&#355;ional prin contribuirea cu date/informa&#355;ii pentru &#238;mbun&#259;t&#259;&#355;irea unor modele.
+        <translation>### Acordul pentru analizarea utilizării anonime şi pentru DataLake
+                Activând aceste functionalităţi vei putea participa la procesul democratic de instruire 
+a unui model conversaţional prin contribuirea cu date/informaţii pentru îmbunătăţirea unor modele.
 
-C&#226;nd un model &#238;n GPT4All &#238;&#355;i r&#259;spunde &#351;i &#238;i accep&#355;i r&#259;spunsul, conversa&#355;ia este
-trimis&#259; la componenta Open-source DataLake a GPT4All. Mai mult - po&#355;i aprecia (Bravo/Aiurea) r&#259;spunsul. Dac&#259;
-un r&#259;spuns e Aiurea. po&#355;i sugera un r&#259;spuns alternativ. Aceste date vor fi colectate &#351;i agregate &#238;n
+Când un model în GPT4All îţi răspunde şi îi accepţi răspunsul, conversaţia este
+trimisă la componenta Open-source DataLake a GPT4All. Mai mult - poţi aprecia (Bravo/Aiurea) răspunsul. Dacă
+un răspuns e Aiurea. poţi sugera un răspuns alternativ. Aceste date vor fi colectate şi agregate în
 componenta DataLake a GPT4All.
 
-NOT&#258;: Dac&#259; activezi aceast&#259; func&#355;ionalitate, vei trimite datele tale la componenta DataLake a GPT4All.
-Atunci nu te vei putea a&#351;tepta la intimitatea (privacy) conversa&#355;iei dac&#259; activezi aceast&#259; func&#355;ionalitate.
-Totu&#351;i, te po&#355;i a&#351;tepta la a beneficia de apreciere - 
-op&#355;ional, dac&#259; dore&#351;ti. Datele din conversa&#355;ie vor fi disponibile 
-pentru oricine vrea s&#259; le descarce &#351;i vor fi utilizate de c&#259;tre Nomic AI
-pentru a &#238;mbun&#259;t&#259;&#355;i modele viitoare &#238;n GPT4All.
-Nomic AI va p&#259;stra 
-toate informa&#355;iile despre atribuire asociate datelor tale &#351;i vei fi men&#355;ionat ca
+NOTĂ: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta DataLake a GPT4All.
+Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi această funcţionalitate.
+Totuşi, te poţi aştepta la a beneficia de apreciere - 
+opţional, dacă doreşti. Datele din conversaţie vor fi disponibile 
+pentru oricine vrea să le descarce şi vor fi utilizate de către Nomic AI
+pentru a îmbunătăţi modele viitoare în GPT4All.
+Nomic AI va păstra 
+toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
 participant contribuitor la orice lansare a unui model GPT4All
-care folose&#351;te datele tale!</translation>
+care foloseşte datele tale!</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="106"/>
@@ -2966,7 +2972,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/StartupDialog.qml" line="107"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="107"/>
         <source>Describes what will happen when you opt-in</source>
-        <translation>Descrie ce se &#206;nt&#226;mpl&#259; c&#226;nd participi</translation>
+        <translation>Descrie ce se Întâmplă când participi</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="124"/>
@@ -2974,7 +2980,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="124"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="150"/>
         <source>Opt-in for anonymous usage statistics</source>
-        <translation>Accept&#259; colectarea de statistici despre utilizare anonm&#259;</translation>
+        <translation>Acceptă colectarea de statistici despre utilizare anonmă</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="147"/>
@@ -2988,7 +2994,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/StartupDialog.qml" line="151"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="151"/>
         <source>Allow opt-in for anonymous usage statistics</source>
-        <translation>Accept&#259; participarea la colectarea de statistici despre utilizare -anonim&#259;-</translation>
+        <translation>Acceptă participarea la colectarea de statistici despre utilizare -anonimă-</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="189"/>
@@ -3002,13 +3008,13 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/StartupDialog.qml" line="192"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="192"/>
         <source>Opt-out for anonymous usage statistics</source>
-        <translation>Anuleaz&#259; participarea la colectarea de statistici despre utilizare -anonim&#259;-</translation>
+        <translation>Anulează participarea la colectarea de statistici despre utilizare -anonimă-</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="193"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="193"/>
         <source>Allow opt-out for anonymous usage statistics</source>
-        <translation>Permite anularea particip&#259;rii la colectarea de statistici despre utilizare -anonim&#259;-</translation>
+        <translation>Permite anularea participării la colectarea de statistici despre utilizare -anonimă-</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="238"/>
@@ -3016,31 +3022,31 @@ care folose&#351;te datele tale!</translation>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="238"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="265"/>
         <source>Opt-in for network</source>
-        <translation>Accept&#259; pentru re&#355;ea</translation>
+        <translation>Acceptă pentru reţea</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="239"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="239"/>
         <source>Allow opt-in for network</source>
-        <translation>Permite participarea pentru re&#355;ea</translation>
+        <translation>Permite participarea pentru reţea</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="266"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="266"/>
         <source>Allow opt-in anonymous sharing of chats to the GPT4All Datalake</source>
-        <translation>Permite participarea la partajarea (share) anonim&#259; a conversa&#355;iilor c&#259;tre DataLake a GPT4All</translation>
+        <translation>Permite participarea la partajarea (share) anonimă a conversaţiilor către DataLake a GPT4All</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="307"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="307"/>
         <source>Opt-out for network</source>
-        <translation>Refuz participarea, pentru re&#355;ea</translation>
+        <translation>Refuz participarea, pentru reţea</translation>
     </message>
     <message>
         <location filename="../qml/StartupDialog.qml" line="308"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/StartupDialog.qml" line="308"/>
         <source>Allow opt-out anonymous sharing of chats to the GPT4All Datalake</source>
-        <translation>Permite anularea particip&#259;rii la partajarea anonim&#259; a conversa&#355;iilor c&#259;tre DataLake a GPT4All</translation>
+        <translation>Permite anularea participării la partajarea anonimă a conversaţiilor către DataLake a GPT4All</translation>
     </message>
 </context>
 <context>
@@ -3048,25 +3054,25 @@ care folose&#351;te datele tale!</translation>
     <message>
         <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
                 conversation. Do you wish to continue?</source>
-        <translation type="vanished">&lt;b&gt;Aten&#355;ie:&lt;/b&gt; schimbarea modelului va sterge conversa&#355;ia curent&#259;. Confirmi aceasta?</translation>
+        <translation type="vanished">&lt;b&gt;Atenţie:&lt;/b&gt; schimbarea modelului va sterge conversaţia curentă. Confirmi aceasta?</translation>
     </message>
     <message>
         <location filename="../qml/SwitchModelDialog.qml" line="22"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="22"/>
         <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current conversation. Do you wish to continue?</source>
-        <translation>&lt;b&gt;Aten&#355;ie:&lt;/b&gt; schimbarea modelului va &#351;terge conversa&#355;ia curent&#259;. Confirmi aceasta?</translation>
+        <translation>&lt;b&gt;Atenţie:&lt;/b&gt; schimbarea modelului va şterge conversaţia curentă. Confirmi aceasta?</translation>
     </message>
     <message>
         <location filename="../qml/SwitchModelDialog.qml" line="33"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="33"/>
         <source>Continue</source>
-        <translation>Continu&#259;</translation>
+        <translation>Continuă</translation>
     </message>
     <message>
         <location filename="../qml/SwitchModelDialog.qml" line="34"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/SwitchModelDialog.qml" line="34"/>
         <source>Continue with model loading</source>
-        <translation>Continu&#259; cu &#206;nc&#259;rcarea modelului</translation>
+        <translation>Continuă cu Încărcarea modelului</translation>
     </message>
     <message>
         <location filename="../qml/SwitchModelDialog.qml" line="38"/>
@@ -3083,13 +3089,13 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/ThumbsDownDialog.qml" line="39"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="39"/>
         <source>Please edit the text below to provide a better response. (optional)</source>
-        <translation>Te rog, editeaz&#259; textul de mai jos pentru a oferi o replic&#259; mai bun&#259; (op&#355;ional).</translation>
+        <translation>Te rog, editează textul de mai jos pentru a oferi o replică mai bună (opţional).</translation>
     </message>
     <message>
         <location filename="../qml/ThumbsDownDialog.qml" line="54"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="54"/>
         <source>Please provide a better response...</source>
-        <translation>Te rog, ofer&#259; o replic&#259; mai bun&#259;...</translation>
+        <translation>Te rog, oferă o replică mai bună...</translation>
     </message>
     <message>
         <location filename="../qml/ThumbsDownDialog.qml" line="64"/>
@@ -3101,7 +3107,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/ThumbsDownDialog.qml" line="65"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="65"/>
         <source>Submits the user&apos;s response</source>
-        <translation>Trimite r&#259;spunsul dat de utilizator</translation>
+        <translation>Trimite răspunsul dat de utilizator</translation>
     </message>
     <message>
         <location filename="../qml/ThumbsDownDialog.qml" line="69"/>
@@ -3113,7 +3119,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../qml/ThumbsDownDialog.qml" line="70"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ThumbsDownDialog.qml" line="70"/>
         <source>Closes the response dialog</source>
-        <translation>&#206;nchide dialogul r&#259;spunsului</translation>
+        <translation>Închide dialogul răspunsului</translation>
     </message>
 </context>
 <context>
@@ -3125,11 +3131,11 @@ care folose&#351;te datele tale!</translation>
                 detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet
                 the minimal requirements to run this program. In particular, it does not support AVX
                 intrinsics which this program requires to successfully run a modern large language
-                model. The only solu&#355;ion at this time is to upgrade your hardware to a more modern
+                model. The only soluţion at this time is to upgrade your hardware to a more modern
                 CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a
                 href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
         <translation type="vanished">
-                &lt;h3&gt;A ap&#259;rut o eroare la ini&#355;ializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din p&#259;cate, procesorul (CPU) nu &#206;ntrune&#351;te condi&#355;iile minime pentru a rula acest program. &#238;n particular, nu suport&#259; instruc&#355;iunile AVX pe care programul le necesit&#259; pentru a integra un model conversa&#355;ional modern. &#238;n acest moment, unica solu&#355;ie este s&#259; &#206;&#355;i aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informa&#355;ii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
+                &lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, procesorul (CPU) nu Întruneşte condiţiile minime pentru a rula acest program. în particular, nu suportă instrucţiunile AVX pe care programul le necesită pentru a integra un model conversaţional modern. în acest moment, unica soluţie este să Îţi aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informaţii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../main.qml" line="23"/>
@@ -3145,79 +3151,83 @@ care folose&#351;te datele tale!</translation>
                 permissions in the local app config directory where the settings file is located.
                 Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord
                 channel&lt;/a&gt; for help.</source>
-        <translation type="vanished">&lt;h3&gt;A ap&#259;rut o eroare la ini&#355;ializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Nu poate fi accesat fi&#351;ierul de configurare a programului.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din p&#259;cate, ceva &#238;mpiedic&#259; programul &#238;n a accesa acel fi&#351;ier. Cauza poate fi un set de permisiuni incorecte &#206;n/pe directorul/folderul local de configurare unde se afl&#259; acel fi&#351;ier. Po&#355;i parcurge canalul nostru &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;Discord&lt;/a&gt; unde vei putea primi asisten&#355;&#259;.</translation>
+        <translation type="vanished">&lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Nu poate fi accesat fişierul de configurare a programului.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, ceva împiedică programul în a accesa acel fişier. Cauza poate fi un set de permisiuni incorecte În/pe directorul/folderul local de configurare unde se află acel fişier. Poţi parcurge canalul nostru &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;Discord&lt;/a&gt; unde vei putea primi asistenţă.</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only soluţion at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+        <translation type="vanished">&lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, procesorul (CPU) nu întruneşte condiţiile minime pentru a rula acest program. În particular, nu suportă instrucţiunile AVX pe care programul le necesită pentru a integra un model conversaţional modern. În acest moment, unica soluţie este să îţi aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informaţii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../main.qml" line="111"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="111"/>
-        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only solu&#355;ion at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-        <translation>&lt;h3&gt;A ap&#259;rut o eroare la ini&#355;ializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din p&#259;cate, procesorul (CPU) nu &#238;ntrune&#351;te condi&#355;iile minime pentru a rula acest program. &#206;n particular, nu suport&#259; instruc&#355;iunile AVX pe care programul le necesit&#259; pentru a integra un model conversa&#355;ional modern. &#206;n acest moment, unica solu&#355;ie este s&#259; &#238;&#355;i aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informa&#355;ii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
+        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only solution at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../main.qml" line="127"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="127"/>
         <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing the settings file. This could be caused by incorrect permissions in the local app config directory where the settings file is located. Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
-        <translation>&lt;h3&gt;A ap&#259;rut o eroare la ini&#355;ializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Nu poate fi accesat fi&#351;ierul de configurare a programului.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din p&#259;cate, ceva &#238;mpiedic&#259; programul &#238;n a accesa acel fi&#351;ier. Cauza poate fi un set de permisiuni incorecte &#238;n/pe directorul/folderul local de configurare unde se afl&#259; acel fi&#351;ier. Po&#355;i parcurge canalul nostru &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;Discord&lt;/a&gt; unde vei putea primi asisten&#355;&#259;.</translation>
+        <translation>&lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Nu poate fi accesat fişierul de configurare a programului.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, ceva împiedică programul în a accesa acel fişier. Cauza poate fi un set de permisiuni incorecte în/pe directorul/folderul local de configurare unde se află acel fişier. Poţi parcurge canalul nostru &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;Discord&lt;/a&gt; unde vei putea primi asistenţă.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="155"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="155"/>
         <source>Connection to datalake failed.</source>
-        <translation>Conectarea la DataLake a e&#351;uat.</translation>
+        <translation>Conectarea la DataLake a eşuat.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="166"/>
         <source>Saving chats.</source>
-        <translation>Se salveaz&#259; conversa&#355;iile.</translation>
+        <translation>Se salvează conversaţiile.</translation>
     </message>
     <message>
         <location filename="../main.qml" line="177"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="177"/>
         <source>Network dialog</source>
-        <translation>Dialogul despre re&#355;ea</translation>
+        <translation>Dialogul despre reţea</translation>
     </message>
     <message>
         <location filename="../main.qml" line="178"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="178"/>
         <source>opt-in to share feedback/conversations</source>
-        <translation>accept&#259; partajarea (share) de comentarii/conversa&#355;ii</translation>
+        <translation>acceptă partajarea (share) de comentarii/conversaţii</translation>
     </message>
     <message>
         <location filename="../main.qml" line="231"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="231"/>
         <source>Home view</source>
-        <translation>Sec&#355;iunea de &#206;nceput</translation>
+        <translation>Secţiunea de Început</translation>
     </message>
     <message>
         <location filename="../main.qml" line="232"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="232"/>
         <source>Home view of application</source>
-        <translation>Sec&#355;iunea de &#206;nceput a programului</translation>
+        <translation>Secţiunea de Început a programului</translation>
     </message>
     <message>
         <location filename="../main.qml" line="240"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="240"/>
         <source>Home</source>
-        <translation>Prima&lt;br&gt;pagin&#259;</translation>
+        <translation>Prima&lt;br&gt;pagină</translation>
     </message>
     <message>
         <location filename="../main.qml" line="266"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="266"/>
         <source>Chat view</source>
-        <translation>Sec&#355;iunea conversa&#355;iilor</translation>
+        <translation>Secţiunea conversaţiilor</translation>
     </message>
     <message>
         <location filename="../main.qml" line="267"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="267"/>
         <source>Chat view to interact with models</source>
-        <translation>Sec&#355;iunea de chat pentru interac&#355;iune cu modele</translation>
+        <translation>Secţiunea de chat pentru interacţiune cu modele</translation>
     </message>
     <message>
         <location filename="../main.qml" line="275"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="275"/>
         <source>Chats</source>
-        <translation>Conversa&#355;ii</translation>
+        <translation>Conversaţii</translation>
     </message>
     <message>
         <location filename="../main.qml" line="300"/>
@@ -3231,7 +3241,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../main.qml" line="301"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="301"/>
         <source>Models view for installed models</source>
-        <translation>Sec&#355;iunea modelelor instalate</translation>
+        <translation>Secţiunea modelelor instalate</translation>
     </message>
     <message>
         <location filename="../main.qml" line="334"/>
@@ -3245,7 +3255,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../main.qml" line="335"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="335"/>
         <source>LocalDocs view to configure and use local docs</source>
-        <translation>Sec&#355;iunea LocalDocs de configurare &#351;i folosire a Documentelor Locale</translation>
+        <translation>Secţiunea LocalDocs de configurare şi folosire a Documentelor Locale</translation>
     </message>
     <message>
         <location filename="../main.qml" line="368"/>
@@ -3259,7 +3269,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../main.qml" line="369"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="369"/>
         <source>Settings view for application configuration</source>
-        <translation>Sec&#355;iunea de configurare a programului</translation>
+        <translation>Secţiunea de configurare a programului</translation>
     </message>
     <message>
         <location filename="../main.qml" line="422"/>
@@ -3271,7 +3281,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../main.qml" line="424"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="424"/>
         <source>Using a network model</source>
-        <translation>Se folose&#351;te un model pe re&#355;ea</translation>
+        <translation>Se foloseşte un model pe reţea</translation>
     </message>
     <message>
         <location filename="../main.qml" line="426"/>
@@ -3289,7 +3299,7 @@ care folose&#351;te datele tale!</translation>
         <location filename="../main.qml" line="641"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/main.qml" line="641"/>
         <source>View of installed models</source>
-        <translation>Sec&#355;iunea modelelor instalate</translation>
+        <translation>Secţiunea modelelor instalate</translation>
     </message>
 </context>
 </TS>

--- a/gpt4all-chat/translations/gpt4all_ro_RO.ts
+++ b/gpt4all-chat/translations/gpt4all_ro_RO.ts
@@ -1618,9 +1618,8 @@ model to get started</source>
         <translation>Dispozitivul pentru Embeddings</translation>
     </message>
     <message>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires
-                restart.</source>
-        <translation type="vanished">Dispozitivul pentru Embeddings. &quot;Auto&quot; apeleaz&#259; la CPU. Necesit&#259; repornire</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation type="vanished">Dispozitivul pentru Embeddings. Necesit&#259; repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="52"/>
@@ -1643,8 +1642,8 @@ model to get started</source>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>Dispozitivul pentru Embeddings. &quot;Auto&quot; apeleaz&#259; la CPU. Necesit&#259; repornire.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>Dispozitivul pentru Embeddings. Necesit&#259; repornire.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>

--- a/gpt4all-chat/translations/gpt4all_zh_CN.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_CN.ts
@@ -119,26 +119,26 @@
         <translation>触发模型的发现和筛选</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>喜欢</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>近期</translation>
     </message>
@@ -147,14 +147,14 @@
         <translation type="vanished">排序：</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>升序</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>倒序</translation>
     </message>
@@ -163,8 +163,8 @@
         <translation type="vanished">排序目录:</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>无</translation>
     </message>
@@ -183,170 +183,170 @@
         <translation>搜索中 · %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation>排序: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation>排序目录: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation>数量: %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation>网络错误：无法检索 %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translation>繁忙程度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation>在模型请求进行中时显示</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation>模型文件</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation>待下载模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation>文件描述</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>下载</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation>停止/重启/开始下载</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation>从系统中删除模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>安装</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>安装在线模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;错误&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的设备硬件不推荐 ，模型需要的内存 (%1 GB)比你的系统还要多  (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>错误：$API_KEY 为空</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
         <translation>错误：$BASE_URL 为空</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>输入 $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>错误：$MODEL_NAME为空</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>输入：$MODEL_NAME</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation>？</translation>
     </message>
@@ -355,8 +355,8 @@
         <translation type="vanished">&lt;a href=&quot;#error&quot;&gt;错误&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>描述下载过程中发生的错误</translation>
     </message>
@@ -373,74 +373,74 @@
         <translation type="vanished">你的系统需要 (</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>硬件不兼容的错误</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation>下载进度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation>显示下载进度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>下载速度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>下载速度  b/kb/mb /s</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>计算中</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation>是否正在计算文件哈希</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>在计算文件哈希时显示</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>输入$API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation>文件大小</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>RAM 需要</translation>
     </message>
@@ -449,20 +449,20 @@
         <translation type="vanished">GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>量化</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
@@ -533,74 +533,74 @@
         <translation>应用的主题颜色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation>深色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>亮色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation>LegacyDark</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>字体大小</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation>应用中的文本大小。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>中</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation>语言和本地化</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation>你想使用的语言</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>系统语言</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>设备</translation>
     </message>
@@ -609,166 +609,166 @@
         <translation type="vanished">用于文本生成的计算设备. &quot;自动&quot; 使用 Vulkan or Metal.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation>设备用于文本生成</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>程序默认</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>默认模型</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>新聊天的首选模式。也用作本地服务器回退。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>建议模式</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>在答复结束时生成建议的后续问题。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation>本地文档检索</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation>只要有可能</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation>从不</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>下载目录</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation>本地模型和本地文档数据库存储目录</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation>查看</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation>模型下载目录</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation>开启数据湖</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>发送对话和反馈给GPT4All 的开源数据湖。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation>CPU线程</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>用于推理和嵌入的CPU线程数</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
+        <location filename="../qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
         <source>Save Chat Context</source>
         <translation>保存对话上下文</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>保存模型&apos;s 状态以提供更快加载速度. 警告: 需用 ~2GB 每个对话.</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
+        <location filename="../qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local Server</source>
         <translation>开启本地服务</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="488"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>将OpenAI兼容服务器暴露给本地主机。警告：导致资源使用量增加。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
         <source>API Server Port</source>
         <translation>API 服务端口</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>使用本地服务的端口，需要重启</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>手动检查更新</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation>更新</translation>
     </message>
@@ -1625,62 +1625,68 @@ model to get started</source>
         <translation>技术设备用于embeddings. 需要重启.</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>程序默认</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>显示</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation>查看源码</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation>显示每个响应所使用的源。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>高级</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
         <translation>提示: 仅限高级使用。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation>值过大可能会导致 localdocs 失败、响应速度极慢或根本无法响应。粗略地说，{N 个字符 x N 个片段} 被添加到模型的上下文窗口中。更多信息请见&lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;此处&lt;/a&gt;。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>文档粘贴大小 (字符)</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>每个文档片段的字符数。较大的数值增加了事实性响应的可能性，但也会导致生成速度变慢。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>每个提示的最大文档片段数</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>检索到的文档片段最多添加到提示上下文中的前 N 个最佳匹配项。较大的数值增加了事实性响应的可能性，但也会导致生成速度变慢。</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_zh_CN.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_CN.ts
@@ -1621,8 +1621,8 @@ model to get started</source>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>技术设备用于embeddings. &quot;自动&quot; 使用.需要重启.</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>技术设备用于embeddings. 需要重启.</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>

--- a/gpt4all-chat/translations/gpt4all_zh_TW.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_TW.ts
@@ -121,309 +121,309 @@
         <translation>觸發探索與過濾模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="191"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="191"/>
         <source>Default</source>
         <translation>預設</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="192"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="192"/>
         <source>Likes</source>
         <translation>讚</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="193"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="193"/>
         <source>Downloads</source>
         <translation>下載次數</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="190"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="190"/>
+        <location filename="../qml/AddModelView.qml" line="194"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="194"/>
         <source>Recent</source>
         <translation>最新</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="197"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="197"/>
+        <location filename="../qml/AddModelView.qml" line="202"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="202"/>
         <source>Sort by: %1</source>
         <translation>排序依據：%1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="216"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>升序</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="210"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="210"/>
+        <location filename="../qml/AddModelView.qml" line="217"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="217"/>
         <source>Desc</source>
         <translation>降序</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="222"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="222"/>
+        <location filename="../qml/AddModelView.qml" line="230"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="230"/>
         <source>Sort dir: %1</source>
         <translation>排序順序：%1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="238"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="238"/>
+        <location filename="../qml/AddModelView.qml" line="252"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>無</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="258"/>
+        <location filename="../qml/AddModelView.qml" line="274"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="274"/>
         <source>Limit: %1</source>
         <translation>上限：%1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="291"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="291"/>
+        <location filename="../qml/AddModelView.qml" line="307"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="307"/>
         <source>Network error: could not retrieve %1</source>
         <translation>網路錯誤：無法取得 %1</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="486"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="486"/>
+        <location filename="../qml/AddModelView.qml" line="502"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="502"/>
         <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#error&quot;&gt;錯誤&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="505"/>
+        <location filename="../qml/AddModelView.qml" line="521"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="521"/>
         <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware. Model requires more memory (%1 GB) than your system has available (%2).&lt;/strong&gt;&lt;/font&gt;</source>
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告：不推薦在您的硬體上運作。模型需要比較多的記憶體（%1 GB），但您的系統記憶體空間不足（%2）。&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="700"/>
-        <location filename="../qml/AddModelView.qml" line="722"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="700"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="722"/>
+        <location filename="../qml/AddModelView.qml" line="716"/>
+        <location filename="../qml/AddModelView.qml" line="738"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="716"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="738"/>
         <source>?</source>
         <translation>？</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="301"/>
-        <location filename="../qml/AddModelView.qml" line="589"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="301"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="589"/>
+        <location filename="../qml/AddModelView.qml" line="317"/>
+        <location filename="../qml/AddModelView.qml" line="605"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="317"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="605"/>
         <source>Busy indicator</source>
         <translatorcomment>參考自 https://terms.naer.edu.tw</translatorcomment>
         <translation>忙線指示器</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="302"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="302"/>
+        <location filename="../qml/AddModelView.qml" line="318"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="318"/>
         <source>Displayed when the models request is ongoing</source>
         <translation>當模型請求正在進行時顯示</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="342"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="342"/>
+        <location filename="../qml/AddModelView.qml" line="358"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="358"/>
         <source>Model file</source>
         <translation>模型檔案</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="343"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="343"/>
+        <location filename="../qml/AddModelView.qml" line="359"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="359"/>
         <source>Model file to be downloaded</source>
         <translation>即將下載的模型檔案</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="366"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="366"/>
+        <location filename="../qml/AddModelView.qml" line="382"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="382"/>
         <source>Description</source>
         <translation>描述</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="367"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="367"/>
+        <location filename="../qml/AddModelView.qml" line="383"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="383"/>
         <source>File description</source>
         <translation>檔案描述</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Resume</source>
         <translation>恢復</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="400"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="400"/>
+        <location filename="../qml/AddModelView.qml" line="416"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="416"/>
         <source>Download</source>
         <translation>下載</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="408"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="408"/>
+        <location filename="../qml/AddModelView.qml" line="424"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="424"/>
         <source>Stop/restart/start the download</source>
         <translation>停止/重啟/開始下載</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="420"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="420"/>
+        <location filename="../qml/AddModelView.qml" line="436"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="436"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="427"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="427"/>
+        <location filename="../qml/AddModelView.qml" line="443"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="443"/>
         <source>Remove model from filesystem</source>
         <translation>從檔案系統移除模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="441"/>
-        <location filename="../qml/AddModelView.qml" line="475"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="441"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="475"/>
+        <location filename="../qml/AddModelView.qml" line="457"/>
+        <location filename="../qml/AddModelView.qml" line="491"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="491"/>
         <source>Install</source>
         <translation>安裝</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="476"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="476"/>
+        <location filename="../qml/AddModelView.qml" line="492"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
         <source>Install online model</source>
         <translation>安裝線上模型</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="492"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="492"/>
+        <location filename="../qml/AddModelView.qml" line="508"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>解釋下載時發生的錯誤</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="511"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="511"/>
+        <location filename="../qml/AddModelView.qml" line="527"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="527"/>
         <source>Error for incompatible hardware</source>
         <translation>錯誤，不相容的硬體</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="549"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="549"/>
+        <location filename="../qml/AddModelView.qml" line="565"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="565"/>
         <source>Download progressBar</source>
         <translation>下載進度條</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="550"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="550"/>
+        <location filename="../qml/AddModelView.qml" line="566"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="566"/>
         <source>Shows the progress made in the download</source>
         <translation>顯示下載進度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="560"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="560"/>
+        <location filename="../qml/AddModelView.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="576"/>
         <source>Download speed</source>
         <translation>下載速度</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="561"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="561"/>
+        <location filename="../qml/AddModelView.qml" line="577"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="577"/>
         <source>Download speed in bytes/kilobytes/megabytes per second</source>
         <translation>下載速度每秒 bytes/kilobytes/megabytes</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="578"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="578"/>
+        <location filename="../qml/AddModelView.qml" line="594"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="594"/>
         <source>Calculating...</source>
         <translation>計算中......</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="582"/>
-        <location filename="../qml/AddModelView.qml" line="612"/>
-        <location filename="../qml/AddModelView.qml" line="633"/>
-        <location filename="../qml/AddModelView.qml" line="654"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="582"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="612"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="633"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="654"/>
+        <location filename="../qml/AddModelView.qml" line="598"/>
+        <location filename="../qml/AddModelView.qml" line="628"/>
+        <location filename="../qml/AddModelView.qml" line="649"/>
+        <location filename="../qml/AddModelView.qml" line="670"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="598"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="628"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="649"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="670"/>
         <source>Whether the file hash is being calculated</source>
         <translation>是否正在計算檔案雜湊</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="590"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="590"/>
+        <location filename="../qml/AddModelView.qml" line="606"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="606"/>
         <source>Displayed when the file hash is being calculated</source>
         <translation>計算檔案雜湊值時顯示</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="603"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="603"/>
+        <location filename="../qml/AddModelView.qml" line="619"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="619"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>錯誤：$API_KEY 未填寫。</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="609"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="609"/>
+        <location filename="../qml/AddModelView.qml" line="625"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="625"/>
         <source>enter $API_KEY</source>
         <translation>請輸入 $API_KEY</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="624"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="624"/>
+        <location filename="../qml/AddModelView.qml" line="640"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="640"/>
         <source>ERROR: $BASE_URL is empty.</source>
         <translation>錯誤：$BASE_URL 未填寫。</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="630"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="630"/>
+        <location filename="../qml/AddModelView.qml" line="646"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="646"/>
         <source>enter $BASE_URL</source>
         <translation>請輸入 $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="645"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="645"/>
+        <location filename="../qml/AddModelView.qml" line="661"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="661"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>錯誤：$MODEL_NAME 未填寫。</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="651"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="651"/>
+        <location filename="../qml/AddModelView.qml" line="667"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="667"/>
         <source>enter $MODEL_NAME</source>
         <translation>請輸入 $MODEL_NAME</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="673"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="673"/>
+        <location filename="../qml/AddModelView.qml" line="689"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="689"/>
         <source>File size</source>
         <translation>檔案大小</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="695"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="695"/>
+        <location filename="../qml/AddModelView.qml" line="711"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>所需的記憶體</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="717"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="717"/>
+        <location filename="../qml/AddModelView.qml" line="733"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="733"/>
         <source>Parameters</source>
         <translation>參數</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="739"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="739"/>
+        <location filename="../qml/AddModelView.qml" line="755"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="755"/>
         <source>Quant</source>
         <translation>量化</translation>
     </message>
     <message>
-        <location filename="../qml/AddModelView.qml" line="761"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="761"/>
+        <location filename="../qml/AddModelView.qml" line="777"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/AddModelView.qml" line="777"/>
         <source>Type</source>
         <translation>類型</translation>
     </message>
@@ -495,238 +495,238 @@
         <translation>應用程式的配色方案。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="113"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="113"/>
         <source>Dark</source>
         <translation>暗色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="112"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>亮色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="111"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="111"/>
+        <location filename="../qml/ApplicationSettings.qml" line="114"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="114"/>
         <source>LegacyDark</source>
         <translation>傳統暗色</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="132"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="132"/>
+        <location filename="../qml/ApplicationSettings.qml" line="136"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="136"/>
         <source>Font Size</source>
         <translation>字體大小</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="133"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="133"/>
+        <location filename="../qml/ApplicationSettings.qml" line="137"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="137"/>
         <source>The size of text in the application.</source>
         <translation>應用程式中的字體大小。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="151"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="151"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="152"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="152"/>
         <source>Medium</source>
         <translation>中</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="146"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="146"/>
+        <location filename="../qml/ApplicationSettings.qml" line="153"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="153"/>
         <source>Large</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="168"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="168"/>
+        <location filename="../qml/ApplicationSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="176"/>
         <source>Language and Locale</source>
         <translation>語言與區域設定</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="169"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="169"/>
+        <location filename="../qml/ApplicationSettings.qml" line="177"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="177"/>
         <source>The language and locale you wish to use.</source>
         <translation>您希望使用的語言與區域設定。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="188"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="188"/>
+        <location filename="../qml/ApplicationSettings.qml" line="196"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="196"/>
         <source>System Locale</source>
         <translation>系統語系</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="215"/>
+        <location filename="../qml/ApplicationSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="223"/>
         <source>Device</source>
         <translation>裝置</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="267"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="267"/>
+        <location filename="../qml/ApplicationSettings.qml" line="275"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="275"/>
         <source>Default Model</source>
         <translation>預設模型</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="268"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="268"/>
+        <location filename="../qml/ApplicationSettings.qml" line="276"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="276"/>
         <source>The preferred model for new chats. Also used as the local server fallback.</source>
         <translation>用於新交談的預設模型。也用於作為本機伺服器後援使用。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="325"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="325"/>
+        <location filename="../qml/ApplicationSettings.qml" line="339"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="339"/>
         <source>Suggestion Mode</source>
         <translation>建議模式</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="353"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="353"/>
         <source>When chatting with LocalDocs</source>
         <translation>當使用「我的文件」交談時</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="354"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="354"/>
         <source>Whenever possible</source>
         <translation>視情況允許</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="338"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="338"/>
+        <location filename="../qml/ApplicationSettings.qml" line="355"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="355"/>
         <source>Never</source>
         <translation>永不</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="326"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="326"/>
+        <location filename="../qml/ApplicationSettings.qml" line="340"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>在回覆末尾生成後續建議的問題。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="216"/>
+        <location filename="../qml/ApplicationSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="224"/>
         <source>The compute device used for text generation.</source>
         <translation>用於生成文字的計算設備。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../qml/ApplicationSettings.qml" line="289"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="234"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="289"/>
+        <location filename="../qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../qml/ApplicationSettings.qml" line="297"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="242"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>應用程式預設值</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="350"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="350"/>
+        <location filename="../qml/ApplicationSettings.qml" line="368"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="368"/>
         <source>Download Path</source>
         <translation>下載路徑</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="351"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="351"/>
+        <location filename="../qml/ApplicationSettings.qml" line="369"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="369"/>
         <source>Where to store local models and the LocalDocs database.</source>
         <translation>儲存本機模型與「我的文件」資料庫的位置。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="380"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="380"/>
+        <location filename="../qml/ApplicationSettings.qml" line="398"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="398"/>
         <source>Browse</source>
         <translation>瀏覽</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="381"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="381"/>
+        <location filename="../qml/ApplicationSettings.qml" line="399"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="399"/>
         <source>Choose where to save model files</source>
         <translation>選擇儲存模型檔案的位置</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="392"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="392"/>
+        <location filename="../qml/ApplicationSettings.qml" line="410"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="410"/>
         <source>Enable Datalake</source>
         <translation>啟用資料湖泊</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="393"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="393"/>
+        <location filename="../qml/ApplicationSettings.qml" line="411"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="411"/>
         <source>Send chats and feedback to the GPT4All Open-Source Datalake.</source>
         <translation>將交談與回饋傳送到 GPT4All 開放原始碼資料湖泊。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="426"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="426"/>
+        <location filename="../qml/ApplicationSettings.qml" line="444"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="444"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="438"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="438"/>
+        <location filename="../qml/ApplicationSettings.qml" line="456"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="456"/>
         <source>CPU Threads</source>
         <translation>中央處理器（CPU）線程</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="439"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="439"/>
+        <location filename="../qml/ApplicationSettings.qml" line="457"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="457"/>
         <source>The number of CPU threads used for inference and embedding.</source>
         <translation>用於推理與嵌入的中央處理器線程數。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="470"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="470"/>
+        <location filename="../qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
         <source>Save Chat Context</source>
         <translation>儲存交談語境</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="471"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="471"/>
+        <location filename="../qml/ApplicationSettings.qml" line="489"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>將交談模型的狀態儲存到磁碟以加快載入速度。警告：每次交談使用約 2GB。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="487"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="487"/>
+        <location filename="../qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local Server</source>
         <translation>啟用本機伺服器</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="488"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="488"/>
+        <location filename="../qml/ApplicationSettings.qml" line="506"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>將 OpenAI 相容伺服器公開給本機。警告：導致資源使用增加。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="504"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="504"/>
+        <location filename="../qml/ApplicationSettings.qml" line="522"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="522"/>
         <source>API Server Port</source>
         <translation>API 伺服器埠口</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="505"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="505"/>
+        <location filename="../qml/ApplicationSettings.qml" line="523"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="523"/>
         <source>The port to use for the local server. Requires restart.</source>
         <translation>用於本機伺服器的埠口。需要重新啟動。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="557"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="557"/>
+        <location filename="../qml/ApplicationSettings.qml" line="575"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="575"/>
         <source>Check For Updates</source>
         <translation>檢查更新</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="558"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="558"/>
+        <location filename="../qml/ApplicationSettings.qml" line="576"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="576"/>
         <source>Manually check for an update to GPT4All.</source>
         <translation>手動檢查 GPT4All 的更新。</translation>
     </message>
     <message>
-        <location filename="../qml/ApplicationSettings.qml" line="567"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="567"/>
+        <location filename="../qml/ApplicationSettings.qml" line="585"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/ApplicationSettings.qml" line="585"/>
         <source>Updates</source>
         <translation>更新</translation>
     </message>
@@ -1528,62 +1528,68 @@ model to get started</source>
         <translation>用於嵌入的計算裝置。需要重新啟動。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="202"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="202"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="176"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="176"/>
+        <source>Application default</source>
+        <translation>應用程式預設值</translation>
+    </message>
+    <message>
+        <location filename="../qml/LocalDocsSettings.qml" line="210"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="210"/>
         <source>Display</source>
         <translation>顯示</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="215"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="215"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="223"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="223"/>
         <source>Show Sources</source>
         <translation>查看來源</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="216"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="216"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="224"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="224"/>
         <source>Display the sources used for each response.</source>
         <translation>顯示每則回覆所使用的來源。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="233"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="233"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="241"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="241"/>
         <source>Advanced</source>
         <translation>進階</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="249"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="249"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="257"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="257"/>
         <source>Warning: Advanced usage only.</source>
         <translation>警告：僅限進階使用。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="250"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="250"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
         <source>Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
         <translation>設定太大的數值可能會導致「我的文件」處理失敗、反應速度極慢或根本無法回覆。簡單地說，這會將 {N 個字元 x N 個片段} 被添加到模型的語境視窗中。更多資訊&lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;此處&lt;/a&gt;。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="258"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="258"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="266"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>文件片段大小（字元）</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="259"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="259"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="267"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="267"/>
         <source>Number of characters per document snippet. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>每個文件片段的字元數。較大的數字會增加實際反應的可能性，但也會導致生成速度變慢。</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="284"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="284"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="292"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>每個提示詞的最大文件片段</translation>
     </message>
     <message>
-        <location filename="../qml/LocalDocsSettings.qml" line="285"/>
-        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="285"/>
+        <location filename="../qml/LocalDocsSettings.qml" line="293"/>
+        <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="293"/>
         <source>Max best N matches of retrieved document snippets to add to the context for prompt. Larger numbers increase likelihood of factual responses, but also result in slower generation.</source>
         <translation>新增至提示詞語境中的檢索到的文件片段的最大 N 個符合的項目。較大的數字會增加實際反應的可能性，但也會導致生成速度變慢。</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_zh_TW.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_TW.ts
@@ -1524,8 +1524,8 @@ model to get started</source>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="166"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsSettings.qml" line="166"/>
-        <source>The compute device used for embeddings. &quot;Auto&quot; uses the CPU. Requires restart.</source>
-        <translation>用於嵌入的計算裝置。「Auto」將自動使用中央處理器。需要重新啟動。</translation>
+        <source>The compute device used for embeddings. Requires restart.</source>
+        <translation>用於嵌入的計算裝置。需要重新啟動。</translation>
     </message>
     <message>
         <location filename="../qml/LocalDocsSettings.qml" line="202"/>


### PR DESCRIPTION
PR #2690 changed `getDevices()`, but failed to update the QML for the "Embeddings Device" option on the LocalDocs page to match. Since the PR had absolutely no description, I can't say I was 100% aware of what was being changed or why, so I didn't catch this.

This change prevents the "Embeddings Device" selection from showing up as blank if "Auto" was internally selected, either by default or by selecting it in a previous version. It also allows you to select the "Auto" option again after switching to something else.

For consistency with the previous PR, "Auto" is now called "Application default," and the informative description of the "Auto" option has been removed from the UI, including all translations. (I would argue that this cannot possibly be an improvement, but too much time has been spent discussing that already.)