### PR TITLE
Misc fixes for undefined behavior, crashes, and build failure

### DIFF
--- a/gpt4all-backend/src/llmodel.cpp
+++ b/gpt4all-backend/src/llmodel.cpp
@@ -140,9 +140,14 @@ const std::vector<LLModel::Implementation> &LLModel::Implementation::implementat
             std::string path;
             // Split the paths string by the delimiter and process each path.
             while (std::getline(ss, path, ';')) {
-                std::u8string u8_path(path.begin(), path.end());
+                fs::directory_iterator iter;
+                try {
+                    iter = fs::directory_iterator(std::u8string(path.begin(), path.end()));
+                } catch (const fs::filesystem_error &) {
+                    continue; // skip nonexistent path
+                }
                 // Iterate over all libraries
-                for (const auto &f : fs::directory_iterator(u8_path)) {
+                for (const auto &f : iter) {
                     const fs::path &p = f.path();
 
                     if (p.extension() != LIB_FILE_EXT) continue;

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Fix several potential crashes ([#3465](https://github.com/nomic-ai/gpt4all/pull/3465))
+
 ## [3.9.0] - 2025-02-04
 
 ### Added
@@ -295,6 +300,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix several Vulkan resource management issues ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
 - Fix crash/hang when some models stop generating, by showing special tokens ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
 
+[Unreleased]: https://github.com/nomic-ai/gpt4all/compare/v3.9.0...HEAD
 [3.9.0]: https://github.com/nomic-ai/gpt4all/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/nomic-ai/gpt4all/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/nomic-ai/gpt4all/compare/v3.6.1...v3.7.0

--- a/gpt4all-chat/src/chatmodel.h
+++ b/gpt4all-chat/src/chatmodel.h
@@ -204,7 +204,8 @@ public:
         : QObject(nullptr)
     {
         moveToThread(parent->thread());
-        setParent(parent);
+        // setParent must be called from the thread the object lives in
+        QMetaObject::invokeMethod(this, [this, parent]() { this->setParent(parent); });
     }
 
     // NOTE: System messages are currently never serialized and only *stored* by the local server.

--- a/gpt4all-chat/src/database.h
+++ b/gpt4all-chat/src/database.h
@@ -171,7 +171,7 @@ public:
     explicit ChunkStreamer(Database *database);
     ~ChunkStreamer();
 
-    void setDocument(const DocumentInfo &doc, int documentId, const QString &embeddingModel);
+    void setDocument(DocumentInfo doc, int documentId, const QString &embeddingModel);
     std::optional<DocumentInfo::key_type> currentDocKey() const;
     void reset();
 

--- a/gpt4all-chat/src/embllm.cpp
+++ b/gpt4all-chat/src/embllm.cpp
@@ -359,8 +359,11 @@ void EmbeddingLLMWorker::handleFinished()
     if (retrievedData.isValid() && retrievedData.canConvert<QVector<EmbeddingChunk>>())
         chunks = retrievedData.value<QVector<EmbeddingChunk>>();
 
-    QVariant response = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
-    Q_ASSERT(response.isValid());
+    QVariant response;
+    if (reply->error() != QNetworkReply::NoError) {
+        response = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
+        Q_ASSERT(response.isValid());
+    }
     bool ok;
     int code = response.toInt(&ok);
     if (!ok || code != 200) {

--- a/gpt4all-chat/src/logger.cpp
+++ b/gpt4all-chat/src/logger.cpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 #include <QGlobalStatic>
 #include <QIODevice>
+#include <QMutexLocker>
 #include <QStandardPaths>
 
 #include <cstdio>
@@ -62,8 +63,11 @@ void Logger::messageHandler(QtMsgType type, const QMessageLogContext &, const QS
     }
     // Get time and date
     auto timestamp = QDateTime::currentDateTime().toString();
-    // Write message
+
     const std::string out = u"[%1] (%2): %3\n"_s.arg(typeString, timestamp, msg).toStdString();
+
+    // Write message
+    QMutexLocker locker(&logger->m_mutex);
     logger->m_file.write(out.c_str());
     logger->m_file.flush();
     std::cerr << out;

--- a/gpt4all-chat/src/logger.h
+++ b/gpt4all-chat/src/logger.h
@@ -2,19 +2,23 @@
 #define LOGGER_H
 
 #include <QFile>
+#include <QMutex>
 #include <QString>
 #include <QtLogging>
 
-class Logger
-{
-    QFile m_file;
-
-    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
-
+class Logger {
 public:
+    explicit Logger();
+
     static Logger *globalInstance();
 
-    explicit Logger();
+private:
+    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
+
+private:
+    QFile  m_file;
+    QMutex m_mutex;
+
     friend class MyLogger;
 };
 

--- a/gpt4all-chat/src/network.cpp
+++ b/gpt4all-chat/src/network.cpp
@@ -242,6 +242,12 @@ void Network::handleJsonUploadFinished()
 
     m_activeUploads.removeAll(jsonReply);
 
+    if (jsonReply->error() != QNetworkReply::NoError) {
+        qWarning() << "Request to" << jsonReply->url().toString() << "failed:" << jsonReply->errorString();
+        jsonReply->deleteLater();
+        return;
+    }
+
     QVariant response = jsonReply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     Q_ASSERT(response.isValid());
     bool ok;
@@ -449,6 +455,11 @@ void Network::handleIpifyFinished()
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     if (!reply)
         return;
+    if (reply->error() != QNetworkReply::NoError) {
+        qWarning() << "Request to" << reply->url().toString() << "failed:" << reply->errorString();
+        reply->deleteLater();
+        return;
+    }
 
     QVariant response = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     Q_ASSERT(response.isValid());
@@ -473,6 +484,11 @@ void Network::handleMixpanelFinished()
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
     if (!reply)
         return;
+    if (reply->error() != QNetworkReply::NoError) {
+        qWarning() << "Request to" << reply->url().toString() << "failed:" << reply->errorString();
+        reply->deleteLater();
+        return;
+    }
 
     QVariant response = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     Q_ASSERT(response.isValid());
@@ -511,6 +527,11 @@ void Network::handleHealthFinished()
     QNetworkReply *healthReply = qobject_cast<QNetworkReply *>(sender());
     if (!healthReply)
         return;
+    if (healthReply->error() != QNetworkReply::NoError) {
+        qWarning() << "Request to" << healthReply->url().toString() << "failed:" << healthReply->errorString();
+        healthReply->deleteLater();
+        return;
+    }
 
     QVariant response = healthReply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
     Q_ASSERT(response.isValid());

--- a/gpt4all-chat/translations/gpt4all_ro_RO.ts
+++ b/gpt4all-chat/translations/gpt4all_ro_RO.ts
@@ -499,11 +499,6 @@
         <translation>introdu $BASE_URL</translation>
     </message>
     <message>
-        <location filename="../qml/AddHFModelView.qml" line="600"/>
-        <source>ERROR: $API_KEY is empty.</source>
-        <translation>EROARE: $API_KEY absentă</translation>
-    </message>
-    <message>
         <location filename="../qml/AddHFModelView.qml" line="606"/>
         <source>enter $MODEL_NAME</source>
         <translation>introdu $MODEL_NAME</translation>


### PR DESCRIPTION
The theme of this PR is things I noticed while trying to make Windows ARM more stable. None of them seem to affect the official releases in practice.

- AddressSanitizer detected a stack-use-after-return in database.cpp, which is now fixed.
- The backend no longer crashes if one of the search dirs does not exist (related to #3417)
- Builds against the debug version of Qt, which is the default on Windows debug builds, were complaining about a call to setParent from the wrong thread. This is fixed.
- The Visual Studio build (not used in CI) was failing due to a duplicate string in gpt4all_ro_RO.ts, which has been fixed.
- Debug builds were crashing when inconsequential network requests were failing, such as Mixpanel. This is now reduced to a warning when the QNetworkReply reports an error (such as "Connection refused").
- We were hitting a QRingBuffer assertion because we were using the log file from multiple threads without a mutex.