### PR TITLE
We can't return early here as nChunks > 0

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Implement Qt 6.8 compatibility ([#3121](https://github.com/nomic-ai/gpt4all/pull/3121))
 
+### Fixed
+- Fix bug in GUI when localdocs encounters binary data ([#3137](https://github.com/nomic-ai/gpt4all/pull/3137))
+
 ## [3.4.2] - 2024-10-16
 
 ### Fixed


### PR DESCRIPTION
We can't return early here as nChunks could be greater than zero in which case we have to update the item statistics. They will be skipped when we generate the embeddings.

Fixes issue #2729.
