### PR TITLE
tests: make python dependency optional

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.25)  # for try_compile SOURCE_FROM_VAR
 
-enable_testing()
-
 include(../common/common.cmake)
 
 set(APP_VERSION_MAJOR 3)
@@ -24,6 +22,9 @@ if(APPLE)
   endif()
 endif()
 
+find_package(Python3 QUIET COMPONENTS Interpreter)
+
+option(GPT4ALL_TEST "Build the tests" ${Python3_FOUND})
 option(GPT4ALL_LOCALHOST "Build installer for localhost repo" OFF)
 option(GPT4ALL_OFFLINE_INSTALLER "Build an offline installer" OFF)
 option(GPT4ALL_SIGN_INSTALL "Sign installed binaries and installers (requires signing identities)" OFF)
@@ -94,10 +95,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_subdirectory(deps)
 add_subdirectory(../gpt4all-backend llmodel)
-add_subdirectory(tests)
 
-# The 'check' target makes sure the tests and their dependencies are up-to-date before running them
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS chat gpt4all_tests)
+if (GPT4ALL_TEST)
+    enable_testing()
+    add_subdirectory(tests)
+
+    # The 'check' target makes sure the tests and their dependencies are up-to-date before running them
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS chat gpt4all_tests)
+endif()
 
 set(CHAT_EXE_RESOURCES)
 

--- a/gpt4all-chat/tests/CMakeLists.txt
+++ b/gpt4all-chat/tests/CMakeLists.txt
@@ -1,13 +1,13 @@
 include(FetchContent)
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 # Google test download and setup
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
 )
 FetchContent_MakeAvailable(googletest)
-
-find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 add_test(NAME ChatPythonTests
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/python_tests


### PR DESCRIPTION
This would allow GPT4All to be built without Python, without any special flags.

By default, the `test` and `check` targets are made available only if Python is found. Setting `-DGPT4ALL_TEST=ON` will explicitly require Python in order to run the tests. Setting `-DGPT4ALL_TEST=OFF` will prevent the tests from being built.