### PR TITLE
Don't block the gui thread for tool calls

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix `codesign --verify` failure on macOS ([#3413](https://github.com/nomic-ai/gpt4all/pull/3413))
 - Code Interpreter: Fix console.log not accepting a single string after v3.7.0 ([#3426](https://github.com/nomic-ai/gpt4all/pull/3426))
 - Fix Phi 3.1 Mini 128K Instruct template (by [@ThiloteE](https://github.com/ThiloteE) in [#3412](https://github.com/nomic-ai/gpt4all/pull/3412))
+- Don't block the gui thread for reasoning ([#3435](https://github.com/nomic-ai/gpt4all/pull/3435))
 
 ## [3.7.0] - 2025-01-21
 

--- a/gpt4all-chat/qml/ChatItemView.qml
+++ b/gpt4all-chat/qml/ChatItemView.qml
@@ -110,6 +110,7 @@ GridLayout {
                         case Chat.PromptProcessing: return qsTr("processing ...")
                         case Chat.ResponseGeneration: return qsTr("generating response ...");
                         case Chat.GeneratingQuestions: return qsTr("generating questions ...");
+                        case Chat.ToolCallGeneration: return qsTr("generating toolcall ...");
                         default: return ""; // handle unexpected values
                         }
                     }

--- a/gpt4all-chat/src/chat.h
+++ b/gpt4all-chat/src/chat.h
@@ -55,7 +55,8 @@ public:
         LocalDocsProcessing,
         PromptProcessing,
         GeneratingQuestions,
-        ResponseGeneration
+        ResponseGeneration,
+        ToolCallGeneration
     };
     Q_ENUM(ResponseState)
 
@@ -166,6 +167,9 @@ private Q_SLOTS:
     void promptProcessing();
     void generatingQuestions();
     void responseStopped(qint64 promptResponseMs);
+    void processToolCall(const QString &toolCall);
+    void toolCallComplete(const ToolCallInfo &info);
+    void responseComplete();
     void generatedNameChanged(const QString &name);
     void generatedQuestionFinished(const QString &question);
     void handleModelLoadingError(const QString &error);

--- a/gpt4all-chat/src/tool.h
+++ b/gpt4all-chat/src/tool.h
@@ -87,7 +87,8 @@ public:
     Tool() : QObject(nullptr) {}
     virtual ~Tool() {}
 
-    virtual QString run(const QList<ToolParam> &params, qint64 timeout = 2000) = 0;
+    virtual void run(const QList<ToolParam> &params) = 0;
+    virtual bool interrupt() = 0;
 
     // Tools should set these if they encounter errors. For instance, a tool depending upon the network
     // might set these error variables if the network is not available.
@@ -122,6 +123,9 @@ public:
     bool operator==(const Tool &other) const { return function() == other.function(); }
 
     jinja2::Value jinjaValue() const;
+
+Q_SIGNALS:
+    void runComplete(const ToolCallInfo &info);
 };
 
 #endif // TOOL_H


### PR DESCRIPTION
Also allow them to run as long as user permits.

We're currently blocking the gui thread for the code interpreter. This fixes that and also gives the user control over how long the toolcall can take. This is useful for prompts like:

`find the first 10 numbers that meet all these criteria: (1) they are part of the fibonacci sequence, (2) they are a prime number plus 7`

Which was mentioned [here](https://github.com/nomic-ai/gpt4all/issues/3355) and is computationally incredibly expensive with naive code.