### PR TITLE
Fix restore from state when the model has a system prompt.

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -1659,7 +1659,6 @@ Rectangle {
                         onClicked: {
                             Network.trackChatEvent("reset_context", { "length": chatModel.count })
                             currentChat.reset();
-                            currentChat.processSystemPrompt();
                         }
                         ToolTip.visible: resetContextButton.hovered
                         ToolTip.text: qsTr("Erase and reset chat session")

--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -78,7 +78,6 @@ void Chat::connectLLM()
     connect(this, &Chat::regenerateResponseRequested, m_llmodel, &ChatLLM::regenerateResponse, Qt::QueuedConnection);
     connect(this, &Chat::resetResponseRequested, m_llmodel, &ChatLLM::resetResponse, Qt::QueuedConnection);
     connect(this, &Chat::resetContextRequested, m_llmodel, &ChatLLM::resetContext, Qt::QueuedConnection);
-    connect(this, &Chat::processSystemPromptRequested, m_llmodel, &ChatLLM::processSystemPrompt, Qt::QueuedConnection);
 
     connect(this, &Chat::collectionListChanged, m_collectionModel, &LocalDocsCollectionsModel::setCollections);
 }
@@ -102,11 +101,6 @@ void Chat::reset()
     // is to allow switching models but throwing up a dialog warning users if we switch between types
     // of models that a long recalculation will ensue.
     m_chatModel->clear();
-}
-
-void Chat::processSystemPrompt()
-{
-    emit processSystemPromptRequested();
 }
 
 void Chat::resetResponseState()

--- a/gpt4all-chat/src/chat.h
+++ b/gpt4all-chat/src/chat.h
@@ -72,7 +72,6 @@ public:
     bool isNewChat() const { return m_name == tr("New Chat") && !m_chatModel->count(); }
 
     Q_INVOKABLE void reset();
-    Q_INVOKABLE void processSystemPrompt();
     bool  isModelLoaded()          const { return m_modelLoadingPercentage == 1.0f; }
     bool  isCurrentlyLoading()     const { return m_modelLoadingPercentage > 0.0f && m_modelLoadingPercentage < 1.0f; }
     float modelLoadingPercentage() const { return m_modelLoadingPercentage; }
@@ -141,7 +140,6 @@ Q_SIGNALS:
     void regenerateResponseRequested();
     void resetResponseRequested();
     void resetContextRequested();
-    void processSystemPromptRequested();
     void modelChangeRequested(const ModelInfo &modelInfo);
     void modelInfoChanged();
     void restoringFromTextChanged();

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -168,7 +168,6 @@ public Q_SLOTS:
     void handleThreadStarted();
     void handleForceMetalChanged(bool forceMetal);
     void handleDeviceChanged();
-    void processSystemPrompt();
     void processRestoreStateFromText();
 
 Q_SIGNALS:
@@ -219,6 +218,7 @@ protected:
 
 private:
     bool loadNewModel(const ModelInfo &modelInfo, QVariantMap &modelLoadProps);
+    void processSystemPrompt(bool force = false);
 
     std::string m_response;
     std::string m_trimmedResponse;


### PR DESCRIPTION
- Simplify the state handling for system prompt by making it completely lazy and a private method of ChatLLM class.
- Explicitly force the processing of the system prompt when we restore from text.

---

Admittedly, it would be nice to process the system prompt as early as possible, but for simplicity sake - and especially because we'll be moving to a substantially different ChatLLM interface soon where state will be handled differently - this PR makes system prompt processing entirely lazy. I've also made the process system prompt method private with only two invocations: one from promptInternal and the other from restore state from text.