### PR TITLE
Support DeepSeek-R1 Qwen

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Support DeepSeek-R1 Qwen models ([#3431](https://github.com/nomic-ai/gpt4all/pull/3431))
+
 ### Fixed
 - Fix regression while using localdocs with server API ([#3410](https://github.com/nomic-ai/gpt4all/pull/3410))
 - Don't show system messages in server chat view ([#3411](https://github.com/nomic-ai/gpt4all/pull/3411))

--- a/gpt4all-chat/src/jinja_replacements.cpp
+++ b/gpt4all-chat/src/jinja_replacements.cpp
@@ -54,6 +54,30 @@ const std::unordered_map<std::string_view, std::string_view> CHAT_TEMPLATE_SUBST
     {{- eos_token }}
 {%- endif %})TEMPLATE",
     },
+    // DeepSeek-R1-Distill-Qwen-7B-Q4_0.gguf
+    {
+        // original
+        R"TEMPLATE({% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='') %}{%- for message in messages %}{%- if message['role'] == 'system' %}{% set ns.system_prompt = message['content'] %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'\n' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '\n' + '```json' + '\n' + tool['function']['arguments'] + '\n' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{% set content = message['content'] %}{% if '</think>' in content %}{% set content = content.split('</think>')[-1] %}{% endif %}{{'<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'\n<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %})TEMPLATE",
+        // replacement
+        R"TEMPLATE({%- if not add_generation_prompt is defined %}
+    {%- set add_generation_prompt = false %}
+{%- endif %}
+{%- if messages[0]['role'] == 'system' %}
+    {{- messages[0]['content'] }}
+{%- endif %}
+{%- for message in messages %}
+    {%- if message['role'] == 'user' %}
+        {{- '<｜User｜>' + message['content'] }}
+    {%- endif %}
+    {%- if message['role'] == 'assistant' %}
+        {%- set content = message['content'] | regex_replace('^[\\s\\S]*</think>', '') %}
+        {{- '<｜Assistant｜>' + content + '<｜end▁of▁sentence｜>' }}
+    {%- endif %}
+{%- endfor -%}
+{%- if add_generation_prompt %}
+    {{- '<｜Assistant｜>' }}
+{%- endif %})TEMPLATE",
+    },
     // gemma-2-9b-it-Q4_0.gguf (nomic-ai/gpt4all#3282)
     {
         // original


### PR DESCRIPTION
This PR adds DeepSeek-R1 Qwen support by:
- Rebasing llama.cpp on a slightly newer upstream commit (ggerganov/llama.cpp@a39ab216a from Oct 2 instead of ggerganov/llama.cpp@95bc82fbc from Sep 26)
- Cherry-picking the [one-line change](https://github.com/nomic-ai/llama.cpp/commit/b06658d366abe3cea92f4e868db72165531a74da) required to load the DeepSeek GGUF
- Adding a prompt template substitution that doesn't rely on things like `namespace` and `str.split` which Jinja2Cpp doesn't implement
- Implementing a `regex_replace` function compatible with [others](https://docs.saltproject.io/en/3006/topics/jinja/index.html#regex-replace) seen in the wild to support the necessary text manipulation in the DeepSeek template.

Tested on DeepSeek-R1 Qwen 7B. Will update with results with 14B and 32B soon.

Note that the replacement prompt template removes the `{{ bos_token }}` from the Jinja template to avoid a double BOS, since at least the [bartowski GGUF](https://huggingface.co/bartowski/DeepSeek-R1-Distill-Qwen-7B-GGUF/tree/main?show_file_info=DeepSeek-R1-Distill-Qwen-7B-Q4_0.gguf) I tried specifies `tokenizer.ggml.add_bos_token` of `true` already.