### PR TITLE
ci: selective signing and automatic release builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1800,15 +1800,18 @@ workflows:
         - << pipeline.parameters.run-all-workflows >>
         - << pipeline.parameters.run-chat-workflow >>
     jobs:
-      - hold:
+      - build-hold:
+          type: approval
+      - sign-hold:
           type: approval
       - build-offline-chat-installer-macos:
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-offline-chat-installer-macos:
           context: gpt4all
           requires:
+            - sign-hold
             - build-offline-chat-installer-macos
       - notarize-offline-chat-installer-macos:
           context: gpt4all
@@ -1817,15 +1820,16 @@ workflows:
       - build-offline-chat-installer-windows:
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-offline-chat-installer-windows:
           context: gpt4all
           requires:
+            - sign-hold
             - build-offline-chat-installer-windows
       - build-offline-chat-installer-windows-arm:
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-offline-chat-installer-windows-arm:
           context: gpt4all
           requires:
@@ -1833,25 +1837,29 @@ workflows:
       - build-offline-chat-installer-linux:
           context: gpt4all
           requires:
-            - hold
+            - build-hold
   build-chat-online-installers:
     when:
       or:
         - << pipeline.parameters.run-all-workflows >>
         - << pipeline.parameters.run-chat-workflow >>
     jobs:
-      - hold:
+      - build-hold:
+          <<: *job_only_main
+          type: approval
+      - sign-hold:
           <<: *job_only_main
           type: approval
       - build-online-chat-installer-macos:
           <<: *job_only_main
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-online-chat-installer-macos:
           <<: *job_only_main
           context: gpt4all
           requires:
+            - sign-hold
             - build-online-chat-installer-macos
       - notarize-online-chat-installer-macos:
           <<: *job_only_main
@@ -1862,17 +1870,18 @@ workflows:
           <<: *job_only_main
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-online-chat-installer-windows:
           <<: *job_only_main
           context: gpt4all
           requires:
+            - sign-hold
             - build-online-chat-installer-windows
       - build-online-chat-installer-windows-arm:
           <<: *job_only_main
           context: gpt4all
           requires:
-            - hold
+            - build-hold
       - sign-online-chat-installer-windows-arm:
           <<: *job_only_main
           context: gpt4all
@@ -1882,7 +1891,7 @@ workflows:
           <<: *job_only_main
           context: gpt4all
           requires:
-            - hold
+            - build-hold
   build-and-test-gpt4all-chat:
     when:
       or:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -25,6 +25,14 @@ jobs:
       - image: cimg/base:stable
     steps:
       - run: "true"
+  validate-commit-on-main:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run:
+          name: Verify that commit is on the main branch
+          command: git merge-base --is-ancestor HEAD main
   build-offline-chat-installer-macos:
     macos:
       xcode: 15.4.0
@@ -1782,6 +1790,13 @@ job_only_main: &job_only_main
     branches:
       only: main
 
+# allow a job to run on tags as well as commits
+job_allow_tags: &job_allow_tags
+  filters:
+    tags:
+      only:
+        - /.*/
+
 workflows:
   version: 2
   noop:
@@ -1794,6 +1809,94 @@ workflows:
           - << pipeline.parameters.run-chat-workflow >>
     jobs:
       - noop
+  build-chat-installers-release:
+    # only run on main branch tags that start with 'v'
+    when:
+      and:
+        - equal: [ << pipeline.git.branch >>, main ]
+        - matches: { pattern: '^v.*', value: << pipeline.git.tag >> }
+    jobs:
+      - validate-commit-on-main
+      - build-offline-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-offline-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-offline-chat-installer-macos
+      - notarize-offline-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - sign-offline-chat-installer-macos
+      - build-offline-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-offline-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-offline-chat-installer-windows
+      - build-offline-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-offline-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-offline-chat-installer-windows-arm
+      - build-offline-chat-installer-linux:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - build-online-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-online-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-macos
+      - notarize-online-chat-installer-macos:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - sign-online-chat-installer-macos
+      - build-online-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-online-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-windows
+      - build-online-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - sign-online-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-windows-arm
+      - build-online-chat-installer-linux:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
   build-chat-offline-installers:
     when:
       or:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1810,11 +1810,11 @@ workflows:
     jobs:
       - noop
   build-chat-installers-release:
-    # only run on main branch tags that start with 'v'
+    # only run on main branch tags that start with 'v' and a digit
     when:
       and:
         - equal: [ << pipeline.git.branch >>, main ]
-        - matches: { pattern: '^v.*', value: << pipeline.git.tag >> }
+        - matches: { pattern: '^v\d.*', value: << pipeline.git.tag >> }
     jobs:
       - validate-commit-on-main
       - build-offline-chat-installer-macos:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -22,10 +22,9 @@ jobs:
   # work around CircleCI-Public/path-filtering-orb#20
   noop:
     docker:
-      - image: cimg/base:current
+      - image: cimg/base:stable
     steps:
       - run: "true"
-
   build-offline-chat-installer-macos:
     macos:
       xcode: 15.4.0
@@ -1220,7 +1219,7 @@ jobs:
             cd gpt4all-bindings/typescript
             npm run docs:build
 
-  build-py-docs:
+  deploy-docs:
     docker:
       - image: circleci/python:3.8
     steps:
@@ -1424,7 +1423,7 @@ jobs:
           paths:
             - "*.whl"
 
-  publish-wheels:
+  deploy-wheels:
     docker:
       - image: circleci/python:3.8
     steps:
@@ -1721,7 +1720,7 @@ jobs:
             - prebuilds/win32-x64/*.node
             - runtimes/win32-x64/*-*.dll
 
-  prepare-npm-pkg:
+  deploy-npm-pkg:
     docker:
       - image: cimg/base:stable
     steps:
@@ -1777,7 +1776,8 @@ jobs:
             npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
             npm publish
 
-main_only: &main_only
+# only run a job on the main branch
+job_only_main: &job_only_main
   filters:
     branches:
       only: main
@@ -1841,45 +1841,45 @@ workflows:
         - << pipeline.parameters.run-chat-workflow >>
     jobs:
       - hold:
-          <<: *main_only
+          <<: *job_only_main
           type: approval
       - build-online-chat-installer-macos:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - hold
       - sign-online-chat-installer-macos:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - build-online-chat-installer-macos
       - notarize-online-chat-installer-macos:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - sign-online-chat-installer-macos
       - build-online-chat-installer-windows:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - hold
       - sign-online-chat-installer-windows:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - build-online-chat-installer-windows
       - build-online-chat-installer-windows-arm:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - hold
       - sign-online-chat-installer-windows-arm:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - build-online-chat-installer-windows-arm
       - build-online-chat-installer-linux:
-          <<: *main_only
+          <<: *job_only_main
           context: gpt4all
           requires:
             - hold
@@ -1905,14 +1905,13 @@ workflows:
             - hold
   deploy-docs:
     when:
-      or:
-        - << pipeline.parameters.run-all-workflows >>
-        - << pipeline.parameters.run-python-workflow >>
+      and:
+        - equal: [ << pipeline.git.branch >>, main ]
+        - or:
+            - << pipeline.parameters.run-all-workflows >>
+            - << pipeline.parameters.run-python-workflow >>
     jobs:
-      - build-ts-docs:
-          <<: *main_only
-      - build-py-docs:
-          <<: *main_only
+      - deploy-docs:
           context: gpt4all
   build-python:
     when:
@@ -1921,7 +1920,7 @@ workflows:
         - << pipeline.parameters.run-python-workflow >>
     jobs:
       - pypi-hold:
-          <<: *main_only
+          <<: *job_only_main
           type: approval
       - hold:
           type: approval
@@ -1934,8 +1933,8 @@ workflows:
       - build-py-windows:
           requires:
             - hold
-      - publish-wheels:
-          <<: *main_only
+      - deploy-wheels:
+          <<: *job_only_main
           context: gpt4all
           requires:
             - pypi-hold
@@ -1946,34 +1945,26 @@ workflows:
     when:
       or:
        - << pipeline.parameters.run-all-workflows >>
-       - << pipeline.parameters.run-python-workflow >>
        - << pipeline.parameters.run-ts-workflow >>
     jobs:
-      - hold:
+      - backend-hold:
           type: approval
       - nodejs-hold:
           type: approval
       - npm-hold:
-          <<: *main_only
+          <<: *job_only_main
+          type: approval
+      - docs-hold:
           type: approval
       - build-bindings-backend-linux:
           requires:
-            - hold
+            - backend-hold
       - build-bindings-backend-macos:
           requires:
-            - hold
+            - backend-hold
       - build-bindings-backend-windows:
           requires:
-            - hold
-
-      # NodeJs Jobs
-      - prepare-npm-pkg:
-          <<: *main_only
-          requires:
-            - npm-hold
-            - build-nodejs-linux
-            - build-nodejs-windows
-            - build-nodejs-macos
+            - backend-hold
       - build-nodejs-linux:
           requires:
             - nodejs-hold
@@ -1986,3 +1977,13 @@ workflows:
           requires:
             - nodejs-hold
             - build-bindings-backend-macos
+      - build-ts-docs:
+          requires:
+            - docs-hold
+      - deploy-npm-pkg:
+          <<: *job_only_main
+          requires:
+            - npm-hold
+            - build-nodejs-linux
+            - build-nodejs-windows
+            - build-nodejs-macos

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1845,50 +1845,40 @@ workflows:
         - << pipeline.parameters.run-chat-workflow >>
     jobs:
       - build-hold:
-          <<: *job_only_main
           type: approval
       - sign-hold:
-          <<: *job_only_main
           type: approval
       - build-online-chat-installer-macos:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - build-hold
       - sign-online-chat-installer-macos:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - sign-hold
             - build-online-chat-installer-macos
       - notarize-online-chat-installer-macos:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - sign-online-chat-installer-macos
       - build-online-chat-installer-windows:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - build-hold
       - sign-online-chat-installer-windows:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - sign-hold
             - build-online-chat-installer-windows
       - build-online-chat-installer-windows-arm:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - build-hold
       - sign-online-chat-installer-windows-arm:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - build-online-chat-installer-windows-arm
       - build-online-chat-installer-linux:
-          <<: *job_only_main
           context: gpt4all
           requires:
             - build-hold


### PR DESCRIPTION
See the commits for details. This PR has two main goals:
- Do not automatically sign and notarize non-release builds, since signing implies that we are confident in the contents of the executable&mdash;but this is not always the case, e.g. when building test installers for a community-submitted PR. This process can still be approved manually.
- Automatically build and sign all installers when a tag starting with `v` is pushed to the main branch.

The former appears to be set up correctly: see [here](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/4214/workflows/e98c11bd-03d7-47ac-8501-43c1dbbf673e) (offline) and [here](https://app.circleci.com/pipelines/github/nomic-ai/gpt4all/4214/workflows/ae05ce00-b7fb-4cba-b102-eec2a6fe1de4) (online). The latter can't easily be tested until this PR is merged.