### PR TITLE
ci: build offline installers when pipeline is scheduled

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1797,6 +1797,14 @@ job_allow_tags: &job_allow_tags
       only:
         - /.*/
 
+# standard chat workflow filter
+workflow-when-chat-requested: &workflow-when-chat-requested
+  when:
+    and:
+      - or: [ << pipeline.parameters.run-all-workflows >>, << pipeline.parameters.run-chat-workflow >> ]
+      - not:
+          equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
+
 workflows:
   version: 2
   noop:
@@ -1807,6 +1815,7 @@ workflows:
           - << pipeline.parameters.run-python-workflow >>
           - << pipeline.parameters.run-ts-workflow >>
           - << pipeline.parameters.run-chat-workflow >>
+          - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - noop
   build-chat-installers-release:
@@ -1815,6 +1824,8 @@ workflows:
       and:
         - equal: [ << pipeline.git.branch >>, main ]
         - matches: { pattern: '^v\d.*', value: << pipeline.git.tag >> }
+        - not:
+            equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - validate-commit-on-main
       - build-offline-chat-installer-macos:
@@ -1898,10 +1909,7 @@ workflows:
           requires:
             - validate-commit-on-main
   build-chat-offline-installers:
-    when:
-      or:
-        - << pipeline.parameters.run-all-workflows >>
-        - << pipeline.parameters.run-chat-workflow >>
+    <<: *workflow-when-chat-requested
     jobs:
       - build-hold:
           type: approval
@@ -1942,10 +1950,7 @@ workflows:
           requires:
             - build-hold
   build-chat-online-installers:
-    when:
-      or:
-        - << pipeline.parameters.run-all-workflows >>
-        - << pipeline.parameters.run-chat-workflow >>
+    <<: *workflow-when-chat-requested
     jobs:
       - build-hold:
           type: approval
@@ -1986,10 +1991,7 @@ workflows:
           requires:
             - build-hold
   build-and-test-gpt4all-chat:
-    when:
-      or:
-        - << pipeline.parameters.run-all-workflows >>
-        - << pipeline.parameters.run-chat-workflow >>
+    <<: *workflow-when-chat-requested
     jobs:
       - hold:
           type: approval
@@ -2012,14 +2014,17 @@ workflows:
         - or:
             - << pipeline.parameters.run-all-workflows >>
             - << pipeline.parameters.run-python-workflow >>
+        - not:
+            equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - deploy-docs:
           context: gpt4all
   build-python:
     when:
-      or:
-        - << pipeline.parameters.run-all-workflows >>
-        - << pipeline.parameters.run-python-workflow >>
+      and:
+        - or: [ << pipeline.parameters.run-all-workflows >>, << pipeline.parameters.run-python-workflow >> ]
+        - not:
+            equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - pypi-hold:
           <<: *job_only_main
@@ -2045,9 +2050,10 @@ workflows:
             - build-py-macos
   build-bindings:
     when:
-      or:
-       - << pipeline.parameters.run-all-workflows >>
-       - << pipeline.parameters.run-ts-workflow >>
+      and:
+        - or: [ << pipeline.parameters.run-all-workflows >>, << pipeline.parameters.run-ts-workflow >> ]
+        - not:
+            equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - backend-hold:
           type: approval

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1818,6 +1818,35 @@ workflows:
           - equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
     jobs:
       - noop
+  schedule:
+    # only run when scheduled by CircleCI
+    when:
+      equal: [ << pipeline.trigger_source >>, scheduled_pipeline ]
+    jobs:
+      - build-offline-chat-installer-macos:
+          context: gpt4all
+      - build-offline-chat-installer-windows:
+          context: gpt4all
+      - build-offline-chat-installer-windows-arm:
+          context: gpt4all
+      - build-offline-chat-installer-linux:
+          context: gpt4all
+      - sign-online-chat-installer-macos:
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-macos
+      - notarize-online-chat-installer-macos:
+          context: gpt4all
+          requires:
+            - sign-online-chat-installer-macos
+      - sign-online-chat-installer-windows:
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-windows
+      - sign-online-chat-installer-windows-arm:
+          context: gpt4all
+          requires:
+            - build-online-chat-installer-windows-arm
   build-chat-installers-release:
     # only run on main branch tags that start with 'v' and a digit
     when:
@@ -1833,6 +1862,21 @@ workflows:
           context: gpt4all
           requires:
             - validate-commit-on-main
+      - build-offline-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - build-offline-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - build-offline-chat-installer-linux:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
       - sign-offline-chat-installer-macos:
           <<: *job_allow_tags
           context: gpt4all
@@ -1843,32 +1887,32 @@ workflows:
           context: gpt4all
           requires:
             - sign-offline-chat-installer-macos
-      - build-offline-chat-installer-windows:
-          <<: *job_allow_tags
-          context: gpt4all
-          requires:
-            - validate-commit-on-main
       - sign-offline-chat-installer-windows:
           <<: *job_allow_tags
           context: gpt4all
           requires:
             - build-offline-chat-installer-windows
-      - build-offline-chat-installer-windows-arm:
-          <<: *job_allow_tags
-          context: gpt4all
-          requires:
-            - validate-commit-on-main
       - sign-offline-chat-installer-windows-arm:
           <<: *job_allow_tags
           context: gpt4all
           requires:
             - build-offline-chat-installer-windows-arm
-      - build-offline-chat-installer-linux:
+      - build-online-chat-installer-macos:
           <<: *job_allow_tags
           context: gpt4all
           requires:
             - validate-commit-on-main
-      - build-online-chat-installer-macos:
+      - build-online-chat-installer-windows:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - build-online-chat-installer-windows-arm:
+          <<: *job_allow_tags
+          context: gpt4all
+          requires:
+            - validate-commit-on-main
+      - build-online-chat-installer-linux:
           <<: *job_allow_tags
           context: gpt4all
           requires:
@@ -1883,31 +1927,16 @@ workflows:
           context: gpt4all
           requires:
             - sign-online-chat-installer-macos
-      - build-online-chat-installer-windows:
-          <<: *job_allow_tags
-          context: gpt4all
-          requires:
-            - validate-commit-on-main
       - sign-online-chat-installer-windows:
           <<: *job_allow_tags
           context: gpt4all
           requires:
             - build-online-chat-installer-windows
-      - build-online-chat-installer-windows-arm:
-          <<: *job_allow_tags
-          context: gpt4all
-          requires:
-            - validate-commit-on-main
       - sign-online-chat-installer-windows-arm:
           <<: *job_allow_tags
           context: gpt4all
           requires:
             - build-online-chat-installer-windows-arm
-      - build-online-chat-installer-linux:
-          <<: *job_allow_tags
-          context: gpt4all
-          requires:
-            - validate-commit-on-main
   build-chat-offline-installers:
     <<: *workflow-when-chat-requested
     jobs:


### PR DESCRIPTION
With the CI changes made in this PR, the "schedule" workflow (and only that workflow) will run when the GPT4All CI pipeline is triggered via a schedule.

Then we can configure a trigger as documented [here](https://circleci.com/docs/set-a-nightly-scheduled-pipeline/) to start making nightly builds.

Currently this workflow simply builds and signs the offline installers, but it can be adjusted as needed.