### PR TITLE
jinja2cpp: update submodule for 'not X is defined' fix

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -12,12 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fix the timeout error in code interpreter ([#3369](https://github.com/nomic-ai/gpt4all/pull/3369))
 - Fix code interpreter console.log not accepting multiple arguments ([#3371](https://github.com/nomic-ai/gpt4all/pull/3371))
-- Remove 'X is defined' checks from templates as they work incorrectly with Jinja2Cpp ([#3372](https://github.com/nomic-ai/gpt4all/pull/3372))
+- Remove 'X is defined' checks from templates for better compatibility ([#3372](https://github.com/nomic-ai/gpt4all/pull/3372))
 - Jinja2Cpp: Add 'if' requirement for 'else' parsing to fix crash ([#3373](https://github.com/nomic-ai/gpt4all/pull/3373))
 - Save chats on quit, even if the window isn't closed first ([#3387](https://github.com/nomic-ai/gpt4all/pull/3387))
 - Add chat template replacements for five new models and fix EM German Mistral ([#3393](https://github.com/nomic-ai/gpt4all/pull/3393))
 - Fix crash when entering `{{ a["foo"(` as chat template ([#3394](https://github.com/nomic-ai/gpt4all/pull/3394))
 - Sign the maintenance tool on macOS to prevent crash on Sonoma ([#3391](https://github.com/nomic-ai/gpt4all/pull/3391))
+- Jinja2Cpp: Fix operator precedence in 'not X is defined' ([#3402](https://github.com/nomic-ai/gpt4all/pull/3402))
 
 ## [3.6.1] - 2024-12-20
 


### PR DESCRIPTION
It turns out that the reason #3372 was needed was that `if not add_generation_prompt is defined` was meant to be parsed as `if not (add_generation_prompt is defined)`, which is how it works in Jinja2Cpp and also how those operators work in the Python language [itself](https://docs.python.org/3/reference/expressions.html#operator-precedence) ('is' binds more strongly than 'not').

But Jinja2Cpp parsed that as `if (not add_generation_prompt) is defined`, which when read that way is nonsense&mdash;it will always be true, so the conditional will always be executed.

With this change, the operator precedence is corrected, so Jinja2Cpp is able to interpret these expressions in the expected manner. This leaves list slicing as the primary limitation preventing Jinja2Cpp from being compatible with most prompt templates.