### PR TITLE
Generate three word chat names

### DIFF
--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -308,11 +308,8 @@ void Chat::trySwitchContextOfLoadedModel()
 
 void Chat::generatedNameChanged(const QString &name)
 {
-    // Only use the first three words maximum and remove newlines and extra spaces
-    m_generatedName = name.simplified();
-    QStringList words = m_generatedName.split(' ', Qt::SkipEmptyParts);
-    int wordCount = qMin(7, words.size());
-    m_name = words.mid(0, wordCount).join(' ');
+    m_generatedName = name;
+    m_name = name;
     emit nameChanged();
     m_needsSave = true;
 }

--- a/gpt4all-chat/src/modellist.h
+++ b/gpt4all-chat/src/modellist.h
@@ -218,7 +218,7 @@ private:
     int     m_repeatPenaltyTokens     = 64;
     QString m_promptTemplate;
     QString m_systemPrompt;
-    QString m_chatNamePrompt          = "Describe the above conversation in seven words or less.";
+    QString m_chatNamePrompt          = "Describe the above conversation in three words or less.";
     QString m_suggestedFollowUpPrompt = "Suggest three very short factual follow-up questions that have not been answered yet or cannot be found inspired by the previous conversation and excerpts.";
     friend class MySettings;
 };


### PR DESCRIPTION
This doesn't belong in the Jinja PR, but it's based on it so it will have to be merged afterwards.

The last commit is the important one. Since v3.0.0, we have generated seven word chat names and truncated them to four words. The magic constant "3" combined with the original message using the word "three" indicates that we actually intend to have three word chat names.