### PR TITLE
ci: use 'current' for Ubuntu image version

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -298,7 +298,7 @@ jobs:
 
   build-offline-chat-installer-linux:
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:
@@ -374,7 +374,7 @@ jobs:
 
   build-online-chat-installer-linux:
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:
@@ -705,7 +705,7 @@ jobs:
 
   build-gpt4all-chat-linux:
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:
@@ -917,7 +917,7 @@ jobs:
 
   build-py-linux:
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - restore_cache:
@@ -1112,7 +1112,7 @@ jobs:
 
   build-bindings-backend-linux:
     machine:
-      image: ubuntu-2204:2023.04.2
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run:


### PR DESCRIPTION
As per [these recommendations](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177#what-do-i-need-to-do-2), CircleCI regularly deprecates older images and they can be removed at any time.

We can't rely on pinning to a particular version forever. So it's best to use the `current` tag, which will build with the latest stable version of the image. Since we're pinning to Ubuntu 22.04 LTS anyway, there shouldn't be any breaking changes with newer images - just backported bugfixes and security patches.