### PR TITLE
chatllm: do not pass nullptr as response callback

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Add bm25 hybrid search to localdocs ([#2969](https://github.com/nomic-ai/gpt4all/pull/2969))
 
+### Fixed
+- Fix a crash when attempting to continue a chat loaded from disk ([#2995](https://github.com/nomic-ai/gpt4all/pull/2995))
+
 ## [3.3.0] - 2024-09-20
 
 ### Added

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -1314,8 +1314,16 @@ void ChatLLM::processRestoreStateFromText()
         auto &response = *it++;
         Q_ASSERT(response.first != "Prompt: ");
 
-        m_llModelInfo.model->prompt(prompt.second.toStdString(), promptTemplate.toStdString(), promptFunc, nullptr,
-                                    /*allowContextShift*/ true, m_ctx, false, response.second.toUtf8().constData());
+        // FIXME(jared): this doesn't work well with the "regenerate" button since we are not incrementing
+        //               m_promptTokens or m_promptResponseTokens
+        m_llModelInfo.model->prompt(
+            prompt.second.toStdString(), promptTemplate.toStdString(),
+            promptFunc, /*responseFunc*/ [](auto &&...) { return true; },
+            /*allowContextShift*/ true,
+            m_ctx,
+            /*special*/ false,
+            response.second.toUtf8().constData()
+        );
     }
 
     if (!m_stopGenerating) {


### PR DESCRIPTION
In #1970, the response callback used by processRestoreStateFromText was set to nullptr because it was never used.

In #2929, this callback is now used to properly count tokens of previous assistant replies provided by the client. (The fact that processRestoreStateFromText doesn't do this causes the "regenerate" button to not work on chats freshly loaded from disk, but it's always been that way.)

The effect of this is that GPT4All throws an unhandled std::bad_function_call exception and crashes if you try to load a chat from disk and then continue it in any way. This is a regression in the v3.3.0 release, which this PR fixes.