### PR TITLE
Ignore DeepSeek-R1 "think" content in name/follow-up responses

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Fix "index N is not a prompt" when using LocalDocs with reasoning ([#3451](https://github.com/nomic-ai/gpt4all/pull/3451)
 - Work around rendering artifacts on Snapdragon SoCs with Windows ([#3450](https://github.com/nomic-ai/gpt4all/pull/3450))
+- Prevent DeepSeek-R1 reasoning from appearing in chat names and follow-up questions ([#3458](https://github.com/nomic-ai/gpt4all/pull/3458))
 
 ## [3.8.0] - 2025-01-30
 

--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -381,11 +381,8 @@ void Chat::trySwitchContextOfLoadedModel()
 
 void Chat::generatedNameChanged(const QString &name)
 {
-    // Only use the first three words maximum and remove newlines and extra spaces
-    m_generatedName = name.simplified();
-    QStringList words = m_generatedName.split(' ', Qt::SkipEmptyParts);
-    int wordCount = qMin(7, words.size());
-    m_name = words.mid(0, wordCount).join(' ');
+    m_generatedName = name;
+    m_name = name;
     emit nameChanged();
     m_needsSave = true;
 }

--- a/gpt4all-chat/src/chat.cpp
+++ b/gpt4all-chat/src/chat.cpp
@@ -255,7 +255,7 @@ void Chat::responseStopped(qint64 promptResponseMs)
 
     ToolCallParser parser;
     parser.update(possibleToolcall.toUtf8());
-    if (parser.state() == ToolEnums::ParseState::Complete && parser.startTag() != ToolCallConstants::ThinkTag)
+    if (parser.state() == ToolEnums::ParseState::Complete && parser.startTag() != ToolCallConstants::ThinkStartTag)
         processToolCall(parser.toolCall());
     else
         responseComplete();

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -945,14 +945,14 @@ auto ChatLLM::promptInternal(
         if (toolCallParser.numberOfBuffers() < 2 && toolCallParser.splitIfPossible()) {
             const auto parseBuffers = toolCallParser.buffers();
             Q_ASSERT(parseBuffers.size() == 2);
-            if (toolCallParser.startTag() == ToolCallConstants::ThinkTag)
+            if (toolCallParser.startTag() == ToolCallConstants::ThinkStartTag)
                 m_chatModel->splitThinking({parseBuffers.at(0), parseBuffers.at(1)});
             else
                 m_chatModel->splitToolCall({parseBuffers.at(0), parseBuffers.at(1)});
         }
 
         // Split the response into three if needed and create chat items
-        if (toolCallParser.numberOfBuffers() < 3 && toolCallParser.startTag() == ToolCallConstants::ThinkTag
+        if (toolCallParser.numberOfBuffers() < 3 && toolCallParser.startTag() == ToolCallConstants::ThinkStartTag
             && toolCallParser.splitIfPossible()) {
             const auto parseBuffers = toolCallParser.buffers();
             Q_ASSERT(parseBuffers.size() == 3);
@@ -979,7 +979,7 @@ auto ChatLLM::promptInternal(
         emit responseChanged();
 
         const bool shouldExecuteToolCall = toolCallParser.state() == ToolEnums::ParseState::Complete
-            && toolCallParser.startTag() != ToolCallConstants::ThinkTag;
+            && toolCallParser.startTag() != ToolCallConstants::ThinkStartTag;
 
         return !shouldExecuteToolCall && !m_stopGenerating;
     };
@@ -999,7 +999,7 @@ auto ChatLLM::promptInternal(
 
     const auto parseBuffers = toolCallParser.buffers();
     const bool shouldExecuteToolCall = toolCallParser.state() == ToolEnums::ParseState::Complete
-        && toolCallParser.startTag() != ToolCallConstants::ThinkTag;
+        && toolCallParser.startTag() != ToolCallConstants::ThinkStartTag;
 
     // trim trailing whitespace
     auto respStr = QString::fromUtf8(result.response);

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -30,6 +30,7 @@
 
 using namespace Qt::Literals::StringLiterals;
 
+class ChatViewResponseHandler;
 class QDataStream;
 
 // NOTE: values serialized to disk, do not change or reuse
@@ -285,6 +286,7 @@ private:
     bool m_isServer;
     bool m_forceMetal;
     bool m_reloadingToChangeVariant;
+    friend class ChatViewResponseHandler;
 };
 
 #endif // CHATLLM_H

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -287,7 +287,7 @@ private:
     bool m_forceMetal;
     bool m_reloadingToChangeVariant;
     friend class ChatViewResponseHandler;
-    friend class NameResponseHandler;
+    friend class SimpleResponseHandler;
 };
 
 #endif // CHATLLM_H

--- a/gpt4all-chat/src/chatllm.h
+++ b/gpt4all-chat/src/chatllm.h
@@ -287,6 +287,7 @@ private:
     bool m_forceMetal;
     bool m_reloadingToChangeVariant;
     friend class ChatViewResponseHandler;
+    friend class NameResponseHandler;
 };
 
 #endif // CHATLLM_H

--- a/gpt4all-chat/src/modellist.h
+++ b/gpt4all-chat/src/modellist.h
@@ -269,7 +269,7 @@ private:
             std::optional<QString> m_chatTemplate;
     mutable std::optional<QString> m_modelChatTemplate;
     QString m_systemMessage;
-    QString m_chatNamePrompt          = "Describe the above conversation in seven words or less.";
+    QString m_chatNamePrompt          = "Describe the above conversation. Your entire response must be three words or less.";
     QString m_suggestedFollowUpPrompt = "Suggest three very short factual follow-up questions that have not been answered yet or cannot be found inspired by the previous conversation and excerpts.";
     friend class MySettings;
     friend class ModelList;

--- a/gpt4all-chat/src/toolcallparser.h
+++ b/gpt4all-chat/src/toolcallparser.h
@@ -1,30 +1,22 @@
 #ifndef TOOLCALLPARSER_H
 #define TOOLCALLPARSER_H
 
-#include "tool.h"
-
 #include <QByteArray>
 #include <QList>
 #include <QString>
 #include <QStringList>
 
-namespace ToolCallConstants
-{
-    const QString CodeInterpreterFunction = R"(javascript_interpret)";
-    const QString CodeInterpreterTag = R"(<)" + CodeInterpreterFunction + R"(>)";
-    const QString CodeInterpreterEndTag = R"(</)" + CodeInterpreterFunction + R"(>)";
-    const QString CodeInterpreterPrefix = CodeInterpreterTag + "\n```javascript\n";
-    const QString CodeInterpreterSuffix = "```\n" + CodeInterpreterEndTag;
+namespace ToolEnums { enum class ParseState; }
 
-    // NB: the parsing code assumes the first char of the various tags differ
-    const QString ThinkTag = QStringLiteral("<think>");
-    const QString ThinkEndTag = QStringLiteral("</think>");
-}
+using namespace Qt::Literals::StringLiterals;
+
 
 class ToolCallParser
 {
 public:
     ToolCallParser();
+    ToolCallParser(const QStringList &tagNames);
+
     void reset();
     void update(const QByteArray &update);
     QString toolCall() const { return QString::fromUtf8(m_toolCall); }
@@ -36,6 +28,9 @@ public:
     bool splitIfPossible();
     QStringList buffers() const;
     int numberOfBuffers() const { return m_buffers.size(); }
+
+    static QString makeStartTag(const QString &name) { return u"<%1>"_s .arg(name); }
+    static QString makeEndTag  (const QString &name) { return u"</%1>"_s.arg(name); }
 
 private:
     QByteArray &currentBuffer();
@@ -57,5 +52,22 @@ private:
     int m_startIndex;
     int m_endIndex;
 };
+
+namespace ToolCallConstants
+{
+    // NB: the parsing code assumes the first char of the various tags differ
+
+    inline const QString CodeInterpreterFunction = u"javascript_interpret"_s;
+    inline const QString CodeInterpreterStartTag = ToolCallParser::makeStartTag(CodeInterpreterFunction);
+    inline const QString CodeInterpreterEndTag   = ToolCallParser::makeEndTag  (CodeInterpreterFunction);
+    inline const QString CodeInterpreterPrefix   = u"%1\n```javascript\n"_s.arg(CodeInterpreterStartTag);
+    inline const QString CodeInterpreterSuffix   = u"```\n%1"_s            .arg(CodeInterpreterEndTag  );
+
+    inline const QString ThinkTagName  = u"think"_s;
+    inline const QString ThinkStartTag = ToolCallParser::makeStartTag(ThinkTagName);
+    inline const QString ThinkEndTag   = ToolCallParser::makeEndTag  (ThinkTagName);
+
+    inline const QStringList AllTagNames { CodeInterpreterFunction, ThinkTagName };
+}
 
 #endif // TOOLCALLPARSER_H


### PR DESCRIPTION
By separating the "tool call" parsing from the chat model using a class abstraction, we are able to reuse the think tag parsing code. Reusing it for the chat name and follow-up generation prevents it from ending up in the response on screen, which should never happen.

Some additional tweaks are made to the name generation so at least Meta Llama 3 generates reasonable chat names (reusing changes from #3172). The DeepSeek-R1 distillations are finicky and will require more advanced prompting techniques to get consistent results.