### PR TITLE
chatviewtextprocessor: fix Go syntax highlighting

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fix models.json cache location ([#3052](https://github.com/nomic-ai/gpt4all/pull/3052))
 - Fix LocalDocs regressions caused by docx change ([#3079](https://github.com/nomic-ai/gpt4all/pull/3079))
+- Fix Go code being highlighted as Java ([#3080](https://github.com/nomic-ai/gpt4all/pull/3080))
 
 ## [3.4.0] - 2024-10-08
 

--- a/gpt4all-chat/src/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/src/chatviewtextprocessor.cpp
@@ -738,7 +738,7 @@ void SyntaxHighlighter::highlightBlock(const QString &text)
     case Java:
         rules = javaHighlightingRules(); break;
     case Go:
-        rules = javaHighlightingRules(); break;
+        rules = goHighlightingRules(); break;
     case Json:
         rules = jsonHighlightingRules(); break;
     case Latex:


### PR DESCRIPTION
While making #3065 I discovered this apparent copy-paste error, that caused Go syntax highlighting to never be used, with Go code highlighted as Java code instead.

This PR splits that change out in order to avoid functional changes in the warning fix PR.