### PR TITLE
ci: add missing context to Windows ARM builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1772,9 +1772,11 @@ workflows:
           requires:
             - build-offline-chat-installer-windows
       - build-offline-chat-installer-windows-arm:
+          context: gpt4all
           requires:
             - hold
       - sign-offline-chat-installer-windows-arm:
+          context: gpt4all
           requires:
             - build-offline-chat-installer-windows-arm
       - build-offline-chat-installer-linux:
@@ -1817,10 +1819,12 @@ workflows:
             - build-online-chat-installer-windows
       - build-online-chat-installer-windows-arm:
           <<: *main_only
+          context: gpt4all
           requires:
             - hold
       - sign-online-chat-installer-windows-arm:
           <<: *main_only
+          context: gpt4all
           requires:
             - build-online-chat-installer-windows-arm
       - build-online-chat-installer-linux:


### PR DESCRIPTION
The Windows ARM PR (#3385) was merged without resolving a conflict with the PR to share secrets with Enterprise (#3392).

This should fix the build which is currently failing because of this: https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/4164/workflows/9df52149-2582-4db6-ae12-13877c916ca7/jobs/23327