### PR TITLE
Fix regression while using localdocs with server API.

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Fix regression while using localdocs with server API ([#3410](https://github.com/nomic-ai/gpt4all/pull/3410))
+
 ## [3.7.0] - 2025-01-21
 
 ### Added

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -869,7 +869,7 @@ auto ChatLLM::promptInternalChat(const QStringList &enabledCollections, const LL
             auto &[promptIndex, queryStr] = *query;
             const int retrievalSize = MySettings::globalInstance()->localDocsRetrievalSize();
             emit requestRetrieveFromDB(enabledCollections, queryStr, retrievalSize, &databaseResults); // blocks
-            m_chatModel->updateSources(promptIndex + startOffset, databaseResults); // start offset is only for local server messages
+            m_chatModel->updateSources(promptIndex + startOffset, databaseResults);
             emit databaseResultsChanged(databaseResults);
         }
     }

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -869,7 +869,7 @@ auto ChatLLM::promptInternalChat(const QStringList &enabledCollections, const LL
             auto &[promptIndex, queryStr] = *query;
             const int retrievalSize = MySettings::globalInstance()->localDocsRetrievalSize();
             emit requestRetrieveFromDB(enabledCollections, queryStr, retrievalSize, &databaseResults); // blocks
-            m_chatModel->updateSources(promptIndex, databaseResults);
+            m_chatModel->updateSources(promptIndex + startOffset, databaseResults); // start offset is only for local server messages
             emit databaseResultsChanged(databaseResults);
         }
     }


### PR DESCRIPTION
We've had a regression since 3.5.x where the model was not using localdocs for N > 1 server api message. We weren't taking into account the idiosyncratic way the server uses the chatmodel so that we require an offset when updating the sources. 