### PR TITLE
Remove unused state in chat.cpp that saves the chat response messages.

### DIFF
--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -186,11 +186,6 @@ void Chat::stopGenerating()
     m_llmodel->stopGenerating();
 }
 
-QString Chat::response() const
-{
-    return m_response;
-}
-
 Chat::ResponseState Chat::responseState() const
 {
     return m_responseState;
@@ -203,10 +198,8 @@ void Chat::handleResponseChanged(const QString &response)
         emit responseStateChanged();
     }
 
-    m_response = response;
     const int index = m_chatModel->count() - 1;
-    m_chatModel->updateValue(index, this->response());
-    emit responseChanged();
+    m_chatModel->updateValue(index, response);
 }
 
 void Chat::handleModelLoadingPercentageChanged(float loadingPercentage)
@@ -246,7 +239,6 @@ void Chat::responseStopped(qint64 promptResponseMs)
 {
     m_tokenSpeed = QString();
     emit tokenSpeedChanged();
-    emit responseChanged();
 
     m_responseInProgress = false;
     m_responseState = Chat::ResponseStopped;

--- a/gpt4all-chat/src/chat.h
+++ b/gpt4all-chat/src/chat.h
@@ -25,7 +25,6 @@ class Chat : public QObject
     Q_PROPERTY(bool isModelLoaded READ isModelLoaded NOTIFY isModelLoadedChanged)
     Q_PROPERTY(bool isCurrentlyLoading READ isCurrentlyLoading NOTIFY isCurrentlyLoadingChanged)
     Q_PROPERTY(float modelLoadingPercentage READ modelLoadingPercentage NOTIFY modelLoadingPercentageChanged)
-    Q_PROPERTY(QString response READ response NOTIFY responseChanged)
     Q_PROPERTY(ModelInfo modelInfo READ modelInfo WRITE setModelInfo NOTIFY modelInfoChanged)
     Q_PROPERTY(bool responseInProgress READ responseInProgress NOTIFY responseInProgressChanged)
     Q_PROPERTY(bool restoringFromText READ restoringFromText NOTIFY restoringFromTextChanged)
@@ -89,7 +88,6 @@ public:
 
     QList<ResultInfo> databaseResults() const { return m_databaseResults; }
 
-    QString response() const;
     bool responseInProgress() const { return m_responseInProgress; }
     ResponseState responseState() const;
     ModelInfo modelInfo() const;
@@ -143,7 +141,6 @@ Q_SIGNALS:
     void isCurrentlyLoadingChanged();
     void modelLoadingPercentageChanged();
     void modelLoadingWarning(const QString &warning);
-    void responseChanged();
     void responseInProgressChanged();
     void responseStateChanged();
     void promptRequested(const QList<QString> &collectionList, const QString &prompt);
@@ -195,7 +192,6 @@ private:
     QString m_tokenSpeed;
     QString m_device;
     QString m_fallbackReason;
-    QString m_response;
     QList<QString> m_collections;
     QList<QString> m_generatedQuestions;
     ChatModel *m_chatModel;


### PR DESCRIPTION
This appears unused. I've verified that the code still compiles, I cannot find any references to this in current QML code, there are no runtime error messages from QML code when I use a model for generation.

Getting rid of this will help enable a future refactoring where chatllm will communicate with chatmodel directly instead of using the chat instance as a go-between.

This is intended as a completely non-functional change.