### PR TITLE
chat: work around Direct3D 11 rendering artifacts on win11 arm

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Work around rendering artifacts on Snapdragon SoCs with Windows ([#3450](https://github.com/nomic-ai/gpt4all/pull/3450))
+
 ## [3.8.0] - 2025-01-30
 
 ### Added
@@ -283,6 +288,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix several Vulkan resource management issues ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
 - Fix crash/hang when some models stop generating, by showing special tokens ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
 
+[Unreleased]: https://github.com/nomic-ai/gpt4all/compare/v3.8.0...HEAD
 [3.8.0]: https://github.com/nomic-ai/gpt4all/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/nomic-ai/gpt4all/compare/v3.6.1...v3.7.0
 [3.6.1]: https://github.com/nomic-ai/gpt4all/compare/v3.6.0...v3.6.1

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -128,7 +128,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(GPT4ALL_CONFIG_FORCE_D3D12 -1)
 if (NOT CMAKE_SYSTEM_NAME MATCHES Windows OR Qt6_VERSION VERSION_LESS "6.6")
-    # Direct3D is not available.
+    # Direct3D 12 is not available.
     if (GPT4ALL_FORCE_D3D12 STREQUAL "ON")
         message(FATAL_ERROR "Cannot use Direct3D 12 on this platform.")
     endif()

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -35,6 +35,8 @@ option(GPT4ALL_SIGN_INSTALL "Sign installed binaries and installers (requires si
 option(GPT4ALL_GEN_CPACK_CONFIG "Generate the CPack config.xml in the package step and nothing else." OFF)
 set(GPT4ALL_USE_QTPDF "AUTO" CACHE STRING "Whether to Use QtPDF for LocalDocs. If OFF or not available on this platform, PDFium is used.")
 set_property(CACHE GPT4ALL_USE_QTPDF PROPERTY STRINGS AUTO ON OFF)
+set(GPT4ALL_FORCE_D3D12 "AUTO" CACHE STRING "Whether to use Direct3D 12 as the Qt scene graph backend. Defaults to ON on Windows ARM.")
+set_property(CACHE GPT4ALL_FORCE_D3D12 PROPERTY STRINGS AUTO ON OFF)
 
 include(cmake/cpack_config.cmake)
 
@@ -90,12 +92,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-# Generate a header file with the version number
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/config.h"
-)
-
 set(CMAKE_FIND_PACKAGE_TARGETS_GLOBAL ON)
 set(GPT4ALL_QT_COMPONENTS Core HttpServer LinguistTools Quick QuickDialogs2 Sql Svg)
 set(GPT4ALL_USING_QTPDF OFF)
@@ -129,6 +125,24 @@ message(STATUS "qmake binary: ${QMAKE_EXECUTABLE}")
 message(STATUS "Qt 6 root directory: ${Qt6_ROOT_DIR}")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(GPT4ALL_CONFIG_FORCE_D3D12 -1)
+if (NOT CMAKE_SYSTEM_NAME MATCHES Windows OR Qt6_VERSION VERSION_LESS "6.6")
+    # Direct3D is not available.
+    if (GPT4ALL_FORCE_D3D12 STREQUAL "ON")
+        message(FATAL_ERROR "Cannot use Direct3D 12 on this platform.")
+    endif()
+elseif (GPT4ALL_FORCE_D3D12 MATCHES "^(ON|AUTO)$")
+    if (GPT4ALL_FORCE_D3D12 STREQUAL "ON" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|AARCH64|arm64|ARM64)$")
+        set(GPT4ALL_CONFIG_FORCE_D3D12 1)
+    endif()
+endif()
+
+# Generate a header file for configuration
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/config.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+)
 
 add_subdirectory(deps)
 add_subdirectory(../gpt4all-backend llmodel)

--- a/gpt4all-chat/cmake/config.h.in
+++ b/gpt4all-chat/cmake/config.h.in
@@ -1,6 +1,0 @@
-#ifndef CONFIG_H
-#define CONFIG_H
-
-#define APP_VERSION "@APP_VERSION@"
-
-#endif // CONFIG_H

--- a/gpt4all-chat/src/config.h.in
+++ b/gpt4all-chat/src/config.h.in
@@ -1,0 +1,7 @@
+#pragma once
+
+#define APP_VERSION "@APP_VERSION@"
+
+#define G4A_CONFIG(name) (1/G4A_CONFIG_##name == 1)
+
+#define G4A_CONFIG_force_d3d12 @GPT4ALL_CONFIG_FORCE_D3D12@

--- a/gpt4all-chat/src/main.cpp
+++ b/gpt4all-chat/src/main.cpp
@@ -25,6 +25,10 @@
 #include <QVariant>
 #include <Qt>
 
+#if G4A_CONFIG(force_d3d12)
+#   include <QSGRendererInterface>
+#endif
+
 #ifndef GPT4ALL_USE_QTPDF
 #   include <fpdfview.h>
 #endif
@@ -82,6 +86,10 @@ int main(int argc, char *argv[])
         app.sendMessage("RAISE_WINDOW");
         return 0;
     }
+
+#if G4A_CONFIG(force_d3d12)
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D12);
+#endif
 
 #ifdef Q_OS_LINUX
     app.setWindowIcon(QIcon(":/gpt4all/icons/gpt4all.svg"));


### PR DESCRIPTION
The Direct3D 11 scene graph backend shows rendering artifacts on my Windows 11 ARM laptop.

System Model: Dell Latitude 7455
SoC: Snapdragon X Elite X1E-80-100
OS: Windows 11 Pro 24H2 build 26100.2894
GPU: Qualcomm Adreno X1-85
GPU Driver Version: 31.0.80.0 (10/28/2024)

They look like this:
![Screenshot 2025-01-31 174458](https://github.com/user-attachments/assets/06bf0bd0-a699-4751-a98a-307e9e64052d)

Also, the (hidden) LocalDocs drawer sometimes pops in and out of visibility while the model is generating a response.

None of these issues happen on the Direct3D 12 backend, so let's use that by default on Windows ARM.