### PR TITLE
Improve .chat file saving/loading

### DIFF
--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -416,15 +416,15 @@ bool Chat::serialize(QDataStream &stream, int version) const
     stream << m_id;
     stream << m_name;
     stream << m_userName;
-    if (version > 4)
+    if (version >= 5)
         stream << m_modelInfo.id();
     else
         stream << m_modelInfo.filename();
-    if (version > 2)
+    if (version >= 3)
         stream << m_collections;
 
     const bool serializeKV = MySettings::globalInstance()->saveChatsContext();
-    if (version > 5)
+    if (version >= 6)
         stream << serializeKV;
     if (!m_llmodel->serialize(stream, version, serializeKV))
         return false;
@@ -445,7 +445,7 @@ bool Chat::deserialize(QDataStream &stream, int version)
 
     QString modelId;
     stream >> modelId;
-    if (version > 4) {
+    if (version >= 5) {
         if (ModelList::globalInstance()->contains(modelId))
             m_modelInfo = ModelList::globalInstance()->modelInfo(modelId);
     } else {
@@ -457,13 +457,13 @@ bool Chat::deserialize(QDataStream &stream, int version)
 
     bool discardKV = m_modelInfo.id().isEmpty();
 
-    if (version > 2) {
+    if (version >= 3) {
         stream >> m_collections;
         emit collectionListChanged(m_collections);
     }
 
     bool deserializeKV = true;
-    if (version > 5)
+    if (version >= 6)
         stream >> deserializeKV;
 
     m_llmodel->setModelInfo(m_modelInfo);

--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -101,6 +101,7 @@ void Chat::reset()
     // is to allow switching models but throwing up a dialog warning users if we switch between types
     // of models that a long recalculation will ensue.
     m_chatModel->clear();
+    m_needsSave = true;
 }
 
 void Chat::processSystemPrompt()
@@ -163,6 +164,7 @@ void Chat::prompt(const QString &prompt)
 {
     resetResponseState();
     emit promptRequested(m_collections, prompt);
+    m_needsSave = true;
 }
 
 void Chat::regenerateResponse()
@@ -170,6 +172,7 @@ void Chat::regenerateResponse()
     const int index = m_chatModel->count() - 1;
     m_chatModel->updateSources(index, QList<ResultInfo>());
     emit regenerateResponseRequested();
+    m_needsSave = true;
 }
 
 void Chat::stopGenerating()
@@ -224,7 +227,7 @@ void Chat::handleModelLoadingPercentageChanged(float loadingPercentage)
 void Chat::promptProcessing()
 {
     m_responseState = !databaseResults().isEmpty() ? Chat::LocalDocsProcessing : Chat::PromptProcessing;
-     emit responseStateChanged();
+    emit responseStateChanged();
 }
 
 void Chat::generatingQuestions()
@@ -261,10 +264,12 @@ ModelInfo Chat::modelInfo() const
 
 void Chat::setModelInfo(const ModelInfo &modelInfo)
 {
-    if (m_modelInfo == modelInfo && isModelLoaded())
+    if (m_modelInfo != modelInfo) {
+        m_modelInfo = modelInfo;
+        m_needsSave = true;
+    } else if (isModelLoaded())
         return;
 
-    m_modelInfo = modelInfo;
     emit modelInfoChanged();
     emit modelChangeRequested(modelInfo);
 }
@@ -343,12 +348,14 @@ void Chat::generatedNameChanged(const QString &name)
     int wordCount = qMin(7, words.size());
     m_name = words.mid(0, wordCount).join(' ');
     emit nameChanged();
+    m_needsSave = true;
 }
 
 void Chat::generatedQuestionFinished(const QString &question)
 {
     m_generatedQuestions << question;
     emit generatedQuestionsChanged();
+    m_needsSave = true;
 }
 
 void Chat::handleRestoringFromText()
@@ -393,6 +400,7 @@ void Chat::handleDatabaseResultsChanged(const QList<ResultInfo> &results)
     m_databaseResults = results;
     const int index = m_chatModel->count() - 1;
     m_chatModel->updateSources(index, m_databaseResults);
+    m_needsSave = true;
 }
 
 void Chat::handleModelInfoChanged(const ModelInfo &modelInfo)
@@ -402,6 +410,7 @@ void Chat::handleModelInfoChanged(const ModelInfo &modelInfo)
 
     m_modelInfo = modelInfo;
     emit modelInfoChanged();
+    m_needsSave = true;
 }
 
 void Chat::handleTrySwitchContextOfLoadedModelCompleted(int value)
@@ -473,7 +482,11 @@ bool Chat::deserialize(QDataStream &stream, int version)
         return false;
 
     emit chatModelChanged();
-    return stream.status() == QDataStream::Ok;
+    if (stream.status() != QDataStream::Ok)
+        return false;
+
+    m_needsSave = false;
+    return true;
 }
 
 QList<QString> Chat::collectionList() const
@@ -493,6 +506,7 @@ void Chat::addCollection(const QString &collection)
 
     m_collections.append(collection);
     emit collectionListChanged(m_collections);
+    m_needsSave = true;
 }
 
 void Chat::removeCollection(const QString &collection)
@@ -502,4 +516,5 @@ void Chat::removeCollection(const QString &collection)
 
     m_collections.removeAll(collection);
     emit collectionListChanged(m_collections);
+    m_needsSave = true;
 }

--- a/gpt4all-chat/src/chat.h
+++ b/gpt4all-chat/src/chat.h
@@ -67,6 +67,7 @@ public:
     {
         m_userName = name;
         emit nameChanged();
+        m_needsSave = true;
     }
     ChatModel *chatModel() { return m_chatModel; }
 
@@ -123,6 +124,8 @@ public:
     int trySwitchContextInProgress() const { return m_trySwitchContextInProgress; }
 
     QList<QString> generatedQuestions() const { return m_generatedQuestions; }
+
+    bool needsSave() const { return m_needsSave; }
 
 public Q_SLOTS:
     void serverNewPromptResponsePair(const QString &prompt, const QList<PromptAttachment> &attachments = {});
@@ -203,6 +206,10 @@ private:
     bool m_firstResponse = true;
     int m_trySwitchContextInProgress = 0;
     bool m_isCurrentlyLoading = false;
+    // True if we need to serialize the chat to disk, because of one of two reasons:
+    // - The chat was freshly created during this launch.
+    // - The chat was interacted with after loading it from disk.
+    bool m_needsSave = true;
 };
 
 #endif // CHAT_H

--- a/gpt4all-chat/src/chatlistmodel.cpp
+++ b/gpt4all-chat/src/chatlistmodel.cpp
@@ -99,7 +99,12 @@ void ChatSaver::saveChats(const QVector<Chat *> &chats)
     QElapsedTimer timer;
     timer.start();
     const QString savePath = MySettings::globalInstance()->modelPath();
+    qsizetype nSavedChats = 0;
     for (Chat *chat : chats) {
+        if (!chat->needsSave())
+            continue;
+        ++nSavedChats;
+
         QString fileName = "gpt4all-" + chat->id() + ".chat";
         QString filePath = savePath + "/" + fileName;
         QFile originalFile(filePath);
@@ -129,7 +134,7 @@ void ChatSaver::saveChats(const QVector<Chat *> &chats)
     }
 
     qint64 elapsedTime = timer.elapsed();
-    qDebug() << "serializing chats took:" << elapsedTime << "ms";
+    qDebug() << "serializing chats took" << elapsedTime << "ms, saved" << nSavedChats << "/" << chats.size() << "chats";
     emit saveChatsFinished();
 }
 

--- a/gpt4all-chat/src/chatlistmodel.cpp
+++ b/gpt4all-chat/src/chatlistmodel.cpp
@@ -193,7 +193,7 @@ void ChatsRestoreThread::run()
             // Read the version
             qint32 version;
             in >> version;
-            if (version < 1) {
+            if (version < 1 || version > CHAT_FORMAT_VERSION) {
                 qWarning() << "ERROR: Chat file has non supported version:" << file.fileName();
                 continue;
             }

--- a/gpt4all-chat/src/chatlistmodel.cpp
+++ b/gpt4all-chat/src/chatlistmodel.cpp
@@ -198,7 +198,7 @@ void ChatsRestoreThread::run()
                 continue;
             }
 
-            if (version <= 1)
+            if (version < 2)
                 in.setVersion(QDataStream::Qt_6_2);
 
             FileInfo info;
@@ -239,7 +239,7 @@ void ChatsRestoreThread::run()
                 continue;
             }
 
-            if (version <= 1)
+            if (version < 2)
                 in.setVersion(QDataStream::Qt_6_2);
         }
 

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -1046,7 +1046,7 @@ bool ChatLLM::handleRestoreStateFromTextPrompt(int32_t token)
 // we want to also serialize n_ctx, and read it at load time.
 bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
 {
-    if (version > 1) {
+    if (version >= 2) {
         if (m_llModelType == LLModelTypeV1::NONE) {
             qWarning() << "ChatLLM ERROR: attempted to serialize a null model for chat id" << m_chat->id()
                        << "name" << m_chat->name();
@@ -1071,7 +1071,7 @@ bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
         return stream.status() == QDataStream::Ok;
     }
 
-    if (version <= 3) {
+    if (version < 4) {
         int responseLogits = 0;
         stream << responseLogits;
     }
@@ -1092,7 +1092,7 @@ bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
 
 bool ChatLLM::deserialize(QDataStream &stream, int version, bool deserializeKV, bool discardKV)
 {
-    if (version > 1) {
+    if (version >= 2) {
         int llModelType;
         stream >> llModelType;
         m_llModelType = (version >= 6 ? parseLLModelTypeV1 : parseLLModelTypeV0)(llModelType);
@@ -1131,7 +1131,7 @@ bool ChatLLM::deserialize(QDataStream &stream, int version, bool deserializeKV, 
         return stream.status() == QDataStream::Ok;
     }
 
-    if (version <= 3) {
+    if (version < 4) {
         int responseLogits;
         stream >> responseLogits;
     }
@@ -1161,7 +1161,7 @@ bool ChatLLM::deserialize(QDataStream &stream, int version, bool deserializeKV, 
         stream.skipRawData(tokensSize * sizeof(int));
     }
 
-    if (version > 0) {
+    if (version >= 1) {
         QByteArray compressed;
         stream >> compressed;
         if (!discardKV)

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -42,8 +42,9 @@ using namespace Qt::Literals::StringLiterals;
 //#define DEBUG
 //#define DEBUG_MODEL_LOADING
 
-#define GPTJ_INTERNAL_STATE_VERSION  0 // GPT-J is gone but old chats still use this
-#define LLAMA_INTERNAL_STATE_VERSION 0
+static constexpr int GPTJ_INTERNAL_STATE_VERSION = 0; // GPT-J is gone but old chats still use this
+static constexpr int LLAMA_INTERNAL_STATE_VERSION = 0;
+static constexpr int API_INTERNAL_STATE_VERSION   = 0;
 
 class LLModelStore {
 public:
@@ -1048,9 +1049,10 @@ bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
     if (version > 1) {
         stream << m_llModelType;
         switch (m_llModelType) {
-        case GPTJ_: stream << GPTJ_INTERNAL_STATE_VERSION; break;
-        case LLAMA_: stream << LLAMA_INTERNAL_STATE_VERSION; break;
-        default: Q_UNREACHABLE();
+            case GPTJ_:  stream << GPTJ_INTERNAL_STATE_VERSION;  break;
+            case LLAMA_: stream << LLAMA_INTERNAL_STATE_VERSION; break;
+            case API_:   stream << API_INTERNAL_STATE_VERSION;   break;
+            default:     Q_UNREACHABLE();
         }
     }
     stream << response();
@@ -1088,6 +1090,7 @@ bool ChatLLM::deserialize(QDataStream &stream, int version, bool deserializeKV, 
     if (version > 1) {
         int internalStateVersion;
         stream >> m_llModelType;
+        // note: prior to chat version 10, API models only wrote this because of UB in Release builds
         stream >> internalStateVersion; // for future use
     }
     QString response;

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -1095,7 +1095,12 @@ bool ChatLLM::deserialize(QDataStream &stream, int version, bool deserializeKV, 
     if (version > 1) {
         int llModelType;
         stream >> llModelType;
-        m_llModelType = version >= 6 ? LLModelTypeV1(llModelType) : llModelTypeV0toV1(LLModelTypeV0(llModelType));
+        m_llModelType = (version >= 6 ? parseLLModelTypeV1 : parseLLModelTypeV0)(llModelType);
+        if (m_llModelType == LLModelTypeV1::NONE) {
+            qWarning().nospace() << "error loading chat id " << m_chat->id() << ": unrecognized model type: "
+                                 << llModelType;
+            return false;
+        }
 
         /* note: prior to chat version 10, API models and chats with models removed in v2.5.0 only wrote this because of
          * UB in Release builds */

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -105,6 +105,7 @@ void LLModelInfo::resetModel(ChatLLM *cllm, LLModel *model) {
 
 ChatLLM::ChatLLM(Chat *parent, bool isServer)
     : QObject{nullptr}
+    , m_chat(parent)
     , m_promptResponseTokens(0)
     , m_promptTokens(0)
     , m_restoringFromText(false)
@@ -1046,6 +1047,12 @@ bool ChatLLM::handleRestoreStateFromTextPrompt(int32_t token)
 bool ChatLLM::serialize(QDataStream &stream, int version, bool serializeKV)
 {
     if (version > 1) {
+        if (m_llModelType == LLModelTypeV1::NONE) {
+            qWarning() << "ChatLLM ERROR: attempted to serialize a null model for chat id" << m_chat->id()
+                       << "name" << m_chat->name();
+            return false;
+        }
+
         stream << m_llModelType;
         switch (m_llModelType) {
             case LLModelTypeV1::LLAMA: stream << LLAMA_INTERNAL_STATE_VERSION; break;

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -48,6 +48,7 @@ enum class LLModelTypeV1 { // since chat version 6 (v2.5.0)
     FALCON    = 5,
     MPT       = 6,
     STARCODER = 7,
+    NONE      = -1, // no state
 };
 
 static LLModelTypeV1 llModelTypeV0toV1(LLModelTypeV0 v0)
@@ -249,12 +250,13 @@ protected:
 private:
     bool loadNewModel(const ModelInfo &modelInfo, QVariantMap &modelLoadProps);
 
+    const Chat *m_chat;
     std::string m_response;
     std::string m_trimmedResponse;
     std::string m_nameResponse;
     QString m_questionResponse;
     LLModelInfo m_llModelInfo;
-    LLModelTypeV1 m_llModelType;
+    LLModelTypeV1 m_llModelType = LLModelTypeV1::NONE;
     ModelInfo m_modelInfo;
     TokenTimer *m_timer;
     QByteArray m_state;

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -28,12 +28,42 @@ using namespace Qt::Literals::StringLiterals;
 class QDataStream;
 
 // NOTE: values serialized to disk, do not change or reuse
-enum LLModelType {
-    GPTJ_  = 0, // no longer used
-    LLAMA_ = 1,
-    API_   = 2,
-    BERT_  = 3, // no longer used
+enum class LLModelTypeV0 { // chat versions 2-5
+    MPT       = 0,
+    GPTJ      = 1,
+    LLAMA     = 2,
+    CHATGPT   = 3,
+    REPLIT    = 4,
+    FALCON    = 5,
+    BERT      = 6, // not used
+    STARCODER = 7,
 };
+enum class LLModelTypeV1 { // since chat version 6 (v2.5.0)
+    GPTJ      = 0, // not for new chats
+    LLAMA     = 1,
+    API       = 2,
+    BERT      = 3, // not used
+    // none of the below are used in new chats
+    REPLIT    = 4,
+    FALCON    = 5,
+    MPT       = 6,
+    STARCODER = 7,
+};
+
+static LLModelTypeV1 llModelTypeV0toV1(LLModelTypeV0 v0)
+{
+    switch (v0) {
+        case LLModelTypeV0::MPT:       return LLModelTypeV1::MPT;
+        case LLModelTypeV0::GPTJ:      return LLModelTypeV1::GPTJ;
+        case LLModelTypeV0::LLAMA:     return LLModelTypeV1::LLAMA;
+        case LLModelTypeV0::CHATGPT:   return LLModelTypeV1::API;
+        case LLModelTypeV0::REPLIT:    return LLModelTypeV1::REPLIT;
+        case LLModelTypeV0::FALCON:    return LLModelTypeV1::FALCON;
+        case LLModelTypeV0::BERT:      return LLModelTypeV1::BERT;
+        case LLModelTypeV0::STARCODER: return LLModelTypeV1::STARCODER;
+    }
+    Q_UNREACHABLE();
+}
 
 class ChatLLM;
 class ChatModel;
@@ -224,7 +254,7 @@ private:
     std::string m_nameResponse;
     QString m_questionResponse;
     LLModelInfo m_llModelInfo;
-    LLModelType m_llModelType;
+    LLModelTypeV1 m_llModelType;
     ModelInfo m_modelInfo;
     TokenTimer *m_timer;
     QByteArray m_state;

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -51,19 +51,36 @@ enum class LLModelTypeV1 { // since chat version 6 (v2.5.0)
     NONE      = -1, // no state
 };
 
-static LLModelTypeV1 llModelTypeV0toV1(LLModelTypeV0 v0)
+static LLModelTypeV1 parseLLModelTypeV1(int type)
 {
-    switch (v0) {
+    switch (LLModelTypeV1(type)) {
+    case LLModelTypeV1::GPTJ:
+    case LLModelTypeV1::LLAMA:
+    case LLModelTypeV1::API:
+    // case LLModelTypeV1::BERT: -- not used
+    case LLModelTypeV1::REPLIT:
+    case LLModelTypeV1::FALCON:
+    case LLModelTypeV1::MPT:
+    case LLModelTypeV1::STARCODER:
+        return LLModelTypeV1(type);
+    default:
+        return LLModelTypeV1::NONE;
+    }
+}
+
+static LLModelTypeV1 parseLLModelTypeV0(int v0)
+{
+    switch (LLModelTypeV0(v0)) {
         case LLModelTypeV0::MPT:       return LLModelTypeV1::MPT;
         case LLModelTypeV0::GPTJ:      return LLModelTypeV1::GPTJ;
         case LLModelTypeV0::LLAMA:     return LLModelTypeV1::LLAMA;
         case LLModelTypeV0::CHATGPT:   return LLModelTypeV1::API;
         case LLModelTypeV0::REPLIT:    return LLModelTypeV1::REPLIT;
         case LLModelTypeV0::FALCON:    return LLModelTypeV1::FALCON;
-        case LLModelTypeV0::BERT:      return LLModelTypeV1::BERT;
+        // case LLModelTypeV0::BERT: -- not used
         case LLModelTypeV0::STARCODER: return LLModelTypeV1::STARCODER;
+        default:                       return LLModelTypeV1::NONE;
     }
-    Q_UNREACHABLE();
 }
 
 class ChatLLM;

--- a/gpt4all-chat/src/chatmodel.h
+++ b/gpt4all-chat/src/chatmodel.h
@@ -386,7 +386,7 @@ public:
             stream << c.stopped;
             stream << c.thumbsUpState;
             stream << c.thumbsDownState;
-            if (version > 7) {
+            if (version >= 8) {
                 stream << c.sources.size();
                 for (const ResultInfo &info : c.sources) {
                     Q_ASSERT(!info.file.isEmpty());
@@ -401,7 +401,7 @@ public:
                     stream << info.from;
                     stream << info.to;
                 }
-            } else if (version > 2) {
+            } else if (version >= 3) {
                 QList<QString> references;
                 QList<QString> referencesContext;
                 int validReferenceNumber = 1;
@@ -468,7 +468,7 @@ public:
             stream >> c.stopped;
             stream >> c.thumbsUpState;
             stream >> c.thumbsDownState;
-            if (version > 7) {
+            if (version >= 8) {
                 qsizetype count;
                 stream >> count;
                 QList<ResultInfo> sources;
@@ -488,7 +488,7 @@ public:
                 }
                 c.sources = sources;
                 c.consolidatedSources = consolidateSources(sources);
-            } else if (version > 2) {
+            } else if (version >= 3) {
                 QString references;
                 QList<QString> referencesContext;
                 stream >> references;


### PR DESCRIPTION
What this PR fixes:
- Undefined behavior when saving remote models (the compiler optimized the code into the right thing but we should actually write the necessary code)
- Undefined behavior when loading and saving chats with old pre-llama.cpp models from before v2.5.0
- Undefined behavior if m_llModelType is serialized with no model ever having been loaded
- ... (TODO)

Out of scope for this PR:
- This crash I saw again while testing (can work around it by commenting out the sanity check): #2626
- Saving chat files eagerly rather than at exit (blocked, first we should remove the old "save context" option that is disabled by default now)
- Handling SIGINT to save chat files when interrupted from command line
- We still forget to save the chat file if the first message is still generating while we exit (probably it's still considered a "new chat" even after clicking send)