### PR TITLE
chat: update and improve translations for the v3.3.0 release

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -29,7 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix the antenna icon tooltip when using the local server ([#2922](https://github.com/nomic-ai/gpt4all/pull/2922))
 - Fix a few issues with locating files and handling errors when loading remote models on startup ([#2875](https://github.com/nomic-ai/gpt4all/pull/2875))
 - Significantly improve API server request parsing and response correctness ([#2929](https://github.com/nomic-ai/gpt4all/pull/2929))
-- Removed unnecessary dependency on Qt WaylandCompositor module ([#2949](https://github.com/nomic-ai/gpt4all/pull/2949))
+- Remove unnecessary dependency on Qt WaylandCompositor module ([#2949](https://github.com/nomic-ai/gpt4all/pull/2949))
+- Update translations ([#2970](https://github.com/nomic-ai/gpt4all/pull/2970))
 
 ## [3.2.1] - 2024-08-13
 

--- a/gpt4all-chat/src/qml/ApplicationSettings.qml
+++ b/gpt4all-chat/src/qml/ApplicationSettings.qml
@@ -32,15 +32,15 @@ MySettingsTab {
         anchors.centerIn: parent
         modal: false
         padding: 20
+        width: 40 + 400 * theme.fontScale
         Text {
+            anchors.fill: parent
             horizontalAlignment: Text.AlignJustify
-            text: qsTr("ERROR: Update system could not find the MaintenanceTool used<br>
-                   to check for updates!<br><br>
-                   Did you install this application using the online installer? If so,<br>
-                   the MaintenanceTool executable should be located one directory<br>
-                   above where this application resides on your filesystem.<br><br>
-                   If you can't start it manually, then I'm afraid you'll have to<br>
-                   reinstall.")
+            text: qsTr("ERROR: Update system could not find the MaintenanceTool used to check for updates!<br/><br/>"
+                  + "Did you install this application using the online installer? If so, the MaintenanceTool "
+                  + "executable should be located one directory above where this application resides on your "
+                  + "filesystem.<br/><br/>If you can't start it manually, then I'm afraid you'll have to reinstall.")
+            wrapMode: Text.WordWrap
             color: theme.textErrorColor
             font.pixelSize: theme.fontSizeLarge
             Accessible.role: Accessible.Dialog

--- a/gpt4all-chat/src/qml/NetworkDialog.qml
+++ b/gpt4all-chat/src/qml/NetworkDialog.qml
@@ -52,11 +52,18 @@ MyDialog {
             MyTextArea {
                 id: textOptIn
                 width: 1024 - 40
-                text: qsTr("By enabling this feature, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
-
-When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
-
-NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!")
+                text: qsTr("By enabling this feature, you will be able to participate in the democratic process of "
+                      + "training a large language model by contributing data for future model improvements.\n\n"
+                      + "When a GPT4All model responds to you and you have opted-in, your conversation will be sent to "
+                      + "the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you "
+                      + "dislike a response, you can suggest an alternative response. This data will be collected and "
+                      + "aggregated in the GPT4All Datalake.\n\n"
+                      + "NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source "
+                      + "Datalake. You should have no expectation of chat privacy when this feature is enabled. You "
+                      + "should; however, have an expectation of an optional attribution if you wish. Your chat data "
+                      + "will be openly available for anyone to download and will be used by Nomic AI to improve "
+                      + "future GPT4All models. Nomic AI will retain all attribution information attached to your data "
+                      + "and you will be credited as a contributor to any GPT4All model release that uses your data!")
                 focus: false
                 readOnly: true
                 Accessible.role: Accessible.Paragraph

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -1098,37 +1098,37 @@ model to get started</source>
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_en_US.ts
+++ b/gpt4all-chat/translations/gpt4all_en_US.ts
@@ -371,17 +371,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation type="unfinished"></translation>
@@ -414,6 +403,11 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2066,47 +2060,47 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -371,17 +371,6 @@
         <translation>optar por compartir comentarios/conversaciones</translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>Diálogo de error</translation>
@@ -415,6 +404,11 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Claro</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation>ERROR: El sistema de actualización no pudo encontrar la Herramienta de Mantenimiento utilizada para buscar actualizaciones.&lt;br&gt;&lt;br&gt;¿Instaló esta aplicación utilizando el instalador en línea? Si es así, el ejecutable de la Herramienta de Mantenimiento debería estar ubicado un directorio por encima de donde reside esta aplicación en su sistema de archivos.&lt;br&gt;&lt;br&gt;Si no puede iniciarlo manualmente, me temo que tendrá que reinstalar la aplicación.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="114"/>
@@ -605,22 +599,6 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="297"/>
         <source>Application default</source>
         <translation>Predeterminado de la aplicación</translation>
-    </message>
-    <message>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                       to check for updates!&lt;br&gt;&lt;br&gt;
-                       Did you install this application using the online installer? If so,&lt;br&gt;
-                       the MaintenanceTool executable should be located one directory&lt;br&gt;
-                       above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                       If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                       reinstall.</source>
-        <translation type="vanished">ERROR: El sistema de actualización no pudo encontrar la Herramienta de Mantenimiento utilizada&lt;br&gt;
-                       para buscar actualizaciones.&lt;br&gt;&lt;br&gt;
-                       ¿Instaló esta aplicación utilizando el instalador en línea? Si es así,&lt;br&gt;
-                       el ejecutable de la Herramienta de Mantenimiento debería estar ubicado un directorio&lt;br&gt;
-                       por encima de donde reside esta aplicación en su sistema de archivos.&lt;br&gt;&lt;br&gt;
-                       Si no puede iniciarlo manualmente, me temo que tendrá que&lt;br&gt;
-                       reinstalar la aplicación.</translation>
     </message>
 </context>
 <context>
@@ -2105,47 +2083,47 @@ Cuando un modelo GPT4All te responda y hayas aceptado participar, tu conversaci�
 NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Código Abierto de GPT4All. No debes esperar privacidad en el chat cuando esta función esté habilitada. Sin embargo, puedes esperar una atribución opcional si lo deseas. Tus datos de chat estarán disponibles abiertamente para que cualquiera los descargue y serán utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará toda la información de atribución adjunta a tus datos y se te acreditará como contribuyente en cualquier lanzamiento de modelo GPT4All que utilice tus datos.</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>Términos para optar por participar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>Describe lo que sucederá cuando opte por participar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>Por favor, proporcione un nombre para la atribución (opcional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>Atribución (opcional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>Proporcionar atribución</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>Habilitar participación</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>Cancelar participación</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_es_MX.ts
+++ b/gpt4all-chat/translations/gpt4all_es_MX.ts
@@ -558,22 +558,12 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local API Server</source>
-        <translation type="unfinished"></translation>
+        <translation>Habilitar el servidor API local</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta en un mayor uso de recursos.</translation>
-    </message>
-    <message>
-        <source>Enable Local Server</source>
-        <translation type="vanished">Habilitar servidor local</translation>
-    </message>
-    <message>
-        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
-                resource usage.</source>
-        <translation type="vanished">Exponer un servidor compatible con OpenAI a localhost. ADVERTENCIA: Resulta
-                en un mayor uso de recursos.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="522"/>
@@ -905,10 +895,6 @@
         <translation>Tú</translation>
     </message>
     <message>
-        <source>recalculating context ...</source>
-        <translation type="vanished">recalculando contexto ...</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="878"/>
         <source>response stopped ...</source>
         <translation>respuesta detenida ...</translation>
@@ -1134,37 +1120,37 @@ modelo para comenzar
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation>El modelo &quot;%1&quot; se ha instalado correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERROR: $MODEL_NAME está vacío.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERROR: $API_KEY está vacía.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation>ERROR: $BASE_URL no es válida.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation>ERROR: El modelo &quot;%1 (%2)&quot; está en conflicto.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation>El modelo &quot;%1 (%2)&quot; se ha instalado correctamente.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation>El modelo &quot;%1&quot; ha sido eliminado.</translation>
     </message>
@@ -1285,12 +1271,6 @@ modelo para comenzar
         <translation>Extensiones de archivo permitidas</translation>
     </message>
     <message>
-        <source>Comma-separated list. LocalDocs will only attempt to process files with these
-                extensions.</source>
-        <translation type="vanished">Lista separada por comas. DocumentosLocales solo intentará procesar
-                archivos con estas extensiones.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="100"/>
         <source>Embedding</source>
         <translation>Incrustación</translation>
@@ -1299,12 +1279,6 @@ modelo para comenzar
         <location filename="../src/qml/LocalDocsSettings.qml" line="112"/>
         <source>Use Nomic Embed API</source>
         <translation>Usar API de incrustación Nomic</translation>
-    </message>
-    <message>
-        <source>Embed documents using the fast Nomic API instead of a private local model.
-                Requires restart.</source>
-        <translation type="vanished">Incrustar documentos usando la rápida API de Nomic en lugar de un modelo
-                local privado. Requiere reinicio.</translation>
     </message>
     <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="130"/>
@@ -1382,11 +1356,6 @@ modelo para comenzar
         <translation>Máximo de N mejores coincidencias de fragmentos de documentos recuperados para añadir al contexto del prompt. Números más grandes aumentan la probabilidad de respuestas verídicas, pero también resultan en una generación más lenta.</translation>
     </message>
     <message>
-        <source> Values too large may cause localdocs failure, extremely slow responses or failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to the model&apos;s context window. More info &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.
-            </source>
-        <translation type="vanished"> Valores demasiado grandes pueden causar fallos en documentos locales, respuestas extremadamente lentas o falta de respuesta. En términos generales, los {N caracteres x N fragmentos} se agregan a la ventana de contexto del modelo. Más información &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aquí&lt;/a&gt;.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>Tamaño del fragmento de documento (caracteres)</translation>
@@ -1413,10 +1382,6 @@ modelo para comenzar
         <location filename="../src/qml/LocalDocsView.qml" line="71"/>
         <source>＋ Add Collection</source>
         <translation>＋ Agregar colección</translation>
-    </message>
-    <message>
-        <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">ERROR: La base de datos de DocumentosLocales no es válida.</translation>
     </message>
     <message>
         <location filename="../src/qml/LocalDocsView.qml" line="109"/>
@@ -1563,12 +1528,6 @@ modelo para comenzar
         <translation>&lt;ul&gt;&lt;li&gt;Requiere clave API personal de OpenAI.&lt;/li&gt;&lt;li&gt;ADVERTENCIA: ¡Enviará sus chats a OpenAI!&lt;/li&gt;&lt;li&gt;Su clave API se almacenará en el disco&lt;/li&gt;&lt;li&gt;Solo se usará para comunicarse con OpenAI&lt;/li&gt;&lt;li&gt;Puede solicitar una clave API &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aquí.&lt;/a&gt;&lt;/li&gt;</translation>
     </message>
     <message>
-        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
-                %1</source>
-        <translation type="vanished">&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de
-                OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
-    </message>
-    <message>
         <location filename="../src/modellist.cpp" line="1585"/>
         <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt; %1</source>
         <translation>&lt;strong&gt;Modelo ChatGPT GPT-3.5 Turbo de OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
@@ -1617,12 +1576,12 @@ modelo para comenzar
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>no se puede abrir &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>no se puede crear &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1289"/>
@@ -2133,19 +2092,6 @@ NOTA: No surte efecto hasta que recargue el modelo.</translation>
         <translation>Contribuir datos al Datalake de código abierto de GPT4All.</translation>
     </message>
     <message>
-        <source>By enabling this feature, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
- 
-When a GPT4All model responds to you and you have opted-in, your conversation will
-be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its
-response. If you dislike a response, you can suggest an alternative response. This
-data will be collected and aggregated in the GPT4All Datalake.
-
-NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
-        <translation type="vanished">Al habilitar esta función, podrá participar en el proceso democrático de entrenamiento de un modelo de lenguaje grande contribuyendo con datos para futuras mejoras del modelo. Cuando un modelo GPT4All le responda y usted haya aceptado, su conversación se enviará al Datalake de código abierto de GPT4All. Además, puede dar me gusta/no me gusta a su respuesta. Si no le gusta una respuesta, puede sugerir una alternativa. Estos datos se recopilarán y agregarán en el Datalake de GPT4All.
-                
-NOTA: Al activar esta función, enviará sus datos al Datalake de código abierto de GPT4All. No debe esperar privacidad en el chat cuando esta función esté habilitada. Sin embargo, puede esperar una atribución opcional si lo desea. Sus datos de chat estarán disponibles abiertamente para que cualquiera los descargue y serán utilizados por Nomic AI para mejorar futuros modelos de GPT4All. Nomic AI conservará toda la información de atribución adjunta a sus datos y se le acreditará como contribuyente en cualquier lanzamiento de modelo GPT4All que utilice sus datos.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/NetworkDialog.qml" line="55"/>
         <source>By enabling this feature, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
 
@@ -2241,13 +2187,6 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
     </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Predeterminado</translation>
-    </message>
-</context>
-<context>
     <name>SettingsView</name>
     <message>
         <location filename="../src/qml/SettingsView.qml" line="22"/>
@@ -2289,7 +2228,10 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
 %1&lt;br/&gt;
 ### Contributors
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>### Notas de la versión
+%1&lt;br/&gt;
+### Colaboradores
+%2</translation>
     </message>
     <message>
         <location filename="../src/qml/StartupDialog.qml" line="71"/>
@@ -2300,16 +2242,6 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
         <location filename="../src/qml/StartupDialog.qml" line="72"/>
         <source>Release notes for this version</source>
         <translation>Notas de la versión para esta versión</translation>
-    </message>
-    <message>
-        <source>### Release notes
-%1### Contributors
-%2
-            </source>
-        <translation type="vanished">### Notas de la versión
-%1### Colaboradores
-%2
-            </translation>
     </message>
     <message>
         <source>### Opt-ins for anonymous usage analytics and datalake By enabling these features, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
@@ -2392,15 +2324,6 @@ NOTA: Al activar esta función, estarás enviando tus datos al Datalake de Códi
         <translation>Permitir rechazar el compartir anónimo de chats con el Datalake de GPT4All</translation>
     </message>
     <message>
-        <source>### Release notes
-%1### Contributors
-%2</source>
-        <translation type="vanished">### Notas de la versión
-%1### Colaboradores
-%2
-        </translation>
-    </message>
-    <message>
         <location filename="../src/qml/StartupDialog.qml" line="87"/>
         <source>### Opt-ins for anonymous usage analytics and datalake
 By enabling these features, you will be able to participate in the democratic process of training a
@@ -2434,12 +2357,6 @@ lanzamiento de modelo GPT4All que utilice sus datos.</translation>
 </context>
 <context>
     <name>SwitchModelDialog</name>
-    <message>
-        <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
-                conversation. Do you wish to continue?</source>
-        <translation type="vanished">&lt;b&gt;Advertencia:&lt;/b&gt; cambiar el modelo borrará la conversación
-                actual. ¿Desea continuar?</translation>
-    </message>
     <message>
         <location filename="../src/qml/SwitchModelDialog.qml" line="22"/>
         <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current conversation. Do you wish to continue?</source>

--- a/gpt4all-chat/translations/gpt4all_it_IT.ts
+++ b/gpt4all-chat/translations/gpt4all_it_IT.ts
@@ -1112,37 +1112,37 @@ modello per iniziare</translation>
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation>Il modello &quot;%1&quot; è stato installato correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERRORE: $MODEL_NAME è vuoto.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERRORE: $API_KEY è vuoto.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation>ERRORE: $BASE_URL non è valido.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation>ERRORE: il modello &quot;%1 (%2)&quot; è in conflitto.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation>Il modello &quot;%1 (%2)&quot; è stato installato correttamente.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation>Il modello &quot;%1&quot; è stato rimosso.</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_it_IT.ts
+++ b/gpt4all-chat/translations/gpt4all_it_IT.ts
@@ -569,7 +569,7 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local API Server</source>
-        <translation type="unfinished"></translation>
+        <translation>Abilita il server API locale</translation>
     </message>
     <message>
         <source>Enable Local Server</source>
@@ -1544,12 +1544,12 @@ modello per iniziare</translation>
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>impossibile aprire &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>impossibile creare &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1288"/>

--- a/gpt4all-chat/translations/gpt4all_it_IT.ts
+++ b/gpt4all-chat/translations/gpt4all_it_IT.ts
@@ -371,17 +371,6 @@
         <translation>aderisci per condividere feedback/conversazioni</translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>Dialogo d&apos;errore</translation>
@@ -415,6 +404,11 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Chiaro</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="114"/>
@@ -884,10 +878,6 @@ modello per iniziare</translation>
         <location filename="../src/qml/ChatView.qml" line="854"/>
         <source>You</source>
         <translation>Tu</translation>
-    </message>
-    <message>
-        <source>recalculating context ...</source>
-        <translation type="vanished">ricalcolo contesto ...</translation>
     </message>
     <message>
         <location filename="../src/qml/ChatView.qml" line="878"/>
@@ -1375,10 +1365,6 @@ modello per iniziare</translation>
         <location filename="../src/qml/LocalDocsView.qml" line="71"/>
         <source>＋ Add Collection</source>
         <translation>＋ Aggiungi raccolta</translation>
-    </message>
-    <message>
-        <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">ERRORE: il database di LocalDocs non è valido.</translation>
     </message>
     <message>
         <location filename="../src/qml/LocalDocsView.qml" line="85"/>
@@ -2096,47 +2082,47 @@ Quando un modello di GPT4All ti risponde e tu hai aderito, la tua conversazione 
 NOTA: attivando questa funzione, invierai i tuoi dati al Datalake Open Source di GPT4All. Non dovresti avere aspettative sulla privacy della chat quando questa funzione è abilitata. Dovresti, tuttavia, aspettarti un&apos;attribuzione facoltativa, se lo desideri. I tuoi dati di chat saranno liberamente disponibili per essere scaricati da chiunque e verranno utilizzati da Nomic AI per migliorare i futuri modelli GPT4All. Nomic AI conserverà tutte le informazioni di attribuzione allegate ai tuoi dati e verrai accreditato come collaboratore a qualsiasi versione del modello GPT4All che utilizza i tuoi dati!</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>Termini per l&apos;adesione</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>Descrive cosa accadrà quando effettuerai l&apos;adesione</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>Fornisci un nome per l&apos;attribuzione (facoltativo)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>Attribuzione (facoltativo)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>Fornire attribuzione</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>Abilita</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>Abilita l&apos;adesione</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>Annulla l&apos;adesione</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_pt_BR.ts
+++ b/gpt4all-chat/translations/gpt4all_pt_BR.ts
@@ -578,11 +578,7 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local API Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Local Server</source>
-        <translation type="vanished">Ativar Servidor Local</translation>
+        <translation>Ativar servidor de API local</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="506"/>
@@ -889,10 +885,6 @@ modelo instalado para funcionar</translation>
         <translation>Você</translation>
     </message>
     <message>
-        <source>recalculating context ...</source>
-        <translation type="vanished">recalculando contexto...</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="878"/>
         <source>response stopped ...</source>
         <translation>resposta interrompida...</translation>
@@ -1115,37 +1107,37 @@ modelo instalado para funcionar</translation>
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation>Modelo &quot;%1&quot; instalado com sucesso.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>ERRO: O nome do modelo ($MODEL_NAME) está vazio.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>ERRO: A chave da API ($API_KEY) está vazia.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation>ERRO: A URL base ($BASE_URL) é inválida.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation>ERRO: Conflito com o modelo &quot;%1 (%2)&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation>Modelo &quot;%1 (%2)&quot; instalado com sucesso.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation>Modelo &quot;%1&quot; removido.</translation>
     </message>
@@ -1380,10 +1372,6 @@ modelo instalado para funcionar</translation>
         <translation>＋ Adicionar Coleção</translation>
     </message>
     <message>
-        <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">ERRO: O banco de dados do LocalDocs não é válido.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsView.qml" line="85"/>
         <source>&lt;h3&gt;ERROR: The LocalDocs database cannot be accessed or is not valid.&lt;/h3&gt;&lt;br&gt;&lt;i&gt;Note: You will need to restart after trying any of the following suggested fixes.&lt;/i&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Make sure that the folder set as &lt;b&gt;Download Path&lt;/b&gt; exists on the file system.&lt;/li&gt;&lt;li&gt;Check ownership as well as read and write permissions of the &lt;b&gt;Download Path&lt;/b&gt;.&lt;/li&gt;&lt;li&gt;If there is a &lt;b&gt;localdocs_v2.db&lt;/b&gt; file, check its ownership and read/write permissions, too.&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;If the problem persists and there are any &apos;localdocs_v*.db&apos; files present, as a last resort you can&lt;br&gt;try backing them up and removing them. You will have to recreate your collections, however.</source>
         <translation>&lt;h3&gt;ERRO: Não foi possível acessar o banco de dados do LocalDocs ou ele não é válido.&lt;/h3&gt;&lt;br&gt;&lt;i&gt;Observação: Será necessário reiniciar o aplicativo após tentar qualquer uma das seguintes correções sugeridas.&lt;/i&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Certifique-se de que a pasta definida como &lt;b&gt;Caminho de Download&lt;/b&gt; existe no sistema de arquivos.&lt;/li&gt;&lt;li&gt;Verifique a propriedade, bem como as permissões de leitura e gravação do &lt;b&gt;Caminho de Download&lt;/b&gt;.&lt;/li&gt;&lt;li&gt;Se houver um arquivo &lt;b&gt;localdocs_v2.db&lt;/b&gt;, verifique também sua propriedade e permissões de leitura/gravação.&lt;/li&gt;&lt;/ul&gt;&lt;br&gt;Se o problema persistir e houver algum arquivo &apos;localdocs_v*.db&apos; presente, como último recurso, você pode&lt;br&gt;tentar fazer backup deles e removê-los. No entanto, você terá que recriar suas coleções.</translation>
@@ -1561,12 +1549,12 @@ modelo instalado para funcionar</translation>
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>não é possível abrir &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>não é possível criar &quot;%1&quot;: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1288"/>
@@ -2179,13 +2167,6 @@ OBS.: Ao ativar este recurso, você estará enviando seus dados para o Datalake 
         <location filename="../src/qml/PopupDialog.qml" line="49"/>
         <source>Displayed when the popup is showing busy</source>
         <translation>Visível durante o processamento</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Padrão</translation>
     </message>
 </context>
 <context>

--- a/gpt4all-chat/translations/gpt4all_pt_BR.ts
+++ b/gpt4all-chat/translations/gpt4all_pt_BR.ts
@@ -371,23 +371,6 @@
         <translation>Compartilhar feedback e conversas</translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation>ERRO: O sistema de atualização não encontrou a Ferramenta de Manutenção&lt;br&gt;
-                   necessária para verificar atualizações!&lt;br&gt;&lt;br&gt;
-                   Você instalou este aplicativo usando o instalador online? Se sim,&lt;br&gt;
-                   o executável da Ferramenta de Manutenção deve estar localizado um diretório&lt;br&gt;
-                   acima de onde este aplicativo está instalado.&lt;br&gt;&lt;br&gt;
-                   Se você não conseguir iniciá-lo manualmente, será necessário&lt;br&gt;
-                   reinstalar o aplicativo.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>Mensagens de erro</translation>
@@ -421,6 +404,11 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>Modo Claro</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation>ERRO: O sistema de atualização não encontrou a Ferramenta de Manutenção necessária para verificar atualizações!&lt;br&gt;&lt;br&gt;Você instalou este aplicativo usando o instalador online? Se sim, o executável da Ferramenta de Manutenção deve estar localizado um diretório acima de onde este aplicativo está instalado.&lt;br&gt;&lt;br&gt;Se você não conseguir iniciá-lo manualmente, será necessário reinstalar o aplicativo.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="114"/>
@@ -2087,47 +2075,47 @@ Quando um modelo GPT4All responder a você e você tiver optado por participar, 
 OBS.: Ao ativar este recurso, você estará enviando seus dados para o Datalake de Código Aberto do GPT4All. Você não deve ter nenhuma expectativa de privacidade no chat quando este recurso estiver ativado. No entanto, você deve ter a expectativa de uma atribuição opcional, se desejar. Seus dados de chat estarão disponíveis para qualquer pessoa baixar e serão usados pela Nomic AI para melhorar os futuros modelos GPT4All. A Nomic AI manterá todas as informações de atribuição anexadas aos seus dados e você será creditado como colaborador em qualquer versão do modelo GPT4All que utilize seus dados!</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>Termos de participação</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>Descrição do que acontece ao participar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>Forneça um nome para atribuição (opcional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>Atribuição (opcional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>Fornecer atribuição</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>Ativar participação</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>Cancelar participação</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_ro_RO.ts
+++ b/gpt4all-chat/translations/gpt4all_ro_RO.ts
@@ -14,11 +14,6 @@
         <translation>Adaugă o Colecţie de documente</translation>
     </message>
     <message>
-        <source>Add a folder containing plain text files, PDFs, or Markdown. Configure
-                additional extensions in Settings.</source>
-        <translation type="vanished">Adaugă un folder care conţine fişiere în cu text-simplu, PDF sau Markdown. Extensii suplimentare pot fi specificate în Configurare.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddCollectionView.qml" line="78"/>
         <source>Add a folder containing plain text files, PDFs, or Markdown. Configure additional extensions in Settings.</source>
         <translation>Adaugă un folder cu fişiere în format text, PDF sau Markdown. Alte extensii pot fi specificate în Configurare.</translation>
@@ -244,12 +239,6 @@
         <translation>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENŢIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are acest sistem (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
-                hardware. Model requires more memory (%1 GB) than your system has available
-                (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENţIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are acest sistem (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddModelView.qml" line="716"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
@@ -264,11 +253,6 @@
         <location filename="../src/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>Descrie eroarea apărută în timpul descărcării</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
-                href=&quot;#eroare&quot;&gt;Eroare&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#eroare&quot;&gt;Eroare&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../src/qml/AddModelView.qml" line="527"/>
@@ -385,17 +369,6 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="26"/>
         <source>opt-in to share feedback/conversations</source>
         <translation>optional: partajarea (share) de comentarii/conversatii</translation>
-    </message>
-    <message>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                to check for updates!&lt;br&gt;&lt;br&gt;
-                Did you install this application using the online installer? If so,&lt;br&gt;
-                the MaintenanceTool executable should be located one directory&lt;br&gt;
-                above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have
-                to&lt;br&gt;
-                reinstall.</source>
-        <translation type="vanished">EROARE: Sistemul de actualizare nu poate găsi componenta MaintenanceTool&lt;br&gt; necesară căutării de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dacă da,&lt;br&gt; atunci MaintenanceTool trebuie să fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dacă nu poate fi lansată manual, atunci programul trebuie reinstalat.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
@@ -608,16 +581,6 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="506"/>
         <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.</source>
         <translation>Activează pe localhost un Server compatibil cu Open-AI. ATENŢIE: Creşte consumul de resurse.</translation>
-    </message>
-    <message>
-        <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB
-                per chat.</source>
-        <translation type="vanished">Salvează pe disc starea modelului pentru încărcare mai rapidă. ATENŢIE: Consumă ~2GB/conversaţie.</translation>
-    </message>
-    <message>
-        <source>Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased
-                resource usage.</source>
-        <translation type="vanished">Activează pe localhost un Server compatibil cu Open-AI. ATENŢIE: Creşte consumul de resurse.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="522"/>
@@ -882,11 +845,6 @@
         <translation>Niciun model instalat</translation>
     </message>
     <message>
-        <source>GPT4All requires that you install at least one
-                model to get started</source>
-        <translation type="vanished">GPT4All necesită cel puţin un model pentru a putea porni</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="58"/>
         <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;%1&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
         <translation>&lt;h3&gt;EROARE la încărcarea
@@ -940,10 +898,6 @@ model to get started</source>
         <location filename="../src/qml/ChatView.qml" line="854"/>
         <source>You</source>
         <translation>Tu</translation>
-    </message>
-    <message>
-        <source>recalculating context ...</source>
-        <translation type="vanished">se recalculează contextul...</translation>
     </message>
     <message>
         <location filename="../src/qml/ChatView.qml" line="878"/>
@@ -1319,10 +1273,6 @@ model to get started</source>
         <translation>nomic.ai</translation>
     </message>
     <message>
-        <source>GitHub</source>
-        <translation type="vanished">GitHub</translation>
-    </message>
-    <message>
         <location filename="../src/qml/HomeView.qml" line="282"/>
         <source>Subscribe to Newsletter</source>
         <translation>Abonare la Newsletter</translation>
@@ -1351,11 +1301,6 @@ model to get started</source>
         <translation>Extensii compatibile de fişier</translation>
     </message>
     <message>
-        <source>Comma-separated list. LocalDocs will only attempt to process files with these
-                extensions.</source>
-        <translation type="vanished">Extensiile, separate prin virgulă. LocalDocs va încerca procesarea numai a fişierelor cu aceste extensii.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="100"/>
         <source>Embedding</source>
         <translation>Embedding</translation>
@@ -1366,20 +1311,9 @@ model to get started</source>
         <translation>Folosesc Nomic Embed API</translation>
     </message>
     <message>
-        <source>Embed documents using the fast Nomic API instead of a private local model.
-                Requires restart.</source>
-        <translation type="vanished">Embedding pe documente folosind API de la Nomic în locul unui model local. Necesită repornire.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="130"/>
         <source>Nomic API Key</source>
         <translation>Cheia API Nomic</translation>
-    </message>
-    <message>
-        <source>API key to use for Nomic Embed. Get one from the Atlas &lt;a
-                href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;API keys page&lt;/a&gt;.
-                Requires restart.</source>
-        <translation type="vanished">Cheia API de utilizat cu Nomic Embed. Obţine o cheie prin Atlas: &lt;a href=&quot;https://atlas.nomic.ai/cli-login&quot;&gt;pagina cheilor API&lt;/a&gt; Necesită repornire.</translation>
     </message>
     <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="165"/>
@@ -1452,34 +1386,14 @@ model to get started</source>
         <translation>Numărul maxim al citatelor ce corespund şi care vor fi adăugate la contextul pentru prompt. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea cauzează generare lentă.</translation>
     </message>
     <message>
-        <source>
-                Values too large may cause localdocs failure, extremely slow responses or
-                failure to respond at all. Roughly speaking, the {N chars x N snippets} are added to
-                the model&apos;s context window. More info &lt;a
-                href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">
-                Valori prea mari pot cauza erori cu LocalDocs, replici lente sau absenţa lor completă. în mare, numărul {N caractere x N citate} este adăugat la Context Window/Size/Length a modelului. Mai multe informaţii: &lt;a href=&quot;https://docs.gpt4all.io/gpt4all_desktop/localdocs.html&quot;&gt;aici&lt;/a&gt;.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="266"/>
         <source>Document snippet size (characters)</source>
         <translation>Lungimea (în caractere) a citatelor din documente</translation>
     </message>
     <message>
-        <source>Number of characters per document snippet. Larger numbers increase likelihood of
-                factual responses, but also result in slower generation.</source>
-        <translation type="vanished">numărul caracterelor din fiecare citat. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea pot cauza generare lentă.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/LocalDocsSettings.qml" line="292"/>
         <source>Max document snippets per prompt</source>
         <translation>Numărul maxim de citate per prompt</translation>
-    </message>
-    <message>
-        <source>Max best N matches of retrieved document snippets to add to the context for
-                prompt. Larger numbers increase likelihood of factual responses, but also result in
-                slower generation.</source>
-        <translation type="vanished">Numărul maxim al citatelor ce corespund şi care vor fi adăugate la contextul pentru prompt. Numere mari amplifică probabilitatea unor replici corecte, dar de asemenea pot cauza generare lentă.</translation>
     </message>
 </context>
 <context>
@@ -1498,10 +1412,6 @@ model to get started</source>
         <location filename="../src/qml/LocalDocsView.qml" line="71"/>
         <source>＋ Add Collection</source>
         <translation>＋ Adaugă o Colecţie</translation>
-    </message>
-    <message>
-        <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">EROARE: Baza de date LocalDocs nu e validă.</translation>
     </message>
     <message>
         <location filename="../src/qml/LocalDocsView.qml" line="85"/>
@@ -1645,31 +1555,15 @@ model to get started</source>
 <context>
     <name>ModelList</name>
     <message>
-        <source>
-                &lt;ul&gt;&lt;li&gt;Requires personal OpenAI API
-                key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
-                OpenAI!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
-                disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
-                OpenAI&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
-                href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;here.&lt;/a&gt;&lt;/li&gt;</source>
-        <translation type="vanished">
-                &lt;ul&gt;&lt;li&gt;Necesită o cheie API OpenAI personală. &lt;/li&gt;&lt;li&gt;ATENţIE: Conversaţiile tale vor fi trimise la OpenAI! &lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local) &lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu OpenAI&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://platform.openai.com/account/api-keys&quot;&gt;aici.&lt;/a&gt;&lt;/li&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;
-                %1</source>
-        <translation type="vanished">&lt;strong&gt;Modelul ChatGPT GPT-3.5 Turbo al OpenAI&lt;/strong&gt;&lt;br&gt; %1</translation>
-    </message>
-    <message>
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>nu se poate deschide „%1”: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>nu se poate crea „%1”: %2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1288"/>
@@ -1736,29 +1630,6 @@ model to get started</source>
         <source>&lt;strong&gt;Created by %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
         <translation>&lt;strong&gt;Creat de către %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informaţii pot fi găsite la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
     </message>
-    <message>
-        <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does
-                not guarantee API key access. Contact OpenAI for more info.</source>
-        <translation type="vanished">&lt;br&gt;&lt;br&gt;&lt;i&gt;* Chiar dacă plăteşti la OpenAI pentru ChatGPT-4, aceasta nu garantează accesul la cheia API. Contactează OpenAI pentru mai multe informaţii.</translation>
-    </message>
-    <message>
-        <source>
-                &lt;ul&gt;&lt;li&gt;Requires personal Mistral API
-                key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to
-                Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on
-                disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with
-                Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a
-                href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
-        <translation type="vanished">
-                &lt;ul&gt;&lt;li&gt;Necesită cheia personală Mistral API. &lt;/li&gt;&lt;li&gt;ATENţIE: Conversaţiile tale vor fi trimise la Mistral!&lt;/li&gt;&lt;li&gt;Cheia ta API va fi stocată pe disc (local)&lt;/li&gt;&lt;li&gt;Va fi utilizată numai pentru comunicarea cu Mistral&lt;/li&gt;&lt;li&gt;Poţi solicita o cheie API aici: &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;aici&lt;/a&gt;.&lt;/li&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;Created by
-                %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Published on %2.&lt;li&gt;This model
-                has %3 likes.&lt;li&gt;This model has %4 downloads.&lt;li&gt;More info can be found
-                &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;here.&lt;/a&gt;&lt;/ul&gt;</source>
-        <translation type="vanished">&lt;strong&gt;Creat de către %1.&lt;/strong&gt;&lt;br&gt;&lt;ul&gt;&lt;li&gt;Publicat in: %2.&lt;li&gt;Acest model are %3 Likes.&lt;li&gt;Acest model are %4 download-uri.&lt;li&gt;Mai multe informaţii pot fi găsite la: &lt;a href=&quot;https://huggingface.co/%5&quot;&gt;aici.&lt;/a&gt;&lt;/ul&gt;</translation>
-    </message>
 </context>
 <context>
     <name>ModelSettings</name>
@@ -1798,11 +1669,6 @@ model to get started</source>
         <translation>System Prompt</translation>
     </message>
     <message>
-        <source>Prefixed at the beginning of every conversation. Must contain the appropriate
-                framing tokens.</source>
-        <translation type="vanished">Plasat la Începutul fiecărei conversaţii. Trebuie să conţină token-uri(le) adecvate de Încadrare.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ModelSettings.qml" line="205"/>
         <source>Prompt Template</source>
         <translation>Prompt Template</translation>
@@ -1811,11 +1677,6 @@ model to get started</source>
         <location filename="../src/qml/ModelSettings.qml" line="206"/>
         <source>The template that wraps every prompt.</source>
         <translation>Standardul de formulare a fiecărui prompt.</translation>
-    </message>
-    <message>
-        <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s
-                input.</source>
-        <translation type="vanished">Trebuie să conţină textul &quot;%1&quot; care va fi Înlocuit cu ceea ce scrie utilizatorul.</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelSettings.qml" line="255"/>
@@ -1848,12 +1709,6 @@ model to get started</source>
         <translation>Numărul token-urilor de input şi de output văzute de model.</translation>
     </message>
     <message>
-        <source>Maximum combined prompt/response tokens before information is lost.
-                Using more context than the model was trained on will yield poor results.
-                NOTE: Does not take effect until you reload the model.</source>
-        <translation type="vanished">Numărul maxim combinat al token-urilor în prompt+replică înainte de a se pierde informaţie. Utilizarea unui context mai mare decât cel cu care a fost instruit modelul va întoarce rezultate mai slabe. NOTĂ: Nu are efect până la reîncărcarea modelului.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ModelSettings.qml" line="412"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
@@ -1864,11 +1719,6 @@ model to get started</source>
         <translation>Libertatea/Confuzia din replica modelului. Mai mare -&gt; mai multă libertate.</translation>
     </message>
     <message>
-        <source>Temperature increases the chances of choosing less likely tokens.
-                NOTE: Higher temperature gives more creative but less predictable outputs.</source>
-        <translation type="vanished">Temperatura creşte probabilitatea de alegere a unor token-uri puţin probabile. NOTĂ: O temperatură tot mai înaltă determină replici tot mai creative şi mai puţin predictibile.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ModelSettings.qml" line="458"/>
         <source>Top-P</source>
         <translation>Top-P</translation>
@@ -1877,11 +1727,6 @@ model to get started</source>
         <location filename="../src/qml/ModelSettings.qml" line="459"/>
         <source>Nucleus Sampling factor. Lower -&gt; more predictable.</source>
         <translation>Factorul de Nucleus Sampling. Mai mic -&gt; predictibilitate mai mare.</translation>
-    </message>
-    <message>
-        <source>Only the most likely tokens up to a total probability of top_p can be chosen.
-                NOTE: Prevents choosing highly unlikely tokens.</source>
-        <translation type="vanished">Pot fi alese numai cele mai probabile token-uri a căror probabilitate totală este Top-P. NOTĂ: Se evită selectarea token-urilor foarte improbabile.</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelSettings.qml" line="159"/>
@@ -1976,11 +1821,6 @@ NOTE: Does not take effect until you reload the model.</source>
         <translation>Cât de multe layere ale modelului să fie încărcate în VRAM. Valori mici trebuie folosite dacă GPT4All rămâne fără VRAM în timp ce încarcă modelul. Valorile tot mai mici cresc utilizarea CPU şi a RAM şi încetinesc inferenţa. NOTĂ: Nu are efect până la reîncărcarea modelului.</translation>
     </message>
     <message>
-        <source>Amount of prompt tokens to process at once.
-                NOTE: Higher values can speed up reading prompts but will use more RAM.</source>
-        <translation type="vanished">numărul token-urilor procesate simultan. NOTĂ: Valori tot mai mari pot accelera citirea prompt-urilor, dar şi utiliza mai multă RAM.</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ModelSettings.qml" line="690"/>
         <source>Repeat Penalty</source>
         <translation>Penalizarea pentru repetare</translation>
@@ -2009,13 +1849,6 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../src/qml/ModelSettings.qml" line="782"/>
         <source>Number of model layers to load into VRAM.</source>
         <translation>Numărul layerelor modelului ce vor fi Încărcate în VRAM.</translation>
-    </message>
-    <message>
-        <source>How many model layers to load into VRAM. Decrease this if GPT4All runs out of
-                VRAM while loading this model.
-                Lower values increase CPU load and RAM usage, and make inference slower.
-                NOTE: Does not take effect until you reload the model.</source>
-        <translation type="vanished">Cât de multe layere ale modelului să fie încărcate în VRAM. Valori mici trebuie folosite dacă GPT4All rămâne fără VRAM în timp ce încarcă modelul. Valorile tot mai mici cresc utilizarea CPU şi a RAM şi încetinesc inferenţa. NOTĂ: Nu are efect până la reîncărcarea modelului.</translation>
     </message>
 </context>
 <context>
@@ -2106,17 +1939,6 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../src/qml/ModelsView.qml" line="272"/>
         <source>Install online model</source>
         <translation>Instalez un model din online</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a
-                href=&quot;#error&quot;&gt;Error&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;1&quot;&gt;&lt;a href=&quot;#eroare&quot;&gt;Eroare&lt;/a&gt;&lt;/strong&gt;&lt;/font&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your
-                hardware. Model requires more memory (%1 GB) than your system has available
-                (%2).&lt;/strong&gt;&lt;/font&gt;</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;ATENţIE: Nerecomandat pentru acest hardware. Modelul necesită mai multă memorie (%1 GB) decât are sistemul tău (%2).&lt;/strong&gt;&lt;/font&gt;</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelsView.qml" line="496"/>
@@ -2463,14 +2285,6 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <translation>Bun venit!</translation>
     </message>
     <message>
-        <source>### Release notes
-                %1### Contributors
-                %2</source>
-        <translation type="vanished">### Despre versiune
-                %1### Contributori
-                %2</translation>
-    </message>
-    <message>
         <location filename="../src/qml/StartupDialog.qml" line="71"/>
         <source>Release notes</source>
         <translation>Despre versiune</translation>
@@ -2528,20 +2342,15 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
                 care foloseşte datele tale!</translation>
     </message>
     <message>
-        <source>### Release notes
-%1### Contributors
-%2</source>
-        <translation type="vanished">### Despre versiune
-                %1### Contributori
-                %2</translation>
-    </message>
-    <message>
         <location filename="../src/qml/StartupDialog.qml" line="67"/>
         <source>### Release Notes
 %1&lt;br/&gt;
 ### Contributors
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>### Despre versiune
+%1&lt;br/&gt;
+### Contributori
+%2</translation>
     </message>
     <message>
         <location filename="../src/qml/StartupDialog.qml" line="87"/>
@@ -2652,11 +2461,6 @@ care foloseşte datele tale!</translation>
 <context>
     <name>SwitchModelDialog</name>
     <message>
-        <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current
-                conversation. Do you wish to continue?</source>
-        <translation type="vanished">&lt;b&gt;Atenţie:&lt;/b&gt; schimbarea modelului va şterge conversaţia curentă. Confirmi aceasta?</translation>
-    </message>
-    <message>
         <location filename="../src/qml/SwitchModelDialog.qml" line="22"/>
         <source>&lt;b&gt;Warning:&lt;/b&gt; changing the model will erase the current conversation. Do you wish to continue?</source>
         <translation>&lt;b&gt;Atenţie:&lt;/b&gt; schimbarea modelului va şterge conversaţia curentă. Confirmi aceasta?</translation>
@@ -2714,36 +2518,9 @@ care foloseşte datele tale!</translation>
 <context>
     <name>main</name>
     <message>
-        <source>
-                &lt;h3&gt;Encountered an error starting
-                up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware
-                detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet
-                the minimal requirements to run this program. In particular, it does not support AVX
-                intrinsics which this program requires to successfully run a modern large language
-                model. The only soluţion at this time is to upgrade your hardware to a more modern
-                CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a
-                href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-        <translation type="vanished">
-                &lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, procesorul (CPU) nu întruneşte condiţiile minime pentru a rula acest program. În particular, nu suportă instrucţiunile AVX pe care programul le necesită pentru a integra un model conversaţional modern. În acest moment, unica soluţie este să îţi aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informaţii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/main.qml" line="23"/>
         <source>GPT4All v%1</source>
         <translation>GPT4All v%1</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;Encountered an error starting
-                up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Inability to access settings
-                file.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the
-                program from accessing the settings file. This could be caused by incorrect
-                permissions in the local app config directory where the settings file is located.
-                Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord
-                channel&lt;/a&gt; for help.</source>
-        <translation type="vanished">&lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Nu poate fi accesat fişierul de configurare a programului.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, ceva împiedică programul în a accesa acel fişier. Cauza poate fi un set de permisiuni incorecte pe directorul/folderul local de configurare unde se află acel fişier. Poţi parcurge canalul nostru &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;Discord&lt;/a&gt; unde vei putea primi asistenţă.</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run this program. In particular, it does not support AVX intrinsics which this program requires to successfully run a modern large language model. The only soluţion at this time is to upgrade your hardware to a more modern CPU.&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-        <translation type="vanished">&lt;h3&gt;A apărut o eroare la iniţializare:; &lt;/h3&gt;&lt;br&gt;&lt;i&gt;&quot;Hardware incompatibil. &quot;&lt;/i&gt;&lt;br&gt;&lt;br&gt;Din păcate, procesorul (CPU) nu întruneşte condiţiile minime pentru a rula acest program. În particular, nu suportă instrucţiunile AVX pe care programul le necesită pentru a integra un model conversaţional modern. În acest moment, unica soluţie este să îţi aduci la zi sistemul hardware cu un CPU mai recent.&lt;br&gt;&lt;br&gt;Aici sunt mai multe informaţii: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/main.qml" line="111"/>

--- a/gpt4all-chat/translations/gpt4all_ro_RO.ts
+++ b/gpt4all-chat/translations/gpt4all_ro_RO.ts
@@ -371,6 +371,11 @@
         <translation>optional: partajarea (share) de comentarii/conversatii</translation>
     </message>
     <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation>EROARE: Sistemul de Update nu poate găsi componenta MaintenanceTool necesară căutării de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dacă da, atunci MaintenanceTool trebuie să fie un nivel mai sus de folderul unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dacă nu poate fi lansată manual, atunci programul trebuie reinstalat.</translation>
+    </message>
+    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>Eroare</translation>
@@ -429,17 +434,6 @@
         <source>The compute device used for text generation. &quot;Auto&quot; uses Vulkan or
                 Metal.</source>
         <translation type="vanished">Dispozitivul de calcul utilizat pentru generarea de text. &quot;Auto&quot; apelează la Vulkan sau la Metal.</translation>
-    </message>
-    <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation>EROARE: Sistemul de Update nu poate găsi componenta MaintenanceTool&lt;br&gt; necesară căutării de versiuni noi!&lt;br&gt;&lt;br&gt; Ai instalat acest program folosind kitul online? Dacă da,&lt;br&gt; atunci MaintenanceTool trebuie să fie un nivel mai sus de folderul&lt;br&gt; unde ai instalat programul.&lt;br&gt;&lt;br&gt; Dacă nu poate fi lansată manual, atunci programul trebuie reinstalat.</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="151"/>
@@ -2111,103 +2105,60 @@ NOTE: Does not take effect until you reload the model.</source>
         <translation>Contribuie cu date/informaţii la componenta Open-source DataLake a GPT4All.</translation>
     </message>
     <message>
-        <source>By enabling this feature, you will be able to participate in the democratic
-                process of training a large language model by contributing data for future model
-                improvements.
-
-                When a GPT4All model responds to you and you have opted-in, your conversation will
-                be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its
-                response. If you dislike a response, you can suggest an alternative response. This
-                data will be collected and aggregated in the GPT4All Datalake.
-
-                NOTE: By turning on this feature, you will be sending your data to the GPT4All Open
-                Source Datalake. You should have no expectation of chat privacy when this feature is
-                enabled. You should; however, have an expectation of an optional attribution if you
-                wish. Your chat data will be openly available for anyone to download and will be
-                used by Nomic AI to improve future GPT4All models. Nomic AI will retain all
-                attribution information attached to your data and you will be credited as a
-                contributor to any GPT4All model release that uses your data!</source>
-        <translation type="vanished">Dacă activezi această funcţionalitate, vei participa la procesul democratic
-                de instruire a unui model LLM prin contribuţia ta cu date la îmbunătăţirea modelului.
-
-                Când un model în GPT4All Îţi răspunde şi îi accepţi replica, atunci conversaţia va fi
-                trimisă la componenta Open-source DataLake a GPT4All. Mai mult - îi poţi aprecia replica,
-                Dacă răspunsul Nu Îti Place, poţi sugera unul alternativ. 
-                Aceste date vor fi colectate şi agregate în componenta DataLake a GPT4All.
-
-                NOTă: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta
-                DataLake a GPT4All. Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi
-                această funcţionalitate. Totuşi, te poţi aştepta la a beneficia de apreciere - opţional, dacă doreşti.
-                Datele din conversaţie vor fi disponibile pentru oricine vrea să le descarce şi vor fi
-                utilizate de către Nomic AI pentru a îmbunătăţi modele viitoare în GPT4All. Nomic AI va păstra
-                toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
-                participant contribuitor la orice lansare a unui model GPT4All care foloseşte datele tale!</translation>
-    </message>
-    <message>
         <location filename="../src/qml/NetworkDialog.qml" line="55"/>
         <source>By enabling this feature, you will be able to participate in the democratic process of training a large language model by contributing data for future model improvements.
 
 When a GPT4All model responds to you and you have opted-in, your conversation will be sent to the GPT4All Open Source Datalake. Additionally, you can like/dislike its response. If you dislike a response, you can suggest an alternative response. This data will be collected and aggregated in the GPT4All Datalake.
 
 NOTE: By turning on this feature, you will be sending your data to the GPT4All Open Source Datalake. You should have no expectation of chat privacy when this feature is enabled. You should; however, have an expectation of an optional attribution if you wish. Your chat data will be openly available for anyone to download and will be used by Nomic AI to improve future GPT4All models. Nomic AI will retain all attribution information attached to your data and you will be credited as a contributor to any GPT4All model release that uses your data!</source>
-        <translation>Dacă activezi această funcţionalitate, vei participa la procesul democratic
-                de instruire a unui model LLM prin contribuţia ta cu date la îmbunătăţirea modelului.
+        <translation>Dacă activezi această funcţionalitate, vei participa la procesul democratic de instruire a unui model LLM prin contribuţia ta cu date la îmbunătăţirea modelului.
 
-                Când un model în GPT4All îţi răspunde şi îi accepţi replica, atunci conversaţia va fi
-                trimisă la componenta Open-source DataLake a GPT4All. Mai mult - îi poţi aprecia replica,
-                Dacă răspunsul Nu Îti Place, poţi sugera unul alternativ. 
-                Aceste date vor fi colectate şi agregate în componenta DataLake a GPT4All.
+Când un model în GPT4All îţi răspunde şi îi accepţi replica, atunci conversaţia va fi trimisă la componenta Open-source DataLake a GPT4All. Mai mult - îi poţi aprecia replica, Dacă răspunsul Nu Îti Place, poţi sugera unul alternativ. Aceste date vor fi colectate şi agregate în componenta DataLake a GPT4All.
 
-                NOTĂ: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta
-                DataLake a GPT4All. Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi
-                această funcţionalitate. Totuşi, te poţi aştepta la a beneficia de apreciere - opţional, dacă doreşti.
-                Datele din conversaţie vor fi disponibile pentru oricine vrea să le descarce şi vor fi
-                utilizate de către Nomic AI pentru a îmbunătăţi modele viitoare în GPT4All. Nomic AI va păstra
-                toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca
-                participant contribuitor la orice lansare a unui model GPT4All care foloseşte datele tale!</translation>
+NOTĂ: Dacă activezi această funcţionalitate, vei trimite datele tale la componenta DataLake a GPT4All. Atunci nu te vei putea aştepta la intimitatea (privacy) conversaţiei dacă activezi această funcţionalitate. Totuşi, te poţi aştepta la a beneficia de apreciere - opţional, dacă doreşti. Datele din conversaţie vor fi disponibile pentru oricine vrea să le descarce şi vor fi utilizate de către Nomic AI pentru a îmbunătăţi modele viitoare în GPT4All. Nomic AI va păstra toate informaţiile despre atribuire asociate datelor tale şi vei fi menţionat ca participant contribuitor la orice lansare a unui model GPT4All care foloseşte datele tale!</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>Termenii pentru participare</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>Descrie ce se întâmplă când participi</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>Specifică o denumire pentru această apreciere (opţional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>Apreciere (opţional)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>Apreciază</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>Activează</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>Activează participarea</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>Anulează participarea</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_zh_CN.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_CN.ts
@@ -87,10 +87,6 @@
         <translation>用于发现和筛选可下载模型的文本字段</translation>
     </message>
     <message>
-        <source>Searching · </source>
-        <translation type="vanished">搜索中</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddModelView.qml" line="171"/>
         <source>Initiate model discovery and filtering</source>
         <translation>启动模型发现和过滤</translation>
@@ -121,10 +117,6 @@
         <translation>近期</translation>
     </message>
     <message>
-        <source>Sort by: </source>
-        <translation type="vanished">排序：</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddModelView.qml" line="216"/>
         <source>Asc</source>
         <translation>升序</translation>
@@ -135,21 +127,9 @@
         <translation>倒序</translation>
     </message>
     <message>
-        <source>Sort dir: </source>
-        <translation type="vanished">排序目录:</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddModelView.qml" line="252"/>
         <source>None</source>
         <translation>无</translation>
-    </message>
-    <message>
-        <source>Limit: </source>
-        <translation type="vanished">限制：</translation>
-    </message>
-    <message>
-        <source>Network error: could not retrieve http://gpt4all.io/models/models3.json</source>
-        <translation type="vanished">网络问题：无法访问 http://gpt4all.io/models/models3.json</translation>
     </message>
     <message>
         <location filename="../src/qml/AddModelView.qml" line="101"/>
@@ -295,25 +275,9 @@
         <translation>？</translation>
     </message>
     <message>
-        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a href=&quot;#error&quot;&gt;错误&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/qml/AddModelView.qml" line="508"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>描述下载过程中发生的错误</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
-    </message>
-    <message>
-        <source> Model requires more memory (</source>
-        <translation type="vanished">需要更多内存（</translation>
-    </message>
-    <message>
-        <source> GB) than your system has available (</source>
-        <translation type="vanished">你的系统需要 (</translation>
     </message>
     <message>
         <location filename="../src/qml/AddModelView.qml" line="527"/>
@@ -372,10 +336,6 @@
         <location filename="../src/qml/AddModelView.qml" line="711"/>
         <source>RAM required</source>
         <translation>RAM 需要</translation>
-    </message>
-    <message>
-        <source> GB</source>
-        <translation type="vanished">GB</translation>
     </message>
     <message>
         <location filename="../src/qml/AddModelView.qml" line="733"/>
@@ -617,11 +577,7 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local API Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Local Server</source>
-        <translation type="vanished">开启本地服务</translation>
+        <translation>开启本地 API 服务</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="506"/>
@@ -666,14 +622,6 @@
         <location filename="../src/chat.cpp" line="38"/>
         <source>Server Chat</source>
         <translation>服务器对话</translation>
-    </message>
-    <message>
-        <source>Prompt: </source>
-        <translation type="vanished">提示词：</translation>
-    </message>
-    <message>
-        <source>Response: </source>
-        <translation type="vanished">响应：</translation>
     </message>
 </context>
 <context>
@@ -788,14 +736,6 @@
 <context>
     <name>ChatView</name>
     <message>
-        <source>&lt;h3&gt;Encountered an error loading model:&lt;/h3&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;h3&gt;加载模型时遇到错误:&lt;/h3&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;br&gt;&lt;br&gt;Model loading failures can happen for a variety of reasons, but the most common causes include a bad file format, an incomplete or corrupted download, the wrong file type, not enough system RAM or an incompatible model type. Here are some suggestions for resolving the problem:&lt;br&gt;&lt;ul&gt;&lt;li&gt;Ensure the model file has a compatible format and type&lt;li&gt;Check the model file is complete in the download folder&lt;li&gt;You can find the download folder in the settings dialog&lt;li&gt;If you&apos;ve sideloaded the model ensure the file is not corrupt by checking md5sum&lt;li&gt;Read more about what models are supported in our &lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;documentation&lt;/a&gt; for the gui&lt;li&gt;Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help</source>
-        <translation type="vanished">lt;br&gt;&lt;br&gt;模型加载失败可能由多种原因造成，但最常见的原因包括文件格式错误、下载不完整或损坏、文件类型错误、系统 RAM 不足或模型类型不兼容。以下是解决该问题的一些建议：&lt;br&gt;&lt;ul&gt;&lt;li&gt;确保模型文件具有兼容的格式和类型&lt;li&gt;检查下载文件夹中的模型文件是否完整&lt;li&gt;您可以在设置对话框中找到下载文件夹&lt;li&gt;如果您已侧载模型，请通过检查 md5sum 确保文件未损坏&lt;li&gt;在我们的&lt;a href=&quot;https://docs.gpt4all.io/&quot;&gt;文档&lt;/a&gt;中了解有关支持哪些模型的更多信息对于 gui&lt;li&gt;查看我们的&lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord 频道&lt;/a&gt; 获取帮助</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="77"/>
         <source>&lt;h3&gt;Warning&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</source>
         <translation>&lt;h3&gt;警告&lt;/h3&gt;&lt;p&gt;%1&lt;/p&gt;</translation>
@@ -819,10 +759,6 @@
         <location filename="../src/qml/ChatView.qml" line="101"/>
         <source>Code copied to clipboard.</source>
         <translation>复制代码到剪切板</translation>
-    </message>
-    <message>
-        <source>Response: </source>
-        <translation type="vanished">响应：</translation>
     </message>
     <message>
         <location filename="../src/qml/ChatView.qml" line="231"/>
@@ -875,14 +811,6 @@
         <translation>没找到: %1</translation>
     </message>
     <message>
-        <source>Reload · </source>
-        <translation type="vanished">重载· </translation>
-    </message>
-    <message>
-        <source>Loading · </source>
-        <translation type="vanished">载入中· </translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="463"/>
         <source>The top item is the current model</source>
         <translation>当前模型的最佳选项</translation>
@@ -902,14 +830,6 @@
         <location filename="../src/qml/ChatView.qml" line="568"/>
         <source>add collections of documents to the chat</source>
         <translation>将文档集合添加到聊天中</translation>
-    </message>
-    <message>
-        <source>Load · </source>
-        <translation type="vanished">加载· </translation>
-    </message>
-    <message>
-        <source> (default) →</source>
-        <translation type="vanished">(默认) →</translation>
     </message>
     <message>
         <location filename="../src/qml/ChatView.qml" line="738"/>
@@ -963,29 +883,9 @@ model to get started</source>
         <translation>您</translation>
     </message>
     <message>
-        <source>Busy indicator</source>
-        <translation type="vanished">繁忙程度</translation>
-    </message>
-    <message>
-        <source>The model is thinking</source>
-        <translation type="vanished">模型在思考</translation>
-    </message>
-    <message>
-        <source>recalculating context ...</source>
-        <translation type="vanished">重新生成上下文...</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ChatView.qml" line="878"/>
         <source>response stopped ...</source>
         <translation>响应停止...</translation>
-    </message>
-    <message>
-        <source>retrieving localdocs: </source>
-        <translation type="vanished">检索本地文档：</translation>
-    </message>
-    <message>
-        <source>searching localdocs: </source>
-        <translation type="vanished">检索本地文档：</translation>
     </message>
     <message>
         <location filename="../src/qml/ChatView.qml" line="881"/>
@@ -1202,37 +1102,37 @@ model to get started</source>
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation>模型 &quot;%1&quot; 安装成功</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>错误：$MODEL_NAME 为空</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>错误：$API_KEY为空</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation>错误：$BASE_URL 非法</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation>错误: 模型 &quot;%1 (%2)&quot; 有冲突.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation>模型 &quot;%1 (%2)&quot; 安装成功.</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation>模型 &quot;%1&quot; 已删除.</translation>
     </message>
@@ -1466,10 +1366,6 @@ model to get started</source>
         <translation>＋ 添加集合</translation>
     </message>
     <message>
-        <source>ERROR: The LocalDocs database is not valid.</source>
-        <translation type="vanished">错误: 本地文档数据库错误.</translation>
-    </message>
-    <message>
         <location filename="../qml/LocalDocsView.qml" line="85"/>
         <location filename="../../build_gpt4all-chat_Desktop_Qt_6_7_2/gpt4all/qml/LocalDocsView.qml" line="85"/>
         <source></source>
@@ -1616,12 +1512,12 @@ model to get started</source>
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>无法打开“%1”：%2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>无法创建“%1”：%2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1288"/>
@@ -1674,34 +1570,14 @@ model to get started</source>
         <translation>&lt;strong&gt;连接到与 OpenAI 兼容的 API 服务器&lt;/strong&gt;&lt;br&gt; %1</translation>
     </message>
     <message>
-        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-3.5 Turbo&lt;/strong&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/modellist.cpp" line="1598"/>
         <source>&lt;br&gt;&lt;br&gt;&lt;i&gt;* Even if you pay OpenAI for ChatGPT-4 this does not guarantee API key access. Contact OpenAI for more info.</source>
         <translation>&lt;br&gt;&lt;br&gt;&lt;i&gt;* 即使您为ChatGPT-4向OpenAI付款，这也不能保证API密钥访问。联系OpenAI获取更多信息。</translation>
     </message>
     <message>
-        <source>&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;strong&gt;OpenAI&apos;s ChatGPT model GPT-4&lt;/strong&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/modellist.cpp" line="1625"/>
         <source>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</source>
         <translation>&lt;ul&gt;&lt;li&gt;Requires personal Mistral API key.&lt;/li&gt;&lt;li&gt;WARNING: Will send your chats to Mistral!&lt;/li&gt;&lt;li&gt;Your API key will be stored on disk&lt;/li&gt;&lt;li&gt;Will only be used to communicate with Mistral&lt;/li&gt;&lt;li&gt;You can apply for an API key &lt;a href=&quot;https://console.mistral.ai/user/api-keys&quot;&gt;here&lt;/a&gt;.&lt;/li&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;strong&gt;Mistral Tiny model&lt;/strong&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;strong&gt;Mistral Small model&lt;/strong&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;strong&gt;Mistral Medium model&lt;/strong&gt;&lt;br&gt;</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="2138"/>
@@ -1765,11 +1641,6 @@ model to get started</source>
         <location filename="../src/qml/ModelSettings.qml" line="210"/>
         <source>Must contain the string &quot;%1&quot; to be replaced with the user&apos;s input.</source>
         <translation>必须包含字符串 &quot;%1&quot; 替换为用户的&apos;s 输入.</translation>
-    </message>
-    <message>
-        <source>Add
-optional image</source>
-        <translation type="vanished">添加可选图片</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelSettings.qml" line="255"/>
@@ -2076,25 +1947,9 @@ NOTE: Does not take effect until you reload the model.</source>
         <translation>？</translation>
     </message>
     <message>
-        <source>&lt;a href=&quot;#error&quot;&gt;Error&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a href=&quot;#错误&quot;&gt;错误&lt;/a&gt;</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ModelsView.qml" line="288"/>
         <source>Describes an error that occurred when downloading</source>
         <translation>描述下载时发生的错误</translation>
-    </message>
-    <message>
-        <source>&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;WARNING: Not recommended for your hardware.</source>
-        <translation type="vanished">&lt;strong&gt;&lt;font size=&quot;2&quot;&gt;警告: 你的硬件不推荐.</translation>
-    </message>
-    <message>
-        <source> Model requires more memory (</source>
-        <translation type="vanished">模型需要更多内存(</translation>
-    </message>
-    <message>
-        <source> GB) than your system has available (</source>
-        <translation type="vanished">GB) 你的系统需要 (</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelsView.qml" line="307"/>
@@ -2158,10 +2013,6 @@ NOTE: Does not take effect until you reload the model.</source>
         <location filename="../src/qml/ModelsView.qml" line="491"/>
         <source>RAM required</source>
         <translation>需要 RAM</translation>
-    </message>
-    <message>
-        <source> GB</source>
-        <translation type="vanished"> GB</translation>
     </message>
     <message>
         <location filename="../src/qml/ModelsView.qml" line="513"/>
@@ -2316,13 +2167,6 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
     </message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">默认</translation>
-    </message>
-</context>
-<context>
     <name>SettingsView</name>
     <message>
         <location filename="../src/qml/SettingsView.qml" line="22"/>
@@ -2357,16 +2201,6 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         <location filename="../src/qml/StartupDialog.qml" line="50"/>
         <source>Welcome!</source>
         <translation>欢迎！</translation>
-    </message>
-    <message>
-        <source>### Release notes
-</source>
-        <translation type="vanished">### 发布日志</translation>
-    </message>
-    <message>
-        <source>### Contributors
-</source>
-        <translation type="vanished">### 贡献者</translation>
     </message>
     <message>
         <location filename="../src/qml/StartupDialog.qml" line="67"/>
@@ -2543,62 +2377,6 @@ model release that uses your data!</source>
 </context>
 <context>
     <name>main</name>
-    <message>
-        <source>GPT4All v</source>
-        <translation type="vanished">GPT4All v</translation>
-    </message>
-    <message>
-        <source>&lt;h3&gt;Encountered an error starting up:&lt;/h3&gt;&lt;br&gt;</source>
-        <translation type="vanished">&lt;h3&gt;启动时遇到错误：:&lt;/h3&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;i&gt;&quot;Incompatible hardware detected.&quot;&lt;/i&gt;</source>
-        <translation type="vanished">&lt;i&gt;&quot;检测到硬件不兼容&quot;&lt;/i&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;br&gt;&lt;br&gt;Unfortunately, your CPU does not meet the minimal requirements to run </source>
-        <translation type="vanished">&lt;br&gt;&lt;br&gt;您的CPU不符合运行的最低要求</translation>
-    </message>
-    <message>
-        <source>this program. In particular, it does not support AVX intrinsics which this </source>
-        <translation type="vanished">这个问题是因为它不支持AVX 版本</translation>
-    </message>
-    <message>
-        <source>program requires to successfully run a modern large language model. </source>
-        <translation type="vanished">程序需要成功运行现代大型语言模型</translation>
-    </message>
-    <message>
-        <source>The only solution at this time is to upgrade your hardware to a more modern CPU.</source>
-        <translation type="vanished">目前唯一的解决方案是将硬件升级到更现代化的CPU。</translation>
-    </message>
-    <message>
-        <source>&lt;br&gt;&lt;br&gt;See here for more information: &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</source>
-        <translation type="vanished">&lt;br&gt;&lt;br&gt;请参阅此处了解更多信息： &lt;a href=&quot;https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&quot;&gt;</translation>
-    </message>
-    <message>
-        <source>https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</source>
-        <translation type="vanished">https://en.wikipedia.org/wiki/Advanced_Vector_Extensions&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;i&gt;&quot;Inability to access settings file.&quot;&lt;/i&gt;</source>
-        <translation type="vanished">&lt;i&gt;&quot;无法访问设置文件。&quot;&lt;/i&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;br&gt;&lt;br&gt;Unfortunately, something is preventing the program from accessing </source>
-        <translation type="vanished">&lt;br&gt;&lt;br&gt;不幸的是，有什么东西阻止了程序访问 </translation>
-    </message>
-    <message>
-        <source>the settings file. This could be caused by incorrect permissions in the local </source>
-        <translation type="vanished">设置文件。这可能是由于本地中的权限不正确造成的</translation>
-    </message>
-    <message>
-        <source>app config directory where the settings file is located. </source>
-        <translation type="vanished">设置文件所在的应用程序配置目录</translation>
-    </message>
-    <message>
-        <source>Check out our &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; for help.</source>
-        <translation type="vanished">检查链接 &lt;a href=&quot;https://discord.gg/4M2QFmTt2k&quot;&gt;discord channel&lt;/a&gt; 寻求.</translation>
-    </message>
     <message>
         <location filename="../src/main.qml" line="23"/>
         <source>GPT4All v%1</source>

--- a/gpt4all-chat/translations/gpt4all_zh_CN.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_CN.ts
@@ -371,20 +371,6 @@
         <translation>选择加入以共享反馈/对话</translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation>错误：更新系统无法找到用于检查更新的 MaintenanceTool！     
-        您是否使用在线安装程序安装了此应用程序？如果是的话，
-        MaintenanceTool 可执行文件应该位于文件系统中此应用程序所在目录的上一级目录。
-        如果无法手动启动它，那么恐怕您需要重新安装。</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>错误对话</translation>
@@ -418,6 +404,11 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="112"/>
         <source>Light</source>
         <translation>亮色</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation>错误：更新系统无法找到用于检查更新的 MaintenanceTool！&lt;br&gt;&lt;br&gt;您是否使用在线安装程序安装了此应用程序？如果是的话，MaintenanceTool 可执行文件应该位于文件系统中此应用程序所在目录的上一级目录。&lt;br&gt;&lt;br&gt;如果无法手动启动它，那么恐怕您需要重新安装。</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="114"/>
@@ -2085,47 +2076,47 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
         注意：通过启用此功能，您将把数据发送到 GPT4All 开源数据湖。启用此功能后，您不应该期望聊天隐私。但是，如果您愿意，您应该期望可选的归因。您的聊天数据将公开供任何人下载，并将被 Nomic AI 用于改进未来的 GPT4All 模型。Nomic AI 将保留与您的数据相关的所有归因信息，并且您将被视为使用您的数据的任何 GPT4All 模型发布的贡献者！</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>选择加入的条款</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>描述选择加入时会发生的情况</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>填写名称属性 (可选)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>属性 (可选)</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>提供属性</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>启用</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>启用选择加入</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>取消加入</translation>
     </message>

--- a/gpt4all-chat/translations/gpt4all_zh_TW.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_TW.ts
@@ -504,7 +504,7 @@
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="505"/>
         <source>Enable Local API Server</source>
-        <translation type="unfinished"></translation>
+        <translation>啟用本機 API 伺服器</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="340"/>
@@ -576,10 +576,6 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="489"/>
         <source>Save the chat model&apos;s state to disk for faster loading. WARNING: Uses ~2GB per chat.</source>
         <translation>將交談模型的狀態儲存到磁碟以加快載入速度。警告：每次交談使用約 2GB。</translation>
-    </message>
-    <message>
-        <source>Enable Local Server</source>
-        <translation type="vanished">啟用本機伺服器</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="506"/>
@@ -1105,37 +1101,37 @@ model to get started</source>
 <context>
     <name>Download</name>
     <message>
-        <location filename="../src/download.cpp" line="279"/>
+        <location filename="../src/download.cpp" line="278"/>
         <source>Model &quot;%1&quot; is installed successfully.</source>
         <translation>模型「%1」已安裝成功。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="289"/>
+        <location filename="../src/download.cpp" line="288"/>
         <source>ERROR: $MODEL_NAME is empty.</source>
         <translation>錯誤：$MODEL_NAME 未填寫。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="295"/>
+        <location filename="../src/download.cpp" line="294"/>
         <source>ERROR: $API_KEY is empty.</source>
         <translation>錯誤：$API_KEY 未填寫。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="301"/>
+        <location filename="../src/download.cpp" line="300"/>
         <source>ERROR: $BASE_URL is invalid.</source>
         <translation>錯誤：$BASE_URL 無效。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="307"/>
+        <location filename="../src/download.cpp" line="306"/>
         <source>ERROR: Model &quot;%1 (%2)&quot; is conflict.</source>
         <translation>錯誤：模型「%1 （%2）」發生衝突。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="326"/>
+        <location filename="../src/download.cpp" line="325"/>
         <source>Model &quot;%1 (%2)&quot; is installed successfully.</source>
         <translation>模型「%1（%2）」已安裝成功。</translation>
     </message>
     <message>
-        <location filename="../src/download.cpp" line="350"/>
+        <location filename="../src/download.cpp" line="349"/>
         <source>Model &quot;%1&quot; is removed.</source>
         <translation>模型「%1」已移除。</translation>
     </message>
@@ -1509,12 +1505,12 @@ model to get started</source>
         <location filename="../src/modellist.cpp" line="1226"/>
         <location filename="../src/modellist.cpp" line="1277"/>
         <source>cannot open &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>無法開啟“%1”：%2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1238"/>
         <source>cannot create &quot;%1&quot;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>無法建立“%1”：%2</translation>
     </message>
     <message>
         <location filename="../src/modellist.cpp" line="1288"/>

--- a/gpt4all-chat/translations/gpt4all_zh_TW.ts
+++ b/gpt4all-chat/translations/gpt4all_zh_TW.ts
@@ -372,21 +372,6 @@
         <translation>分享回饋/對話計畫</translation>
     </message>
     <message>
-        <location filename="../src/qml/ApplicationSettings.qml" line="37"/>
-        <source>ERROR: Update system could not find the MaintenanceTool used&lt;br&gt;
-                   to check for updates!&lt;br&gt;&lt;br&gt;
-                   Did you install this application using the online installer? If so,&lt;br&gt;
-                   the MaintenanceTool executable should be located one directory&lt;br&gt;
-                   above where this application resides on your filesystem.&lt;br&gt;&lt;br&gt;
-                   If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to&lt;br&gt;
-                   reinstall.</source>
-        <translation>錯誤：更新系統找不到可使用的維護工具來檢查更新！&lt;br&gt;
-                        您是否使用了線上安裝程式安裝了本應用程式？&lt;br&gt;
-                        若是如此，維護工具的執行檔（MaintenanceTool）應位於安裝資料夾中。&lt;br&gt;
-                        請試著手動開啟它。&lt;br&gt;
-                        如果您無法順利啟動，您可能得重新安裝本應用程式。</translation>
-    </message>
-    <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="48"/>
         <source>Error dialog</source>
         <translation>錯誤對話視窗</translation>
@@ -510,6 +495,11 @@
         <location filename="../src/qml/ApplicationSettings.qml" line="340"/>
         <source>Generate suggested follow-up questions at the end of responses.</source>
         <translation>在回覆末尾生成後續建議的問題。</translation>
+    </message>
+    <message>
+        <location filename="../src/qml/ApplicationSettings.qml" line="39"/>
+        <source>ERROR: Update system could not find the MaintenanceTool used to check for updates!&lt;br/&gt;&lt;br/&gt;Did you install this application using the online installer? If so, the MaintenanceTool executable should be located one directory above where this application resides on your filesystem.&lt;br/&gt;&lt;br/&gt;If you can&apos;t start it manually, then I&apos;m afraid you&apos;ll have to reinstall.</source>
+        <translation>錯誤：更新系統找不到可使用的維護工具來檢查更新！&lt;br&gt;&lt;br&gt;您是否使用了線上安裝程式安裝了本應用程式？若是如此，維護工具的執行檔（MaintenanceTool）應位於安裝資料夾中。&lt;br&gt;&lt;br&gt;請試著手動開啟它。&lt;br&gt;&lt;br&gt;如果您無法順利啟動，您可能得重新安裝本應用程式。</translation>
     </message>
     <message>
         <location filename="../src/qml/ApplicationSettings.qml" line="224"/>
@@ -2084,47 +2074,47 @@ NOTE: By turning on this feature, you will be sending your data to the GPT4All O
 Nomic AI 將保留附加在您的資料上的所有署名訊息，並且您將被認可為任何使用您的資料的 GPT4All 模型版本的貢獻者！</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="63"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="70"/>
         <source>Terms for opt-in</source>
         <translation>計畫規範</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="64"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="71"/>
         <source>Describes what will happen when you opt-in</source>
         <translation>解釋當您加入計畫後，會發生什麼事情</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="72"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="79"/>
         <source>Please provide a name for attribution (optional)</source>
         <translation>請提供署名（非必填）</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="74"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="81"/>
         <source>Attribution (optional)</source>
         <translation>署名（非必填）</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="75"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="82"/>
         <source>Provide attribution</source>
         <translation>提供署名</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="88"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="95"/>
         <source>Enable</source>
         <translation>啟用</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="89"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="96"/>
         <source>Enable opt-in</source>
         <translation>加入計畫</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="93"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="100"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/qml/NetworkDialog.qml" line="94"/>
+        <location filename="../src/qml/NetworkDialog.qml" line="101"/>
         <source>Cancel opt-in</source>
         <translation>拒絕計畫</translation>
     </message>


### PR DESCRIPTION
- Add translations for the new messages: `Enable Local API Server`, `cannot open "%1": %2`, and `cannot create "%1": %2`
- Fix the line wrapping of two strings in QML: One of them was hard-wrapped to a specific width which made translation difficult, and the other had lines of source code that were longer than 120 characters.
- Remove several `type="vanished"` messages that should no longer be needed.

Closes #2968