### PR TITLE
ci: downgrade Windows image to fix build

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -462,7 +462,7 @@ jobs:
 
   build-offline-chat-installer-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -553,7 +553,7 @@ jobs:
 
   sign-offline-chat-installer-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -586,7 +586,7 @@ jobs:
 
   build-online-chat-installer-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -684,7 +684,7 @@ jobs:
 
   sign-online-chat-installer-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -784,7 +784,7 @@ jobs:
 
   build-gpt4all-chat-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -1047,7 +1047,7 @@ jobs:
 
   build-py-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:
@@ -1244,7 +1244,7 @@ jobs:
 
   build-bindings-backend-windows:
     machine:
-      image: windows-server-2022-gui:current
+      image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass
     steps:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -462,6 +462,7 @@ jobs:
 
   build-offline-chat-installer-windows:
     machine:
+      # we use 2024.04.01 because nvcc complains about the MSVC ver if we use anything newer
       image: windows-server-2022-gui:2024.04.1
       resource_class: windows.large
       shell: powershell.exe -ExecutionPolicy Bypass


### PR DESCRIPTION
CircleCI recently updated "current" tag of the "windows-server-2022-gui" image from 2024.04.1 to 2024.12.1, which [broke nvcc](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/4023/workflows/1aec9d7f-9f40-44df-914d-4416b446eb74/jobs/22586).

>   C:\Program Files\NVIDIA GPU Computing
  Toolkit\CUDA\v11.8\include\crt/host_config.h(153): fatal error C1189:
  #error: -- unsupported Microsoft Visual Studio version! Only the versions
  between 2017 and 2022 (inclusive) are supported! The nvcc flag
  '-allow-unsupported-compiler' can be used to override this version check;
  however, using an unsupported host compiler may cause compilation failure
  or incorrect run time execution.  Use at your own risk.

Downgrade back to 2024.04.1 to work around this incompatibility. I tried 2024.07.1 but it had the same issue.