### PR TITLE
fix: Load correct icon on Flatpak

### DIFF
--- a/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.desktop
+++ b/gpt4all-chat/flatpak-manifest/io.gpt4all.gpt4all.desktop
@@ -7,3 +7,4 @@ Icon=io.gpt4all.gpt4all
 Type=Application
 Categories=Utility;Office;
 Keywords=GPT,Chat;AI
+StartupWMClass=io.gpt4all.chat


### PR DESCRIPTION
## Describe your changes
On a desktop with KDE Plasma, it was being shown a generic Wayland icon for GPT4All (Flatpak) because it couldn't match the running window to the desktop entry. This was due to the missing StartupWMClass field in the .desktop file.

By adding "StartupWMClass=io.gpt4all.chat" the window-class mismatch was fixed and allowed KDE to display the correct icon.

## Issue ticket number and link
No issue

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [X] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [X] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
### Before the fix
![before](https://github.com/user-attachments/assets/e30099ba-3e20-47be-8f4f-f69d82d8a4c4)

### After the fix
![after](https://github.com/user-attachments/assets/aefcf347-ab7e-4edc-abe7-1e396850bb9f)

### Steps to Reproduce
- Open GPT4ALL (Flatpak installation) in KDE Plasma Wayland
- Check the icon
