### PR TITLE
ci: fix macOS codesigning

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -85,6 +85,16 @@ jobs:
               -DGPT4ALL_GEN_CPACK_CONFIG=ON
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target package
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake . -DGPT4ALL_GEN_CPACK_CONFIG=OFF
+            # The 'install' step here *should* be completely unnecessary. There is absolutely no reason we should have
+            # to copy all of the build artifacts to an output directory that we do not use (because we package GPT4All
+            # as an installer instead).
+            # However, because of the way signing is implemented in the cmake script, the *source* files are signed at
+            # install time instead of the *installed* files. This side effect is the *only* way libraries that are not
+            # processed by macdeployqt, such as libllmodel.so, get signed (at least, with -DBUILD_UNIVERSAL=ON).
+            # Also, we have to run this as a *separate* step. Telling cmake to run both targets in one command causes it
+            # to execute them in parallel, since it is not aware of the dependency of the package target on the install
+            # target.
+            ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target install
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target package
             ccache -s
             mkdir upload
@@ -224,6 +234,8 @@ jobs:
               -DGPT4ALL_GEN_CPACK_CONFIG=ON
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target package
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake . -DGPT4ALL_GEN_CPACK_CONFIG=OFF
+            # See comment above related to the 'install' target.
+            ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target install
             ~/Qt/Tools/CMake/CMake.app/Contents/bin/cmake --build . --target package
             ccache -s
             mkdir upload

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -10,6 +10,10 @@ set(APP_VERSION "${APP_VERSION_BASE}")
 
 project(gpt4all VERSION ${APP_VERSION_BASE} LANGUAGES CXX C)
 
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "..." FORCE)
+endif()
+
 if(APPLE)
   option(BUILD_UNIVERSAL "Build a Universal binary on macOS" OFF)
   if(BUILD_UNIVERSAL)
@@ -125,10 +129,6 @@ message(STATUS "qmake binary: ${QMAKE_EXECUTABLE}")
 message(STATUS "Qt 6 root directory: ${Qt6_ROOT_DIR}")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "..." FORCE)
-endif()
 
 add_subdirectory(deps)
 add_subdirectory(../gpt4all-backend llmodel)


### PR DESCRIPTION
On Sequoia, GPT4All builds made in CI crashed after #3391.

My local builds were signed successfully because I was not using `-DBUILD_UNIVERSAL=ON`. I do not really understand why that option affects code signing, but that's not important. This does however explain why I didn't catch this when I originally tested the build and verified that it was signed, even though I never run the `install` target.

What is important is that the way #2443 signs binaries in a way that is antithetical to the spirit of CMake: Instead of each task taking input and producing separate output files, forming an explicit dependency, there is a task manually added to the `install` target that signs the *source* binaries in the build dir *before* copying them, *in place*.

This means that running the `install` target *before* starting the package target (i.e., as an explicit and separate command) is necessary to produce a signed version of GPT4All. This was confirmed [here](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/4186/workflows/f88195a5-f95a-4d5c-b065-ce04e8d7774e/jobs/23500/artifacts). This was removed in #3391, but is now added back as a workaround until we can fix it properly.

As a bonus, this PR fixes a regression in the default install prefix caused by #3391 - otherwise, it is skipped the first time cmake is run, and already initialized the second time so it is not overridden. Which would cause the install step to fail without extra configuration (such as DESTDIR or --prefix) when using GPT4ALL_GEN_CPACK_CONFIG.