### PR TITLE
chat: release version 3.7.0

### DIFF
--- a/gpt4all-chat/metadata/latestnews.md
+++ b/gpt4all-chat/metadata/latestnews.md
@@ -1,6 +1,6 @@
 ## Latest News
 
-GPT4All v3.7.0 was released on January 22nd. Changes include:
+GPT4All v3.7.0 was released on January 23rd. Changes include:
 
 * **Windows ARM Support:** GPT4All now supports the Windows ARM platform, ensuring compatibility with devices powered by Qualcomm Snapdragon and Microsoft SQ-series processors.
   * **NOTE:** Support for GPU and/or NPU acceleration is not available at this time. Only the CPU will be used to run LLMs.

--- a/gpt4all-chat/metadata/latestnews.md
+++ b/gpt4all-chat/metadata/latestnews.md
@@ -1,16 +1,17 @@
 ## Latest News
 
-GPT4All v3.6.1 was released on December 20th and fixes issues with the stop generation and copy conversation buttons which were broken in v3.6.0.
+GPT4All v3.7.0 was released on January 22nd. Changes include:
 
----
-
-GPT4All v3.6.0 was released on December 19th. Changes include:
-
-* **Reasoner v1:**
-  * Built-in javascript code interpreter tool.
-  * Custom curated model that utilizes the code interpreter to break down, analyze, perform, and verify complex reasoning tasks.
-* **Templates:** Automatically substitute chat templates that are not compatible with Jinja2Cpp in GGUFs.
-* **Fixes:**
-  * Remote model template to allow for XML in messages.
-  * Jinja2Cpp bug that broke system message detection in chat templates.
-  * LocalDocs sources displaying in unconsolidated form after v3.5.0.
+* **Windows ARM Support:** GPT4All now supports the Windows ARM platform, ensuring compatibility with devices powered by Qualcomm Snapdragon and Microsoft SQ-series processors.
+  * **NOTE:** Support for GPU and/or NPU acceleration is not available at this time. Only the CPU will be used to run LLMs.
+  * **NOTE:** You must install the new *Windows ARM* version of GPT4All from the website. The standard *Windows* version will not work due to emulation limitations.
+* **Fixed Updating on macOS:** The maintenance tool no longer crashes when attempting to update or uninstall GPT4All on Sequoia.
+  * **NOTE:** If you have installed the version from the GitHub releases as a workaround for this issue, you can safely uninstall it and switch back to the version from the website.
+* **Fixed Chat Saving macOS:** Chats now save as expected when the application is quit with Command-Q.
+* **Code Interpreter Improvements:**
+  * The behavior when the code takes too long to execute and times out has been improved.
+  * console.log now accepts multiple arguments for better compatibility with native JavaScript.
+* **Chat Templating Improvements:**
+  * Two crashes and one compatibility issue have been fixed in the chat template parser.
+  * The default chat template for EM German Mistral has been fixed.
+  * Automatic replacements have been added for five new models as we continue to improve compatibility with common chat templates.

--- a/gpt4all-chat/metadata/release.json
+++ b/gpt4all-chat/metadata/release.json
@@ -251,12 +251,17 @@
   },
   {
     "version": "3.6.0",
-    "notes": "* **Reasoner v1:**\n  * Built-in javascript code interpreter tool.\n  * Custom curated model that utilizes the code interpreter to break down, analyze, perform, and verify complex reasoning tasks.\n* **Templates:** Automatically substitute chat templates that are not compatible with Jinja2Cpp in GGUFs.\n* **Fixes:**\n  * Remote model template to allow for XML in messages.\n  * Jinja2Cpp bug that broke system message detection in chat templates.\n  * LocalDocs sources displaying in unconsolidated form after v3.5.0.",
+    "notes": "* **Reasoner v1:**\n  * Built-in javascript code interpreter tool.\n  * Custom curated model that utilizes the code interpreter to break down, analyze, perform, and verify complex reasoning tasks.\n* **Templates:** Automatically substitute chat templates that are not compatible with Jinja2Cpp in GGUFs.\n* **Fixes:**\n  * Remote model template to allow for XML in messages.\n  * Jinja2Cpp bug that broke system message detection in chat templates.\n  * LocalDocs sources displaying in unconsolidated form after v3.5.0.\n",
     "contributors": "* Adam Treat (Nomic AI)\n* Jared Van Bortel (Nomic AI)"
   },
   {
     "version": "3.6.1",
-    "notes": "* **Fixes:**\n  * The stop generation button no longer working in v3.6.0.\n  * The copy entire conversation button no longer working in v3.6.0.",
+    "notes": "* **Fixes:**\n  * The stop generation button no longer working in v3.6.0.\n  * The copy entire conversation button no longer working in v3.6.0.\n",
     "contributors": "* Adam Treat (Nomic AI)"
+  },
+  {
+    "version": "3.7.0",
+    "notes": "* **Windows ARM Support:** GPT4All now supports the Windows ARM platform, ensuring compatibility with devices powered by Qualcomm Snapdragon and Microsoft SQ-series processors.\n  * **NOTE:** Support for GPU and/or NPU acceleration is not available at this time. Only the CPU will be used to run LLMs.\n  * **NOTE:** You must install the new *Windows ARM* version of GPT4All from the website. The standard *Windows* version will not work due to emulation limitations.\n* **Fixed Updating on macOS:** The maintenance tool no longer crashes when attempting to update or uninstall GPT4All on Sequoia.\n  * **NOTE:** If you have installed the version from the GitHub releases as a workaround for this issue, you can safely uninstall it and switch back to the version from the website.\n* **Fixed Chat Saving macOS:** Chats now save as expected when the application is quit with Command-Q.\n* **Code Interpreter Improvements:**\n  * The behavior when the code takes too long to execute and times out has been improved.\n  * console.log now accepts multiple arguments for better compatibility with native JavaScript.\n* **Chat Templating Improvements:**\n  * Two crashes and one compatibility issue have been fixed in the chat template parser.\n  * The default chat template for EM German Mistral has been fixed.\n  * Automatic replacements have been added for five new models as we continue to improve compatibility with common chat templates.\n",
+    "contributors": "* Jared Van Bortel (Nomic AI)\n* Adam Treat (Nomic AI)\n* Riccardo Giovanetti (`@Harvester62`)"
   }
 ]


### PR DESCRIPTION
These are the release notes for v3.7.0. This PR is not ready to merge yet because the online installers have not been fully uploaded.