### PR TITLE
modellist: fix cloning of chat template and system message

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Fix mishandling of default chat template and system message of cloned models in 3.5.0 ([#3262](https://github.com/nomic-ai/gpt4all/pull/3262))
+
 ## [3.5.1] - 2024-12-10
 
 ### Fixed
@@ -211,6 +216,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix several Vulkan resource management issues ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
 - Fix crash/hang when some models stop generating, by showing special tokens ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
 
+[Unreleased]: https://github.com/nomic-ai/gpt4all/compare/v3.5.1...HEAD
 [3.5.1]: https://github.com/nomic-ai/gpt4all/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/nomic-ai/gpt4all/compare/v3.5.0-rc2...v3.5.0
 [3.5.0-rc2]: https://github.com/nomic-ai/gpt4all/compare/v3.5.0-rc1...v3.5.0-rc2

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix API server ignoring assistant messages in history after v3.5.0 ([#3256](https://github.com/nomic-ai/gpt4all/pull/3256))
 - Fix API server replying with incorrect token counts and stop reason after v3.5.0 ([#3256](https://github.com/nomic-ai/gpt4all/pull/3256))
 - Fix API server remembering previous, unrelated conversations after v3.5.0 ([#3256](https://github.com/nomic-ai/gpt4all/pull/3256))
-- Fix mishandling of default chat template and system message of cloned models in 3.5.0 ([#3262](https://github.com/nomic-ai/gpt4all/pull/3262))
+- Fix mishandling of default chat template and system message of cloned models in v3.5.0 ([#3262](https://github.com/nomic-ai/gpt4all/pull/3262))
 
 ## [3.5.1] - 2024-12-10
 


### PR DESCRIPTION
When you change a model's system message and chat template from the defaults, and then clone it, one would expect the "Reset" and/or "Clear" options on these settings to still be available (and reset to the official defaults).

Additionally, one would expect the overrides for these settings to be preserved after a restart of GPT4All if they came from overrides on the base model.

Neither of these things was working properly, because of a mistake in the clone() call - instead of copying the defaults to the defaults and the overrides to the overrides, we copied the overrides to the defaults and didn't set the overrides. So the Reset/Clear buttons were not available. And defaults are intentionally not serialized, so after a restart the clone would act like you had clicked Reset on both settings.

Most settings don't typically come from defaults in models3.json, so none of this applies to them in practice (even though ideally they would also work this way).

This is a regression in #3147, although the way the defaults of these settings are handled was entirely new in that PR, so one could argue that until this PR this never worked quite right.