### PR TITLE
Fix local server ignoring assistant messages in history

### DIFF
--- a/gpt4all-chat/src/chatmodel.h
+++ b/gpt4all-chat/src/chatmodel.h
@@ -111,8 +111,13 @@ public:
     ChatItem(prompt_tag_t, const QString &value, const QList<PromptAttachment> &attachments = {})
         : name(u"Prompt: "_s), value(value), promptAttachments(attachments) {}
 
-    ChatItem(response_tag_t, bool isCurrentResponse = true)
-        : name(u"Response: "_s), isCurrentResponse(isCurrentResponse) {}
+    // A new response, to be filled in
+    ChatItem(response_tag_t)
+        : name(u"Response: "_s), isCurrentResponse(true) {}
+
+    // An existing response, from Server
+    ChatItem(response_tag_t, const QString &value)
+        : name(u"Response: "_s), value(value) {}
 
     Type type() const
     {

--- a/gpt4all-chat/src/server.cpp
+++ b/gpt4all-chat/src/server.cpp
@@ -775,9 +775,9 @@ auto Server::handleChatRequest(const ChatRequest &request)
     for (auto &message : request.messages) {
         using enum ChatRequest::Message::Role;
         switch (message.role) {
-            case System:    chatItems.emplace_back(ChatItem::system_tag, message.content); break;
-            case User:      chatItems.emplace_back(ChatItem::prompt_tag, message.content); break;
-            case Assistant: chatItems.emplace_back(ChatItem::response_tag, /*currentResponse*/ false); break;
+            case System:    chatItems.emplace_back(ChatItem::system_tag,   message.content); break;
+            case User:      chatItems.emplace_back(ChatItem::prompt_tag,   message.content); break;
+            case Assistant: chatItems.emplace_back(ChatItem::response_tag, message.content); break;
         }
     }
     m_chatModel->appendResponseWithHistory(chatItems);


### PR DESCRIPTION
This was originally fixed in #2929 (the first time it worked), but was broken again in #3147. We should write an automated test for this so we don't break it again.

This is a simple test of the message history using the local server:
```
user: What is your name?
assistant: My name is Bob.
user: Could you repeat that?
```

This works after #2929, with a different response depending on the model:
```
assistant: I'm just an AI, I don't have a personal name. I was initialized with the name "Bob" for testing purposes, but it's not my actual identity.
```

It is broken on main:
```
assistant: I apologize, but I didn't say anything yet! This is the beginning of our conversation.
```

This PR fixes that.

See also: #2602