### PR TITLE
cmake: set minimum Qt version back to 6.5

### DIFF
--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -75,7 +75,7 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/config.h"
 )
 
-find_package(Qt6 6.4 COMPONENTS Core HttpServer LinguistTools Pdf Quick QuickDialogs2 Sql Svg REQUIRED)
+find_package(Qt6 6.5 COMPONENTS Core HttpServer LinguistTools Pdf Quick QuickDialogs2 Sql Svg REQUIRED)
 
 if (QT_KNOWN_POLICY_QTP0004)
     qt_policy(SET QTP0004 NEW)  # generate extra qmldir files on Qt 6.8+


### PR DESCRIPTION
Sometime between #1928 and now, we broke compatibility with Qt 6.4. I discovered this while [trying to use](https://github.com/nomic-ai/gpt4all/actions/runs/11449664045/job/31855669107?pr=3125) system Qt on Ubuntu 24.04 (and this was *after* making all of our references to the `<QtLogging>` header conditional).

It has been EOL since September 2023 and doesn't show up in the Qt installer by default anymore, so I don't think we should worry about it. But we should make this a hard requirement in the build script rather than failing to compile later.