### PR TITLE
chat: set the window icon on Linux

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Bring back "Auto" option for Embeddings Device as "Application default," which went missing in v3.1.0 ([#2873](https://github.com/nomic-ai/gpt4all/pull/2873))
 - Correct a few strings in the Italian translation (by [@Harvester62](https://github.com/Harvester62) in [#2872](https://github.com/nomic-ai/gpt4all/pull/2872))
 - Correct typos in Traditional Chinese translation (by [@supersonictw](https://github.com/supersonictw) in [#2852](https://github.com/nomic-ai/gpt4all/pull/2852))
+- Set the window icon on Linux ([#2880](https://github.com/nomic-ai/gpt4all/pull/2880))
 
 ## [3.2.1] - 2024-08-13
 

--- a/gpt4all-chat/main.cpp
+++ b/gpt4all-chat/main.cpp
@@ -21,6 +21,11 @@
 #include <QUrl>
 #include <Qt>
 
+#ifdef Q_OS_LINUX
+#   include <QIcon>
+#endif
+
+
 int main(int argc, char *argv[])
 {
     QCoreApplication::setOrganizationName("nomic.ai");
@@ -32,6 +37,9 @@ int main(int argc, char *argv[])
     Logger::globalInstance();
 
     QGuiApplication app(argc, argv);
+#ifdef Q_OS_LINUX
+    app.setWindowIcon(QIcon(":/gpt4all/icons/gpt4all.svg"));
+#endif
 
     // set search path before constructing the MySettings instance, which relies on this
     QString llmodelSearchPaths = QCoreApplication::applicationDirPath();


### PR DESCRIPTION
On Windows, the window icon is set in the executable's metadata. macOS does not really use window icons.

But on Linux, the executable format has nothing GUI-related, so we must set the window icon explicitly when the program starts. Otherwise, you just get a placeholder that looks ugly. The window icon is used in both the title bar and taskbar in many DEs (I use XFCE).

Before:
![gpt4all-noicon](https://github.com/user-attachments/assets/be9e2b00-5c1b-430f-b2f2-4661ef3b23b3)

After:
![gpt4all-icon](https://github.com/user-attachments/assets/60e5e2c5-2c9c-49fa-bee9-8b3eac41a50a)