### PR TITLE
chat: fix regression in regenerate from #2929

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fix a crash when attempting to continue a chat loaded from disk ([#2995](https://github.com/nomic-ai/gpt4all/pull/2995))
 - Fix the local server rejecting min\_p/top\_p less than 1 ([#2996](https://github.com/nomic-ai/gpt4all/pull/2996))
+- Fix "regenerate" always forgetting the most recent message ([#3011](https://github.com/nomic-ai/gpt4all/pull/3011))
 
 ## [3.3.1] - 2024-09-27 ([v3.3.y](https://github.com/nomic-ai/gpt4all/tree/v3.3.y))
 

--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -238,8 +238,9 @@ void Chat::newPromptResponsePair(const QString &prompt)
 {
     resetResponseState();
     m_chatModel->updateCurrentResponse(m_chatModel->count() - 1, false);
+    // the prompt is passed as the prompt item's value and the response item's prompt
     m_chatModel->appendPrompt("Prompt: ", prompt);
-    m_chatModel->appendResponse("Response: ", QString());
+    m_chatModel->appendResponse("Response: ", prompt);
     emit resetResponseRequested();
 }
 
@@ -248,8 +249,9 @@ void Chat::serverNewPromptResponsePair(const QString &prompt)
 {
     resetResponseState();
     m_chatModel->updateCurrentResponse(m_chatModel->count() - 1, false);
+    // the prompt is passed as the prompt item's value and the response item's prompt
     m_chatModel->appendPrompt("Prompt: ", prompt);
-    m_chatModel->appendResponse("Response: ", QString());
+    m_chatModel->appendResponse("Response: ", prompt);
 }
 
 bool Chat::restoringFromText() const


### PR DESCRIPTION
This bugfix comes from #3007, but that PR is complex enough as it is, so I'm splitting it out here.

PR #2929 made an incorrect change to these two lines:
https://github.com/nomic-ai/gpt4all/blob/1aae4ffe0a29ec41fadbef8098709e8a8ca7156c/gpt4all-chat/src/chat.cpp#L241-L242

To me this looked like `appendX(key, value)` was the pattern here, and that the initial response value was the prompt for no reason. I changed this to an empty string and everything still worked, so I thought I was in the clear.

Apparently not - I hadn't sufficiently tested the regenerate button, which is the sole user of the property actually set here, the response's `prompt`:
https://github.com/nomic-ai/gpt4all/blob/62bc84366bed4df3ffb6496b94b44c5a8ccb542e/gpt4all-chat/qml/ChatView.qml#L1701-L1708

All other uses of the ChatModel, such as restoreStateFromText, use the `value` of the associated prompt ChatItem instead.

This PR restores the original argument. Credit to Adam for finding this.