### PR TITLE
Fix Jinja2Cpp bug that broke system msg detection in templates

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fix remote model template to allow for XML in messages ([#3318](https://github.com/nomic-ai/gpt4all/pull/3318))
+- Fix Jinja2Cpp bug that broke system message detection in chat templates ([#3325](https://github.com/nomic-ai/gpt4all/pull/3325))
 
 ## [3.5.3] - 2024-12-16
 


### PR DESCRIPTION
### Description
This PR fixes system message detection in the chat template of models such as Mistral Instruct which handle it specially. The bug is not always easy to reproduce, but it seems to occur most reliably on Windows. The symptom is that when trying to chat with Mistral Instruct with a system prompt set, you get this instead of a response:

> ﻿Error: Failed to parse chat template: 1:1: error: Unexpected exception occurred during template processing. Exception: Jinja template error: After the optional system message, conversation roles must alternate user/assistant/user/assistant/...

### Details
The prompt template in question:
```jinja
{%- if messages[0]['role'] == 'system' %}
    {%- set system_message = messages[0]['content'] %}
    {%- set loop_start = 1 %}
{%- else %}
    {%- set loop_start = 0 %}
{%- endif %}
{%- for message in messages %}
    {%- if loop.index0 >= loop_start %}
        {%- if (message['role'] == 'user') != ((loop.index0 - loop_start) % 2 == 0) %}
            {{- raise_exception('After the optional system message, conversation roles must alternate user/assistant/user/assistant/...') }}
        {%- endif %}
        # ... message processing omitted for brevity ...
    {%- endif %}
{%- endfor %}
```

With Mistral Instruct, the Jinja2Cpp bug (see below) manifested as it missing the system prompt at `messages[0]`, but then finding it as the first message in the `{%- for message in messages %}` loop, which caused it to call raise_exception as it was expecting it to be a user message instead.

### The Fix
From the commit I added to the submodule:

    template_parser: fix failure to clear errno before strtoll
    
    This caused chaos if errno was ERANGE while calling Load +
    RenderAsString and parsing a template with integer literals in
    subscripts (e.g. messages[0]['content']).
    
    The integer literals would parse as floating point numbers, which
    ListAdapter doesn't implement subscript for, and all subscripts with
    constant integers would return EmptyValue.