### PR TITLE
chatllm: remove use of deprecated '_qs'

### DIFF
--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -198,7 +198,7 @@ bool ChatLLM::loadDefaultModel()
 {
     ModelInfo defaultModel = ModelList::globalInstance()->defaultModelInfo();
     if (defaultModel.filename().isEmpty()) {
-        emit modelLoadingError(u"Could not find any model to load"_qs);
+        emit modelLoadingError(u"Could not find any model to load"_s);
         return false;
     }
     return loadModel(defaultModel);


### PR DESCRIPTION
The `""_qs` operator was deprecated in Qt 6.8. It's the old way of spelling `""_s`.