### PR TITLE
ci: verify that installers we build function and are signed

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -187,13 +187,16 @@ jobs:
       - store_artifacts:
           path: build/upload
       - run:
+          name: Install Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license  # needed for QtIFW
+      - run:
           name: Test installation and verify that it is signed
           command: |
             set -e
             hdiutil attach build/upload/gpt4all-installer-darwin-signed.dmg
             codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
             /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
-              --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
+              --no-size-checking --default-answer --accept-licenses --confirm-command \
               install gpt4all
             codesign --verify --deep --verbose /Applications/gpt4all/bin/gpt4all.app
             codesign --verify --deep --verbose /Applications/gpt4all/maintenancetool.app
@@ -346,6 +349,9 @@ jobs:
       - store_artifacts:
           path: build/upload
       - run:
+          name: Install Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license  # needed for QtIFW
+      - run:
           name: Test installation and verify that it is signed
           command: |
             set -e
@@ -353,8 +359,7 @@ jobs:
             codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
             tar -xf build/upload/repository.tar.gz
             /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
-              --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
-              --set-temp-repository repository \
+              --no-size-checking --default-answer --accept-licenses --confirm-command --set-temp-repository repository \
               install gpt4all
             codesign --verify --deep --verbose /Applications/gpt4all/bin/gpt4all.app
             codesign --verify --deep --verbose /Applications/gpt4all/maintenancetool.app
@@ -444,8 +449,9 @@ jobs:
       - run:
           name: Test installation
           command: |
+            mkdir ~/Desktop
             build/upload/gpt4all-installer-linux.run --no-size-checking --default-answer --accept-licenses \
-              --confirm-command --accept-obligations \
+              --confirm-command \
               install gpt4all
 
   build-online-chat-installer-linux:
@@ -533,8 +539,9 @@ jobs:
       - run:
           name: Test installation
           command: |
+            mkdir ~/Desktop
             build/upload/gpt4all-installer-linux.run --no-size-checking --default-answer --accept-licenses \
-              --confirm-command --accept-obligations \
+              --confirm-command \
               --set-temp-repository build/_CPack_Packages/Linux/IFW/gpt4all-installer-linux/repository \
               install gpt4all
 
@@ -670,7 +677,7 @@ jobs:
           name: Test installation
           command: |
             build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations `
+              --confirm-command `
               install gpt4all
 
   build-online-chat-installer-windows:
@@ -815,9 +822,9 @@ jobs:
       - run:
           name: Test installation
           command: |
-            Expand-Archive -LiteralPath build\upload\repository.zip
+            Expand-Archive -LiteralPath build\upload\repository.zip -DestinationPath .
             build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations --set-temp-repository repository `
+              --confirm-command --set-temp-repository repository `
               install gpt4all
 
   build-offline-chat-installer-windows-arm:
@@ -945,7 +952,7 @@ jobs:
           name: Test installation
           command: |
             build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations `
+              --confirm-command `
               install gpt4all
 
   build-online-chat-installer-windows-arm:
@@ -1083,9 +1090,9 @@ jobs:
       - run:
           name: Test installation
           command: |
-            Expand-Archive -LiteralPath build\upload\repository.zip
+            Expand-Archive -LiteralPath build\upload\repository.zip -DestinationPath .
             build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations --set-temp-repository repository `
+              --confirm-command --set-temp-repository repository `
               install gpt4all
 
   build-gpt4all-chat-linux:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -351,7 +351,7 @@ jobs:
             set -e
             hdiutil attach build/upload/gpt4all-installer-darwin-signed.dmg
             codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
-            tar -xf upload/repository.tar.gz
+            tar -xf build/upload/repository.tar.gz
             /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
               --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
               --set-temp-repository repository \
@@ -815,7 +815,7 @@ jobs:
       - run:
           name: Test installation
           command: |
-            Expand-Archive -LiteralPath upload\repository.zip
+            Expand-Archive -LiteralPath build\upload\repository.zip
             build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
               --confirm-command --accept-obligations --set-temp-repository repository `
               install gpt4all
@@ -1083,7 +1083,7 @@ jobs:
       - run:
           name: Test installation
           command: |
-            Expand-Archive -LiteralPath upload\repository.zip
+            Expand-Archive -LiteralPath build\upload\repository.zip
             build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
               --confirm-command --accept-obligations --set-temp-repository repository `
               install gpt4all

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -351,9 +351,10 @@ jobs:
             set -e
             hdiutil attach build/upload/gpt4all-installer-darwin-signed.dmg
             codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
+            tar -xf upload/repository.tar.gz
             /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
               --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
-              --install-compressed-repository upload/repository.tar.gz \
+              --set-temp-repository repository \
               install gpt4all
             codesign --verify --deep --verbose /Applications/gpt4all/bin/gpt4all.app
             codesign --verify --deep --verbose /Applications/gpt4all/maintenancetool.app
@@ -533,7 +534,8 @@ jobs:
           name: Test installation
           command: |
             build/upload/gpt4all-installer-linux.run --no-size-checking --default-answer --accept-licenses \
-              --confirm-command --accept-obligations --install-compressed-repository upload/repository.tar.gz \
+              --confirm-command --accept-obligations \
+              --set-temp-repository build/_CPack_Packages/Linux/IFW/gpt4all-installer-linux/repository \
               install gpt4all
 
   build-offline-chat-installer-windows:
@@ -813,8 +815,9 @@ jobs:
       - run:
           name: Test installation
           command: |
+            Expand-Archive -LiteralPath upload\repository.zip
             build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations --install-compressed-repository install upload/repository.zip `
+              --confirm-command --accept-obligations --set-temp-repository repository `
               install gpt4all
 
   build-offline-chat-installer-windows-arm:
@@ -1080,8 +1083,9 @@ jobs:
       - run:
           name: Test installation
           command: |
+            Expand-Archive -LiteralPath upload\repository.zip
             build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
-              --confirm-command --accept-obligations --install-compressed-repository install upload/repository.zip `
+              --confirm-command --accept-obligations --set-temp-repository repository `
               install gpt4all
 
   build-gpt4all-chat-linux:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -186,6 +186,18 @@ jobs:
             xcrun stapler staple build/upload/gpt4all-installer-darwin-signed.dmg
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation and verify that it is signed
+          command: |
+            set -e
+            hdiutil attach build/upload/gpt4all-installer-darwin-signed.dmg
+            codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
+            /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
+              --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
+              install gpt4all
+            codesign --verify --deep --verbose /Applications/gpt4all/bin/gpt4all.app
+            codesign --verify --deep --verbose /Applications/gpt4all/maintenancetool.app
+            hdiutil detach /Volumes/gpt4all-installer-darwin
 
   build-online-chat-installer-macos:
     macos:
@@ -333,6 +345,19 @@ jobs:
             xcrun stapler staple build/upload/gpt4all-installer-darwin-signed.dmg
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation and verify that it is signed
+          command: |
+            set -e
+            hdiutil attach build/upload/gpt4all-installer-darwin-signed.dmg
+            codesign --verify --deep --verbose /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app
+            /Volumes/gpt4all-installer-darwin/gpt4all-installer-darwin.app/Contents/MacOS/gpt4all-installer-darwin \
+              --no-size-checking --default-answer --accept-licenses --confirm-command --accept-obligations \
+              --install-compressed-repository upload/repository.tar.gz \
+              install gpt4all
+            codesign --verify --deep --verbose /Applications/gpt4all/bin/gpt4all.app
+            codesign --verify --deep --verbose /Applications/gpt4all/maintenancetool.app
+            hdiutil detach /Volumes/gpt4all-installer-darwin
 
   build-offline-chat-installer-linux:
     machine:
@@ -415,6 +440,12 @@ jobs:
           when: always
           paths:
             - ../.ccache
+      - run:
+          name: Test installation
+          command: |
+            build/upload/gpt4all-installer-linux.run --no-size-checking --default-answer --accept-licenses \
+              --confirm-command --accept-obligations \
+              install gpt4all
 
   build-online-chat-installer-linux:
     machine:
@@ -498,6 +529,12 @@ jobs:
           when: always
           paths:
             - ../.ccache
+      - run:
+          name: Test installation
+          command: |
+            build/upload/gpt4all-installer-linux.run --no-size-checking --default-answer --accept-licenses \
+              --confirm-command --accept-obligations --install-compressed-repository upload/repository.tar.gz \
+              install gpt4all
 
   build-offline-chat-installer-windows:
     machine:
@@ -627,6 +664,12 @@ jobs:
             AzureSignTool.exe sign -du "https://gpt4all.io/index.html" -kvu https://gpt4all.vault.azure.net -kvi "$Env:AZSignGUID" -kvs "$Env:AZSignPWD" -kvc "$Env:AZSignCertName" -kvt "$Env:AZSignTID" -tr http://timestamp.digicert.com -v "$($(Get-Location).Path)\build\upload\gpt4all-installer-win64.exe"
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation
+          command: |
+            build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
+              --confirm-command --accept-obligations `
+              install gpt4all
 
   build-online-chat-installer-windows:
     machine:
@@ -767,6 +810,12 @@ jobs:
             AzureSignTool.exe sign -du "https://gpt4all.io/index.html" -kvu https://gpt4all.vault.azure.net -kvi "$Env:AZSignGUID" -kvs "$Env:AZSignPWD" -kvc "$Env:AZSignCertName" -kvt "$Env:AZSignTID" -tr http://timestamp.digicert.com -v "$($(Get-Location).Path)/build/upload/gpt4all-installer-win64.exe"
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation
+          command: |
+            build\upload\gpt4all-installer-win64.exe --no-size-checking --default-answer --accept-licenses `
+              --confirm-command --accept-obligations --install-compressed-repository install upload/repository.zip `
+              install gpt4all
 
   build-offline-chat-installer-windows-arm:
     machine:
@@ -889,6 +938,12 @@ jobs:
             AzureSignTool.exe sign -du "https://gpt4all.io/index.html" -kvu https://gpt4all.vault.azure.net -kvi "$Env:AZSignGUID" -kvs "$Env:AZSignPWD" -kvc "$Env:AZSignCertName" -kvt "$Env:AZSignTID" -tr http://timestamp.digicert.com -v "$($(Get-Location).Path)\build\upload\gpt4all-installer-win64-arm.exe"
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation
+          command: |
+            build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
+              --confirm-command --accept-obligations `
+              install gpt4all
 
   build-online-chat-installer-windows-arm:
     machine:
@@ -1022,6 +1077,12 @@ jobs:
             AzureSignTool.exe sign -du "https://gpt4all.io/index.html" -kvu https://gpt4all.vault.azure.net -kvi "$Env:AZSignGUID" -kvs "$Env:AZSignPWD" -kvc "$Env:AZSignCertName" -kvt "$Env:AZSignTID" -tr http://timestamp.digicert.com -v "$($(Get-Location).Path)/build/upload/gpt4all-installer-win64-arm.exe"
       - store_artifacts:
           path: build/upload
+      - run:
+          name: Test installation
+          command: |
+            build\upload\gpt4all-installer-win64-arm.exe --no-size-checking --default-answer --accept-licenses `
+              --confirm-command --accept-obligations --install-compressed-repository install upload/repository.zip `
+              install gpt4all
 
   build-gpt4all-chat-linux:
     machine:


### PR DESCRIPTION
When we initially attempted to deploy GPT4All v3.7.0, we could have benefited from these checks. The installer functioned on macOS but the installed binary was not correctly signed (#3408).