### PR TITLE
qml: fix missing localdocs and prefill progress

### DIFF
--- a/gpt4all-chat/qml/ChatItemView.qml
+++ b/gpt4all-chat/qml/ChatItemView.qml
@@ -36,7 +36,6 @@ GridLayout {
         Layout.preferredWidth: 32
         Layout.preferredHeight: 32
         Layout.topMargin: model.index > 0 ? 25 : 0
-        visible: content !== "" || childItems.length > 0
 
         Image {
             id: logo
@@ -71,7 +70,6 @@ GridLayout {
         Layout.fillWidth: true
         Layout.preferredHeight: 38
         Layout.topMargin: model.index > 0 ? 25 : 0
-        visible: content !== "" || childItems.length > 0
 
         RowLayout {
             spacing: 5


### PR DESCRIPTION
Follow-up to #3173 that seems to fix a regression in the progress display.

This progress output is crucial when waiting minutes for a slow embedding job or prompt processing, especially on CPU.