### PR TITLE
Add olmoe and granitemoe architecture to whitelist

### DIFF
--- a/gpt4all-backend/src/llamamodel.cpp
+++ b/gpt4all-backend/src/llamamodel.cpp
@@ -53,7 +53,7 @@ static const std::vector<const char *> KNOWN_ARCHES {
     "gpt2",
     // "gptj", -- no inference code
     "gptneox",
-    "granitemoe",    //not compatible with kompute backend (GPT4All v3.8.0)
+    "granitemoe",
     "mpt",
     "baichuan",
     "starcoder",
@@ -81,7 +81,7 @@ static const std::vector<const char *> KNOWN_ARCHES {
     "command-r",
     // "dbrx", -- 16x12B parameters
     "olmo",
-    "olmoe",    //not compatible with kompute backend (GPT4All v3.8.0)
+    "olmoe",
     "openelm",
     // "arctic", -- 10B+128x3.66B parameters
     "deepseek2",

--- a/gpt4all-backend/src/llamamodel.cpp
+++ b/gpt4all-backend/src/llamamodel.cpp
@@ -53,6 +53,7 @@ static const std::vector<const char *> KNOWN_ARCHES {
     "gpt2",
     // "gptj", -- no inference code
     "gptneox",
+    "granitemoe",    //not compatible with kompute backend (GPT4All v3.8.0)
     "mpt",
     "baichuan",
     "starcoder",
@@ -80,6 +81,7 @@ static const std::vector<const char *> KNOWN_ARCHES {
     "command-r",
     // "dbrx", -- 16x12B parameters
     "olmo",
+    "olmoe",    //not compatible with kompute backend (GPT4All v3.8.0)
     "openelm",
     // "arctic", -- 10B+128x3.66B parameters
     "deepseek2",

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Whitelist OLMoE and Granite model architectures (no Vulkan) ([#3449](https://github.com/nomic-ai/gpt4all/pull/3449))
+- Whitelist OLMoE and Granite MoE model architectures (no Vulkan) ([#3449](https://github.com/nomic-ai/gpt4all/pull/3449))
 
 ### Fixed
 - Fix "index N is not a prompt" when using LocalDocs with reasoning ([#3451](https://github.com/nomic-ai/gpt4all/pull/3451)

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Whitelist OLMoE and Granite model architectures (no Vulkan) ([#3449](https://github.com/nomic-ai/gpt4all/pull/3449))
+
 ### Fixed
 - Fix "index N is not a prompt" when using LocalDocs with reasoning ([#3451](https://github.com/nomic-ai/gpt4all/pull/3451)
 - Work around rendering artifacts on Snapdragon SoCs with Windows ([#3450](https://github.com/nomic-ai/gpt4all/pull/3450))


### PR DESCRIPTION
## Describe your changes
Those two model architectures are supported in llama.cpp and technically in GPT4All 3.8.0 as well, but they have to be whitelisted to make them accessible to users, so do it.

Here are the models:
- https://huggingface.co/allenai/OLMoE-1B-7B-0924-Instruct
- https://huggingface.co/ibm-granite/granite-3.1-3b-a800m-instruct

They are really small and not the brightest, but very fast. I am hoping to make use of them for sentence similarity search with the LocalDocs feature. There was also a user that wanted to have tiny LLMs for educational purposes in Africa, because of hardware constraints.

Because they are so fast and tiny and not the brightest, not having them supported on the compute backend could be argued to be justified. They are compatible with the Cuda backend though, so that's good.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.