### PR TITLE
codespell: update .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = blong, afterall, som, assistent, crasher
-skip = .git,*.pdf,*.svg,*.lock,*.ts
+ignore-words-list = blong, afterall, assistent, crasher, requestor
+skip = ./.git,./gpt4all-chat/translations,*.pdf,*.svg,*.lock


### PR DESCRIPTION
This fixes the codespell-related check failure after #3116.

The CircleCI failure due to no workflows running can be ignored and will be fixed in an upcoming PR.