### PR TITLE
Fix sysctl check on non-arm Macs

### DIFF
--- a/gpt4all-bindings/python/gpt4all/_pyllmodel.py
+++ b/gpt4all-bindings/python/gpt4all/_pyllmodel.py
@@ -32,7 +32,7 @@ EmbeddingsType = TypeVar('EmbeddingsType', bound='list[Any]')
 # Detect Rosetta 2
 if platform.system() == "Darwin" and platform.processor() == "i386":
     if subprocess.run(
-        "sysctl -n sysctl.proc_translated".split(), check=True, capture_output=True, text=True,
+        "sysctl -n sysctl.proc_translated".split(), capture_output=True, text=True,
     ).stdout.strip() == "1":
         raise RuntimeError(textwrap.dedent("""\
             Running GPT4All under Rosetta is not supported due to CPU feature requirements.


### PR DESCRIPTION
## Describe your changes

Simple fix for python bindings on non-arm Macs.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.
  - (I presume a traceback from the CLI is enough here)

### Steps to Reproduce

Try to run python bindings on any non-arm mac where this sysctl does not exist. See [this issue](https://github.com/simonw/llm-gpt4all/issues/40) for others that have run into this.

Backtrace:

```
% llm --version
Traceback (most recent call last):
  File "/usr/local/bin/llm", line 5, in <module>
    from llm.cli import cli
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/llm/__init__.py", line 18, in <module>
    from .plugins import pm
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/llm/plugins.py", line 17, in <module>
    pm.load_setuptools_entrypoints("llm")
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/pluggy/_manager.py", line 421, in load_setuptools_entrypoints
    plugin = ep.load()
             ^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/llm_gpt4all.py", line 1, in <module>
    from gpt4all import GPT4All as _GPT4All
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/gpt4all/__init__.py", line 1, in <module>
    from .gpt4all import CancellationError as CancellationError, Embed4All as Embed4All, GPT4All as GPT4All
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/gpt4all/gpt4all.py", line 23, in <module>
    from ._pyllmodel import (CancellationError as CancellationError, EmbCancelCallbackType, EmbedResult as EmbedResult,
  File "/usr/local/Cellar/llm/0.16/libexec/lib/python3.12/site-packages/gpt4all/_pyllmodel.py", line 34, in <module>
    if subprocess.run(
       ^^^^^^^^^^^^^^^
  File "/usr/local/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['sysctl', '-n', 'sysctl.proc_translated']' returned non-zero exit status 1.
```

This sysctl clearly does not exist when run independently:

```
% sysctl -n sysctl.proc_translated                               
sysctl: unknown oid 'sysctl.proc_translated'
```

See also a similar question on [stack overflow](https://stackoverflow.com/a/65347893).

I don't have access to an arm mac to test on, but this fix _should_ still work as intended there (raise error).

I have verified with this in place that the `llm` tool now works with the gpt4all plugin enabled:

```
% llm --version
llm, version 0.16
```
