### PR TITLE
Fix PDFium abuse that leads to a crash on Windows ARM

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix "index N is not a prompt" when using LocalDocs with reasoning ([#3451](https://github.com/nomic-ai/gpt4all/pull/3451)
 - Work around rendering artifacts on Snapdragon SoCs with Windows ([#3450](https://github.com/nomic-ai/gpt4all/pull/3450))
 - Prevent DeepSeek-R1 reasoning from appearing in chat names and follow-up questions ([#3458](https://github.com/nomic-ai/gpt4all/pull/3458))
+- Fix LocalDocs crash on Windows ARM when reading PDFs ([#3460](https://github.com/nomic-ai/gpt4all/pull/3460))
 
 ## [3.8.0] - 2025-01-30
 

--- a/gpt4all-chat/deps/CMakeLists.txt
+++ b/gpt4all-chat/deps/CMakeLists.txt
@@ -17,32 +17,32 @@ add_subdirectory(QXlsx/QXlsx)
 
 if (NOT GPT4ALL_USING_QTPDF)
     # If we do not use QtPDF, we need to get PDFium.
-    set(GPT4ALL_PDFIUM_TAG "chromium/6954")
+    set(GPT4ALL_PDFIUM_TAG "chromium/6996")
     if (CMAKE_SYSTEM_NAME MATCHES Linux)
         FetchContent_Declare(
             pdfium
             URL "https://github.com/bblanchon/pdfium-binaries/releases/download/${GPT4ALL_PDFIUM_TAG}/pdfium-linux-x64.tgz"
-            URL_HASH "SHA256=69917fd9543befc6c806254aff6c8a604d9e7cd3999a3e70fc32b8690d372da2"
+            URL_HASH "SHA256=68b381b87efed539f2e33ae1e280304c9a42643a878cc296c1d66a93b0cb4335"
         )
     elseif (CMAKE_SYSTEM_NAME MATCHES Windows)
         if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
             FetchContent_Declare(
                 pdfium
                 URL "https://github.com/bblanchon/pdfium-binaries/releases/download/${GPT4ALL_PDFIUM_TAG}/pdfium-win-x64.tgz"
-                URL_HASH "SHA256=62ecac78fbaf658457beaffcc05eb147f493d435a2e1309e6a731808b4e80d38"
+                URL_HASH "SHA256=83e714c302ceacccf403826d5cb57ea39b77f393d83b8d5781283012774a9378"
             )
         elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|AARCH64|arm64|ARM64)$")
             FetchContent_Declare(
                 pdfium
                 URL "https://github.com/bblanchon/pdfium-binaries/releases/download/${GPT4ALL_PDFIUM_TAG}/pdfium-win-arm64.tgz"
-                URL_HASH "SHA256=a0b69014467f2b9824776c064920bc95359c9ba0d88793bdda1894a0f22206f8"
+                URL_HASH "SHA256=78e77e871453a4915cbf66fb381b951c9932f88a747c6b2b33c9f27ec2371445"
             )
         endif()
     elseif (CMAKE_SYSTEM_NAME MATCHES Darwin)
         FetchContent_Declare(
             pdfium
             URL "https://github.com/bblanchon/pdfium-binaries/releases/download/${GPT4ALL_PDFIUM_TAG}/pdfium-mac-univ.tgz"
-            URL_HASH "SHA256=7442f1dc6bef90898b2b7bd38dbec369ddd81bbf66c1c5aac3a1b60e107098f9"
+            URL_HASH "SHA256=e7577f3242ff9c1df50025f9615673a43601a201bc51ee4792975f98920793a2"
         )
     endif()
 

--- a/gpt4all-chat/src/database.cpp
+++ b/gpt4all-chat/src/database.cpp
@@ -1209,7 +1209,6 @@ public:
             FPDF_ClosePage(m_page);
         if (m_doc)
             FPDF_CloseDocument(m_doc);
-        FPDF_DestroyLibrary();
     }
 
     int page() const override { return m_currentPage; }
@@ -1224,7 +1223,7 @@ private:
                     return std::nullopt;
 
                 if (m_page)
-                    FPDF_ClosePage(m_page);
+                    FPDF_ClosePage(std::exchange(m_page, nullptr));
                 m_page = FPDF_LoadPage(m_doc, m_currentPage++);
                 if (!m_page)
                     throw std::runtime_error("Failed to load page.");

--- a/gpt4all-chat/src/main.cpp
+++ b/gpt4all-chat/src/main.cpp
@@ -181,5 +181,9 @@ int main(int argc, char *argv[])
     // Otherwise, we can get a heap-use-after-free inside of llama.cpp.
     ChatListModel::globalInstance()->destroyChats();
 
+#ifndef GPT4ALL_USE_QTPDF
+    FPDF_DestroyLibrary();
+#endif
+
     return res;
 }


### PR DESCRIPTION
With -DGPT4ALL_USE_QTPDF=OFF, we hit an embarrassingly misplaced call to `FPDF_DestroyLibrary()` after the first PDF is read. This prevents further use of PDFium without a call to FPDF_InitLibrary, which never happens.

So after we read a few PDFs, this causes a crash. The fix is to destroy it at shutdown instead. There is also a change here to improve the exception safety of m_page, which might result in a double-free otherwise.