### PR TITLE
jinja2cpp: update submodule for else/endif crash fix

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix the timeout error in code interpreter ([#3369](https://github.com/nomic-ai/gpt4all/pull/3369))
 - Fix code interpreter console.log not accepting multiple arguments ([#3371](https://github.com/nomic-ai/gpt4all/pull/3371))
 - Remove 'X is defined' checks from templates as they work incorrectly with Jinja2Cpp ([#3372](https://github.com/nomic-ai/gpt4all/pull/3372))
+- Jinja2Cpp: Add 'if' requirement for 'else' parsing to fix crash ([#3373](https://github.com/nomic-ai/gpt4all/pull/3373))
 
 ## [3.6.1] - 2024-12-20
 


### PR DESCRIPTION
Using AFL I found that GPT4All would consistently crash with a stack-buffer-overflow when the following text is entered into the chat template box: `{% else %}{% endif %}{{`

<details>
<summary>ASAN Report</summary>

```
==567001==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffee048218 at pc 0x55555bc4873b bp 0x7fffffff6d60 sp 0x7fffffff6d50
READ of size 8 at 0x7fffee048218 thread T0
    #0 0x55555bc4873a in std::__shared_ptr<jinja2::ComposedRenderer, (__gnu_cxx::_Lock_policy)2>::get() const /usr/include/c++/14.2.1/bits/shared_ptr_base.h:1667
    #1 0x55555bc1c2cb in std::__shared_ptr_access<jinja2::ComposedRenderer, (__gnu_cxx::_Lock_policy)2, false, false>::_M_get() const /usr/include/c++/14.2.1/bits/shared_ptr_base.h:1364
    #2 0x55555bbe6d80 in std::__shared_ptr_access<jinja2::ComposedRenderer, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const /usr/include/c++/14.2.1/bits/shared_ptr_base.h:1358
    #3 0x55555bbb71e0 in jinja2::TemplateParser<char>::DoFineParsing(std::shared_ptr<jinja2::ComposedRenderer>) (/home/jared/src/own/gpt4all/gpt4all-chat/build.asan/bin/chat+0x66631e0) (BuildId: 844e167d2e7ee702d799d6b513768718f310764a)
    #4 0x55555bb96d3c in jinja2::TemplateParser<char>::Parse() (/home/jared/src/own/gpt4all/gpt4all-chat/build.asan/bin/chat+0x6642d3c) (BuildId: 844e167d2e7ee702d799d6b513768718f310764a)
    #5 0x55555bb6ed1e in jinja2::TemplateImpl<char>::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/jared/src/own/gpt4all/gpt4all-chat/deps/Jinja2Cpp/src/template_impl.h:225
    #6 0x55555bb319e8 in jinja2::Template::Load(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/jared/src/own/gpt4all/gpt4all-chat/deps/Jinja2Cpp/src/template.cpp:44
    #7 0x55555a90a7ea in loadJinjaTemplate /home/jared/src/own/gpt4all/gpt4all-chat/src/chatllm.cpp:765
    #8 0x55555a90aa29 in ChatLLM::checkJinjaTemplateError(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/jared/src/own/gpt4all/gpt4all-chat/src/chatllm.cpp:771
    #9 0x55555aeaaf61 in MySettings::checkJinjaTemplateError(QString const&) /home/jared/src/own/gpt4all/gpt4all-chat/src/mysettings.cpp:179
    #10 0x55555a613586 in MySettings::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/jared/src/own/gpt4all/gpt4all-chat/build.asan/chat_autogen/UVLADIE3JM/moc_mysettings.cpp:778
    #11 0x55555a63430e in MySettings::qt_metacall(QMetaObject::Call, int, void**) /home/jared/src/own/gpt4all/gpt4all-chat/build.asan/chat_autogen/UVLADIE3JM/moc_mysettings.cpp:1589
    #12 0x7ffff5f14a8a  (/usr/lib/libQt6Qml.so.6+0x314a8a) (BuildId: 347d88bfffc01e618fed39d98aceb125c38ae148)
    #13 0x7ffff5dde76a in QV4::QObjectMethod::callPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*, QMetaObject::Call) (/usr/lib/libQt6Qml.so.6+0x1de76a) (BuildId: 347d88bfffc01e618fed39d98aceb125c38ae148)
    #14 0x7ffff5de89dc in QV4::QObjectMethod::callInternal(QV4::Value const*, QV4::Value const*, int) const (/usr/lib/libQt6Qml.so.6+0x1e89dc) (BuildId: 347d88bfffc01e618fed39d98aceb125c38ae148)
    #15 0x7ffff5e0523c in QV4::Runtime::CallPropertyLookup::call(QV4::ExecutionEngine*, QV4::Value const&, unsigned int, QV4::Value*, int) (/usr/lib/libQt6Qml.so.6+0x20523c) (BuildId: 347d88bfffc01e618fed39d98aceb125c38ae148)
    #16 0x7fffbac04a7d  (/memfd:JITCode:QtQml (deleted)+0xa7d)

Address 0x7fffee048218 is located in stack of thread T0 at offset 536 in frame
    #0 0x55555bbb658b in jinja2::TemplateParser<char>::DoFineParsing(std::shared_ptr<jinja2::ComposedRenderer>) (/home/jared/src/own/gpt4all/gpt4all-chat/build.asan/bin/chat+0x666258b) (BuildId: 844e167d2e7ee702d799d6b513768718f310764a)

  This frame has 21 object(s):
    [32, 40) '__for_begin' (line 640)
    [64, 72) '__for_end' (line 640)
    [96, 104) '<unknown>'
    [128, 136) '<unknown>'
    [160, 168) '<unknown>'
    [192, 208) '<unknown>'
    [224, 240) 'range' (line 651)
    [256, 272) 'renderer' (line 654)
    [288, 304) '<unknown>'
    [320, 336) 'range' (line 660)
    [352, 368) 'metadata' (line 663)
    [384, 400) '<unknown>'
    [416, 432) '<unknown>'
    [448, 472) 'errors' (line 636)
    [512, 536) 'statementsStack' (line 637) <== Memory access at offset 536 overflows this variable
    [576, 600) 'block' (line 642)
    [640, 664) '<unknown>'
    [704, 824) '<unknown>'
    [864, 1024) 'parseResult' (line 670)
    [1088, 1248) 'parseResult' (line 680)
    [1312, 1496) 'root' (line 638)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /usr/include/c++/14.2.1/bits/shared_ptr_base.h:1667 in std::__shared_ptr<jinja2::ComposedRenderer, (__gnu_cxx::_Lock_policy)2>::get() const
Shadow bytes around the buggy address:
  0x7fffee047f80: f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5 f5
  0x7fffee048000: f1 f1 f1 f1 00 f2 f2 f2 00 f2 f2 f2 f8 f2 f2 f2
  0x7fffee048080: f8 f2 f2 f2 00 f2 f2 f2 f8 f8 f2 f2 00 00 f2 f2
  0x7fffee048100: 00 00 f2 f2 00 00 f2 f2 00 00 f2 f2 00 00 f2 f2
  0x7fffee048180: 00 00 f2 f2 00 00 f2 f2 00 00 00 f2 f2 f2 f2 f2
=>0x7fffee048200: 00 00 00[f2]f2 f2 f2 f2 00 00 00 f2 f2 f2 f2 f2
  0x7fffee048280: 00 00 00 f2 f2 f2 f2 f2 f8 f8 f8 f8 f8 f8 f8 f8
  0x7fffee048300: f8 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 f2 00 00 00 00
  0x7fffee048380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7fffee048400: f2 f2 f2 f2 f2 f2 f2 f2 f8 f8 f8 f8 f8 f8 f8 f8
  0x7fffee048480: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==567001==ABORTING
```

</details>

This is fixed by adding a check to the "else" and "elif" parsing for an opening "if" statement.