### PR TITLE
Tweaks for Excel to Markdown conversion

### DIFF
--- a/gpt4all-chat/qml/ChatView.qml
+++ b/gpt4all-chat/qml/ChatView.qml
@@ -939,6 +939,7 @@ Rectangle {
 
                                                     Text {
                                                         id: attachmentFileText
+                                                        width: 295
                                                         height: 40
                                                         text: modelData.file
                                                         color: theme.textColor
@@ -947,6 +948,7 @@ Rectangle {
                                                         font.pixelSize: theme.fontSizeMedium
                                                         font.bold: true
                                                         wrapMode: Text.WrapAnywhere
+                                                        elide: Qt.ElideRight
                                                     }
                                                 }
                                             }
@@ -1971,6 +1973,7 @@ Rectangle {
 
                                     Text {
                                         id: attachmentFileText2
+                                        width: 265
                                         height: 40
                                         text: model.file
                                         color: theme.textColor
@@ -1979,6 +1982,7 @@ Rectangle {
                                         font.pixelSize: theme.fontSizeMedium
                                         font.bold: true
                                         wrapMode: Text.WrapAnywhere
+                                        elide: Qt.ElideRight
                                     }
                                 }
 

--- a/gpt4all-chat/src/xlsxtomd.cpp
+++ b/gpt4all-chat/src/xlsxtomd.cpp
@@ -44,15 +44,14 @@ static QString formatCellText(const QXlsx::Cell *cell)
     // Apply Markdown and HTML formatting based on font styles
     QString formattedText = cellText;
 
-    if (format.fontBold() && format.fontItalic())
-        formattedText = "***" + formattedText + "***";
-    else if (format.fontBold())
-        formattedText = "**" + formattedText + "**";
-    else if (format.fontItalic())
-        formattedText = "*" + formattedText + "*";
-
+    if (format.fontUnderline())
+        formattedText = u"_%1_"_s.arg(formattedText);
+    if (format.fontBold())
+        formattedText = u"**%1**"_s.arg(formattedText);
+    if (format.fontItalic())
+        formattedText = u"*%1*"_s.arg(formattedText);
     if (format.fontStrikeOut())
-        formattedText = "~~" + formattedText + "~~";
+        formattedText = u"~~%1~~"_s.arg(formattedText);
 
     // Escape pipe characters to prevent Markdown table issues
     formattedText.replace("|", "\\|");

--- a/gpt4all-chat/src/xlsxtomd.cpp
+++ b/gpt4all-chat/src/xlsxtomd.cpp
@@ -127,29 +127,14 @@ QString XLSXToMD::toMarkdown(QIODevice *xlsxDevice)
             continue;
         }
 
-        // Assume the first row is the header
-        int headerRow = firstRow;
-
-        // Collect headers
-        QStringList headers;
-        for (int col = firstCol; col <= lastCol; ++col) {
-            QString header = getCellValue(sheet, headerRow, col);
-            headers << header;
-        }
-
-        // Create Markdown header row
-        QString headerRowMarkdown = "|" + headers.join("|") + "|";
-        markdown += headerRowMarkdown + "\n";
-
-        // Create Markdown separator row
+        // Separator row (no header)
         QStringList separators;
-        for (int i = 0; i < headers.size(); ++i)
-            separators << "---";
-        QString separatorRow = "|" + separators.join("|") + "|";
-        markdown += separatorRow + "\n";
+        for (int col = firstCol; col <= lastCol; ++col)
+            separators << u"---"_s;
+        markdown += u"|%1|\n"_s.arg(separators.join(u'|'));
 
-        // Iterate through data rows (starting from the row after header)
-        for (int row = headerRow + 1; row <= lastRow; ++row) {
+        // Iterate through data rows
+        for (int row = 0; row <= lastRow; ++row) {
             QStringList rowData;
             for (int col = firstCol; col <= lastCol; ++col) {
                 QString cellText = getCellValue(sheet, row, col);

--- a/gpt4all-chat/src/xlsxtomd.cpp
+++ b/gpt4all-chat/src/xlsxtomd.cpp
@@ -39,7 +39,7 @@ static QString formatCellText(const QXlsx::Cell *cell)
     }
 
     if (cellText.isEmpty())
-        return QString();
+        return u" "_s;
 
     // Apply Markdown and HTML formatting based on font styles
     QString formattedText = cellText;


### PR DESCRIPTION
There are a few changes here that we didn't have time to discuss in the previous PR:
- `_Underlines_` seem to be recognized by Llama 3, so use them
- Not all spreadsheets use the first row as a header. Llama 3 seems to generalize better with no header row.
- Empty cells seem to not be well supported by Llama 3 unless there is a space in them (this matters more for spreadsheets with lots of horizontal whitespace)
- Long filenames were exceeding the width and height of the attached file cards. Probably we should be using a RowLayout and not a Row so it's easier to automatically constrain the width of the elements, but this change works too.

Needs a changelog entry once we decide which of these changes to keep.

Follow-up to #3007