### PR TITLE
jinja2cpp: update submodule for partial subscript crash fix

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Remove 'X is defined' checks from templates as they work incorrectly with Jinja2Cpp ([#3372](https://github.com/nomic-ai/gpt4all/pull/3372))
 - Jinja2Cpp: Add 'if' requirement for 'else' parsing to fix crash ([#3373](https://github.com/nomic-ai/gpt4all/pull/3373))
 - Save chats on quit, even if the window isn't closed first ([#3387](https://github.com/nomic-ai/gpt4all/pull/3387))
+- Fix crash when entering `{{ a["foo"(` as chat template ([#3394](https://github.com/nomic-ai/gpt4all/pull/3394))
 
 ## [3.6.1] - 2024-12-20
 


### PR DESCRIPTION
This fixes the crash when you enter this text in the chat template field:
```
{{ a["foo"(
```

The crash was caused by this assertion failure:
> nonstd/expected.hpp:2173: nonstd::expected_lite::expected<T, E>::value_type& nonstd::expected_lite::expected<T, E>::operator*() & [with T = std::shared_ptr\<jinja2::ExpressionEvaluatorBase\>; E = jinja2::ParseError; value_type = std::shared_ptr\<jinja2::ExpressionEvaluatorBase>]: Assertion `has_value()' failed.`