### PR TITLE
Small tweak to add allow the QXlsx library to format the date properly.

### DIFF
--- a/gpt4all-chat/src/xlsxtomd.cpp
+++ b/gpt4all-chat/src/xlsxtomd.cpp
@@ -25,7 +25,7 @@ static QString formatCellText(const QXlsx::Cell *cell)
 {
     if (!cell) return QString();
 
-    QVariant value = cell->value();
+    QVariant value = cell->readValue();
     QXlsx::Format format = cell->format();
     QString cellText;
 


### PR DESCRIPTION
The QXlsx::Cell class has a readValue method that apparently is necessary to jog the code that formats the dates correctly. This can be seen when looking at the raw markdown we generate on this file: https://www.stock-analysis-on.net/NYSE/Company/Walt-Disney-Co/Financial-Statement/Income-Statement
