### PR TITLE
ci: use LLVM Clang on macOS

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -97,6 +97,7 @@ jobs:
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
               -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
               -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+              -DCMAKE_RANLIB=/usr/bin/ranlib \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -264,6 +265,7 @@ jobs:
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
               -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
               -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+              -DCMAKE_RANLIB=/usr/bin/ranlib \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1274,6 +1276,7 @@ jobs:
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
               -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
               -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+              -DCMAKE_RANLIB=/usr/bin/ranlib \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1417,6 +1420,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
               -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+              -DCMAKE_RANLIB=/usr/bin/ranlib \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1615,6 +1619,7 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
               -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
+              -DCMAKE_RANLIB=/usr/bin/ranlib \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -18,6 +18,17 @@ parameters:
     type: boolean
     default: false
 
+job-macos-executor: &job-macos-executor
+  macos:
+    xcode: 16.2.0
+  resource_class: macos.m1.medium.gen1
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: 1
+
+job-macos-install-deps: &job-macos-install-deps
+  name: Install common macOS dependencies
+  command: brew install ccache llvm wget
+
 jobs:
   # work around CircleCI-Public/path-filtering-orb#20
   noop:
@@ -34,8 +45,7 @@ jobs:
           name: Verify that commit is on the main branch
           command: git merge-base --is-ancestor HEAD main
   build-offline-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - run:
@@ -47,11 +57,10 @@ jobs:
           keys:
             - ccache-gpt4all-macos-
       - run:
+          <<: *job-macos-install-deps
+      - run:
           name: Install Rosetta
           command: softwareupdate --install-rosetta --agree-to-license  # needed for QtIFW
-      - run:
-          name: Install dependencies
-          command: brew install ccache wget
       - run:
           name: Installing Qt
           command: |
@@ -86,6 +95,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH:PATH=~/Qt/6.8.2/macos/lib/cmake \
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -128,8 +139,7 @@ jobs:
             - upload
 
   sign-offline-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       # attach to a workspace containing unsigned dmg
@@ -163,8 +173,7 @@ jobs:
             - upload
 
   notarize-offline-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - attach_workspace:
@@ -203,8 +212,7 @@ jobs:
             hdiutil detach /Volumes/gpt4all-installer-darwin
 
   build-online-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - run:
@@ -216,11 +224,10 @@ jobs:
           keys:
             - ccache-gpt4all-macos-
       - run:
+          <<: *job-macos-install-deps
+      - run:
           name: Install Rosetta
           command: softwareupdate --install-rosetta --agree-to-license  # needed for QtIFW
-      - run:
-          name: Install dependencies
-          command: brew install ccache wget
       - run:
           name: Installing Qt
           command: |
@@ -255,6 +262,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH:PATH=~/Qt/6.8.2/macos/lib/cmake \
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -290,8 +299,7 @@ jobs:
             - upload
 
   sign-online-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       # attach to a workspace containing unsigned dmg
@@ -325,8 +333,7 @@ jobs:
             - upload
 
   notarize-online-chat-installer-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - attach_workspace:
@@ -1227,8 +1234,7 @@ jobs:
             - ..\.ccache
 
   build-gpt4all-chat-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - run:
@@ -1240,11 +1246,10 @@ jobs:
           keys:
             - ccache-gpt4all-macos-
       - run:
+          <<: *job-macos-install-deps
+      - run:
           name: Install Rosetta
           command: softwareupdate --install-rosetta --agree-to-license  # needed for QtIFW
-      - run:
-          name: Install dependencies
-          command: brew install ccache wget
       - run:
           name: Installing Qt
           command: |
@@ -1267,6 +1272,8 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_PREFIX_PATH:PATH=~/Qt/6.8.2/macos/lib/cmake \
               -DCMAKE_MAKE_PROGRAM:FILEPATH=~/Qt/Tools/Ninja/ninja \
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1387,18 +1394,17 @@ jobs:
             - "*.whl"
 
   build-py-macos:
-    macos:
-      xcode: 15.4.0
-    resource_class: macos.m1.large.gen1
+    <<: *job-macos-executor
     steps:
       - checkout
       - restore_cache:
           keys:
             - ccache-gpt4all-macos-
       - run:
+          <<: *job-macos-install-deps
+      - run:
           name: Install dependencies
           command: |
-            brew install ccache cmake
             pip install setuptools wheel cmake
       - run:
           name: Build C library
@@ -1409,6 +1415,8 @@ jobs:
             cd gpt4all-backend
             cmake -B build \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1582,8 +1590,7 @@ jobs:
             - runtimes/linux-x64/*.so
 
   build-bindings-backend-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - run:
@@ -1595,9 +1602,7 @@ jobs:
           keys:
             - ccache-gpt4all-macos-
       - run:
-          name: Install dependencies
-          command: |
-            brew install ccache cmake
+          <<: *job-macos-install-deps
       - run:
           name: Build Libraries
           no_output_timeout: 30m
@@ -1608,6 +1613,8 @@ jobs:
             cd runtimes/build
             cmake ../.. \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang \
+              -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DBUILD_UNIVERSAL=ON \
@@ -1725,8 +1732,7 @@ jobs:
             - runtimes/linux-x64/*-*.so
 
   build-nodejs-macos:
-    macos:
-      xcode: 15.4.0
+    <<: *job-macos-executor
     steps:
       - checkout
       - attach_workspace:

--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - Substitute prettier default templates for OLMoE 7B 0924/0125 and Granite 3.1 3B/8B (by [@ThiloteE](https://github.com/ThiloteE) in [#3471](https://github.com/nomic-ai/gpt4all/pull/3471))
+- Build with LLVM Clang on macOS ([#3495](https://github.com/nomic-ai/gpt4all/pull/3495))
 
 ### Fixed
 - Fix several potential crashes ([#3465](https://github.com/nomic-ai/gpt4all/pull/3465))


### PR DESCRIPTION
The problem with Apple Clang is that in terms of [C++20](https://en.cppreference.com/w/cpp/compiler_support/20) and [C++23](https://en.cppreference.com/w/cpp/compiler_support/23) language features, it always lags LLVM Clang. It is straightforward to install LLVM Clang with Homebrew and configure GPT4All to build with it, and there are no downsides that I know of.

This will enable use of more C++20 and C++23 features in this repo, which will be important for the upcoming backend changes. The lowest common denominator between LLVM Clang on macOS, GCC on Linux, and MSVC on Windows is better than what we have now.