### PR TITLE
qml: fix copy-paste error in antenna description logic

### DIFF
--- a/gpt4all-chat/src/main.qml
+++ b/gpt4all-chat/src/main.qml
@@ -422,7 +422,7 @@ Window {
                             return qsTr("The datalake is enabled")
                         else if (currentChat.modelInfo.isOnline)
                             return qsTr("Using a network model")
-                        else if (currentChat.modelInfo.isOnline)
+                        else if (currentChat.isServer)
                             return qsTr("Server mode is enabled")
                         return ""
                     }


### PR DESCRIPTION
When using the built-in local server but not the DataLake or a remote model, the antenna icon would show with a blank tooltip, because the condition in an 'if' statement was incorrect.