### PR TITLE
Fix spacing issues with deepseek models:

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -300,6 +300,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix several Vulkan resource management issues ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
 - Fix crash/hang when some models stop generating, by showing special tokens ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
 
+[Unreleased]: https://github.com/nomic-ai/gpt4all/compare/v3.9.0...HEAD
 [3.9.0]: https://github.com/nomic-ai/gpt4all/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/nomic-ai/gpt4all/compare/v3.7.0...v3.8.0
 [3.7.0]: https://github.com/nomic-ai/gpt4all/compare/v3.6.1...v3.7.0

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Fix visual spacing issues with deepseek models ([#3470](https://github.com/nomic-ai/gpt4all/pull/3470))
+
 ## [3.9.0] - 2025-02-04
 
 ### Added

--- a/gpt4all-chat/qml/ChatItemView.qml
+++ b/gpt4all-chat/qml/ChatItemView.qml
@@ -198,6 +198,7 @@ GridLayout {
                         isError: false
                         isThinking: true
                         thinkingTime: modelData.thinkingTime
+                        visible: modelData.content !== ""
                     }
                 }
             }

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -976,7 +976,8 @@ public:
     {
         Q_UNUSED(bufferIdx)
         try {
-            m_cllm->m_chatModel->setResponseValue(response.trimmed());
+            QString r = response;
+            m_cllm->m_chatModel->setResponseValue(removeLeadingWhitespace(r));
         } catch (const std::exception &e) {
             // We have a try/catch here because the main thread might have removed the response from
             // the chatmodel by erasing the conversation during the response... the main thread sets
@@ -991,7 +992,7 @@ public:
     bool onRegularResponse() override
     {
         auto respStr = QString::fromUtf8(m_result->response);
-        return onBufferResponse(removeLeadingWhitespace(respStr), 0);
+        return onBufferResponse(respStr, 0);
     }
 
     bool getStopGenerating() const override

--- a/gpt4all-chat/src/chatllm.cpp
+++ b/gpt4all-chat/src/chatllm.cpp
@@ -976,7 +976,7 @@ public:
     {
         Q_UNUSED(bufferIdx)
         try {
-            m_cllm->m_chatModel->setResponseValue(response);
+            m_cllm->m_chatModel->setResponseValue(response.trimmed());
         } catch (const std::exception &e) {
             // We have a try/catch here because the main thread might have removed the response from
             // the chatmodel by erasing the conversation during the response... the main thread sets
@@ -1078,7 +1078,7 @@ auto ChatLLM::promptInternal(
     auto respStr = QString::fromUtf8(result.response);
     if (!respStr.isEmpty() && (std::as_const(respStr).back().isSpace() || finalBuffers.size() > 1)) {
         if (finalBuffers.size() > 1)
-            m_chatModel->setResponseValue(finalBuffers.last());
+            m_chatModel->setResponseValue(finalBuffers.last().trimmed());
         else
             m_chatModel->setResponseValue(respStr.trimmed());
         emit responseChanged();


### PR DESCRIPTION
1) If the think tag is empty don't show it at all
2) Always trim the responses for whitespace so if the model generates
   <think>blah</think>
   [new line]
   final response

The finale response is trimmed of the newline.

