### PR TITLE
llamamodel: add missing softmax sampler

### DIFF
--- a/gpt4all-backend/src/llamamodel.cpp
+++ b/gpt4all-backend/src/llamamodel.cpp
@@ -589,7 +589,8 @@ void LLamaModel::initSampler(PromptContext &promptCtx)
             llama_sampler_init_top_p(promptCtx.top_p, 1),
             llama_sampler_init_min_p(promptCtx.min_p, 1),
             llama_sampler_init_temp(promptCtx.temp),
-            llama_sampler_init_dist(LLAMA_DEFAULT_SEED)
+            llama_sampler_init_softmax(),
+            llama_sampler_init_dist(LLAMA_DEFAULT_SEED),
         };
         for (auto *smpl : samplers)
             llama_sampler_chain_add(chain, smpl);


### PR DESCRIPTION
This fixes the discrete_distribution-related assertion failure for certain sampler settings, and likely improves output quality in cases where GPT4All does not crash - since we were not even computing the probabilities of the remaining top-K (typically 20) tokens in some cases.