### PR TITLE
localdocs: fix regressions caused by docx change

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fix models.json cache location ([#3052](https://github.com/nomic-ai/gpt4all/pull/3052))
+- Fix LocalDocs regressions caused by docx change ([#3079](https://github.com/nomic-ai/gpt4all/pull/3079))
 
 ## [3.4.0] - 2024-10-08
 

--- a/gpt4all-chat/src/database.cpp
+++ b/gpt4all-chat/src/database.cpp
@@ -1385,7 +1385,7 @@ ChunkStreamer::Status ChunkStreamer::step()
                 if (!addChunk(q,
                     m_documentId,
                     chunk,
-                    m_reader->doc().file.canonicalFilePath(),
+                    m_reader->doc().file.fileName(), // basename
                     m_title,
                     m_author,
                     m_subject,

--- a/gpt4all-chat/src/database.cpp
+++ b/gpt4all-chat/src/database.cpp
@@ -1246,9 +1246,13 @@ public:
 protected:
     std::optional<QString> advance() override
     {
+        if (getError())
+            return std::nullopt;
         while (!m_stream.atEnd()) {
             QString word;
             m_stream >> word;
+            if (getError())
+                return std::nullopt;
             if (!word.isEmpty())
                 return word;
         }
@@ -1257,9 +1261,11 @@ protected:
 
     std::optional<ChunkStreamer::Status> getError() const override
     {
-        if (!m_file.error())
-            return std::nullopt;
-        return m_file.binarySeen() ? ChunkStreamer::Status::BINARY_SEEN : ChunkStreamer::Status::ERROR;
+        if (m_file.binarySeen())
+            return ChunkStreamer::Status::BINARY_SEEN;
+        if (m_file.error())
+            return ChunkStreamer::Status::ERROR;
+        return std::nullopt;
     }
 
     BinaryDetectingFile m_file;

--- a/gpt4all-chat/src/database.h
+++ b/gpt4all-chat/src/database.h
@@ -224,6 +224,12 @@ private:
     void commit();
     void rollback();
 
+    bool addChunk(QSqlQuery &q, int document_id, const QString &chunk_text, const QString &file,
+                  const QString &title, const QString &author, const QString &subject, const QString &keywords,
+                  int page, int from, int to, int words, int *chunk_id);
+    bool refreshDocumentIdCache(QSqlQuery &q);
+    bool removeChunksByDocumentId(QSqlQuery &q, int document_id);
+    bool sqlRemoveDocsByFolderPath(QSqlQuery &q, const QString &path);
     bool hasContent();
     // not found -> 0, , exists and has content -> 1, error -> -1
     int openDatabase(const QString &modelPath, bool create = true, int ver = LOCALDOCS_VERSION);
@@ -293,6 +299,7 @@ private:
     QHash<int, CollectionItem> m_collectionMap; // used only for tracking indexing/embedding progress
     std::atomic<bool> m_databaseValid;
     ChunkStreamer m_chunkStreamer;
+    QSet<int> m_documentIdCache; // cached list of documents with chunks for fast lookup
 
     friend class ChunkStreamer;
 };

--- a/gpt4all-chat/src/database.h
+++ b/gpt4all-chat/src/database.h
@@ -163,6 +163,8 @@ public:
 
     void setDocument(const DocumentInfo &doc, int documentId, const QString &embeddingModel, const QString &title,
                      const QString &author, const QString &subject, const QString &keywords);
+    std::optional<DocumentInfo::key_type> currentDocKey() const;
+    void reset();
 
     Status step();
 


### PR DESCRIPTION
Follow-up to #2986.

Some of the docx changes were not completely finished and didn't really make sense.

This fixes the dropped words at the beginning of chunks, as well as some other issues.