### PR TITLE
codeinterpreter: permit console.log with single string arg

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix regression while using localdocs with server API ([#3410](https://github.com/nomic-ai/gpt4all/pull/3410))
 - Don't show system messages in server chat view ([#3411](https://github.com/nomic-ai/gpt4all/pull/3411))
 - Fix `codesign --verify` failure on macOS ([#3413](https://github.com/nomic-ai/gpt4all/pull/3413))
+- Code Interpreter: Fix console.log not accepting a single string after v3.7.0 ([#3426](https://github.com/nomic-ai/gpt4all/pull/3426))
 
 ## [3.7.0] - 2025-01-21
 

--- a/gpt4all-chat/src/codeinterpreter.cpp
+++ b/gpt4all-chat/src/codeinterpreter.cpp
@@ -102,6 +102,8 @@ void CodeInterpreterWorker::request(const QString &code)
     auto consoleObject = m_engine.evaluate(uR"(
         class Console {
             log(...args) {
+                if (args.length == 0)
+                    return;
                 if (args.length >= 2 && typeof args[0] === 'string')
                     throw new Error('console.log string formatting not supported');
                 let cat = '';

--- a/gpt4all-chat/src/codeinterpreter.cpp
+++ b/gpt4all-chat/src/codeinterpreter.cpp
@@ -102,7 +102,7 @@ void CodeInterpreterWorker::request(const QString &code)
     auto consoleObject = m_engine.evaluate(uR"(
         class Console {
             log(...args) {
-                if (args.length && typeof args[0] === 'string')
+                if (args.length >= 2 && typeof args[0] === 'string')
                     throw new Error('console.log string formatting not supported');
                 let cat = '';
                 for (const arg of args) {


### PR DESCRIPTION
See [the docs](https://developer.mozilla.org/en-US/docs/Web/API/console/log_static).

#3371 causes the `console.log(msg)` case to throw an error, which is overly restrictive.

Only throw an error if there are at least *two* arguments and the first one is a string, which is the case that we definitely cannot handle correctly without additional code.

Also make sure the zero-arg case is a no-op, to be consistent with standard JavaScript.