### PR TITLE
Fix apparent CI failure due to "All Workflows filtered"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  path-filtering: circleci/path-filtering@0.0.1
+  path-filtering: circleci/path-filtering@1.1.0
 
 workflows:
   version: 2.1

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -19,6 +19,13 @@ parameters:
     default: false
 
 jobs:
+  # work around CircleCI-Public/path-filtering-orb#20
+  noop:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: "true"
+
   build-offline-chat-installer-macos:
     macos:
       xcode: 15.4.0
@@ -1451,6 +1458,16 @@ jobs:
 
 workflows:
   version: 2
+  noop:
+    when:
+      not:
+        or:
+          - << pipeline.parameters.run-all-workflows >>
+          - << pipeline.parameters.run-python-workflow >>
+          - << pipeline.parameters.run-ts-workflow >>
+          - << pipeline.parameters.run-chat-workflow >>
+    jobs:
+      - noop
   build-chat-offline-installers:
     when:
       or:


### PR DESCRIPTION
This workflow was removed in #2941 because it didn't have a clear purpose.

I realized recently that always running at least one workflow prevents GitHub from complaining when no files are changed.

Now that its purpose is understood, add it back with a clearer description and a more selective `when` condition (so it only runs when nothing else does).