### PR TITLE
server: block server access via non-local domains

### DIFF
--- a/gpt4all-chat/CHANGELOG.md
+++ b/gpt4all-chat/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Make the the local server resistant to DNS rebind attacks ([#3587](https://github.com/nomic-ai/gpt4all/pull/3587))
+
 ## [3.10.0] - 2025-02-24
 
 ### Added
@@ -312,6 +317,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix several Vulkan resource management issues ([#2694](https://github.com/nomic-ai/gpt4all/pull/2694))
 - Fix crash/hang when some models stop generating, by showing special tokens ([#2701](https://github.com/nomic-ai/gpt4all/pull/2701))
 
+[Unreleased]: https://github.com/nomic-ai/gpt4all/compare/v3.10.0...HEAD
 [3.10.0]: https://github.com/nomic-ai/gpt4all/compare/v3.9.0...v3.10.0
 [3.9.0]: https://github.com/nomic-ai/gpt4all/compare/v3.8.0...v3.9.0
 [3.8.0]: https://github.com/nomic-ai/gpt4all/compare/v3.7.0...v3.8.0

--- a/gpt4all-chat/CMakeLists.txt
+++ b/gpt4all-chat/CMakeLists.txt
@@ -244,6 +244,7 @@ qt_add_executable(chat
     src/localdocsmodel.cpp        src/localdocsmodel.h
     src/logger.cpp                src/logger.h
     src/modellist.cpp             src/modellist.h
+    src/mwhttpserver.cpp          src/mwhttpserver.h
     src/mysettings.cpp            src/mysettings.h
     src/network.cpp               src/network.h
     src/server.cpp                src/server.h

--- a/gpt4all-chat/src/mwhttpserver.cpp
+++ b/gpt4all-chat/src/mwhttpserver.cpp
@@ -1,0 +1,15 @@
+#include <QTcpServer>
+
+#include "mwhttpserver.h"
+
+
+namespace gpt4all::ui {
+
+
+MwHttpServer::MwHttpServer()
+    : m_httpServer()
+    , m_tcpServer (new QTcpServer(&m_httpServer))
+    {}
+
+
+} // namespace gpt4all::ui

--- a/gpt4all-chat/src/mwhttpserver.h
+++ b/gpt4all-chat/src/mwhttpserver.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QHttpServer>
+#include <QHttpServerRequest>
+
+#include <functional>
+#include <optional>
+#include <utility>
+#include <vector>
+
+class QHttpServerResponse;
+class QHttpServerRouterRule;
+class QString;
+
+
+namespace gpt4all::ui {
+
+
+/// @brief QHttpServer wrapper with middleware support.
+///
+/// This class wraps QHttpServer and provides addBeforeRequestHandler() to add middleware.
+class MwHttpServer
+{
+    using BeforeRequestHandler = std::function<std::optional<QHttpServerResponse>(const QHttpServerRequest &)>;
+
+public:
+    explicit MwHttpServer();
+
+    bool bind() { return m_httpServer.bind(m_tcpServer); }
+
+    void addBeforeRequestHandler(BeforeRequestHandler handler)
+    { m_beforeRequestHandlers.push_back(std::move(handler)); }
+
+    template <typename Handler>
+    void addAfterRequestHandler(
+        const typename QtPrivate::ContextTypeForFunctor<Handler>::ContextType *context, Handler &&handler
+    ) {
+        return m_httpServer.addAfterRequestHandler(context, std::forward<Handler>(handler));
+    }
+
+    template <typename... Args>
+    QHttpServerRouterRule *route(
+        const QString &pathPattern,
+        QHttpServerRequest::Methods method,
+        std::function<QHttpServerResponse(Args..., const QHttpServerRequest &)> viewHandler
+    );
+
+    QTcpServer *tcpServer() { return m_tcpServer; }
+
+private:
+    QHttpServer                        m_httpServer;
+    QTcpServer                        *m_tcpServer;
+    std::vector<BeforeRequestHandler>  m_beforeRequestHandlers;
+};
+
+
+} // namespace gpt4all::ui
+
+
+#include "mwhttpserver.inl" // IWYU pragma: export

--- a/gpt4all-chat/src/mwhttpserver.inl
+++ b/gpt4all-chat/src/mwhttpserver.inl
@@ -1,0 +1,20 @@
+namespace gpt4all::ui {
+
+
+template <typename... Args>
+QHttpServerRouterRule *MwHttpServer::route(
+    const QString &pathPattern,
+    QHttpServerRequest::Methods method,
+    std::function<QHttpServerResponse(Args..., const QHttpServerRequest &)> viewHandler
+) {
+    auto wrapped = [this, vh = std::move(viewHandler)](Args ...args, const QHttpServerRequest &req) {
+        for (auto &handler : m_beforeRequestHandlers)
+            if (auto resp = handler(req))
+                return *std::move(resp);
+        return vh(std::forward<Args>(args)..., req);
+    };
+    return m_httpServer.route(pathPattern, method, std::move(wrapped));
+}
+
+
+} // namespace gpt4all::ui

--- a/gpt4all-chat/src/server.cpp
+++ b/gpt4all-chat/src/server.cpp
@@ -501,7 +501,10 @@ void Server::start()
         // this works for HTTP/1.1 "Host" header and HTTP/2 ":authority" pseudo-header
         auto host = req.url().host();
         if (!host.isEmpty() && isHostUnsafe(host))
-            return QHttpServerResponse(QHttpServerResponder::StatusCode::Forbidden);
+            return QHttpServerResponse(
+                QJsonObject { { u"error"_s, u"Access to the server via non-local host %1 is forbidden."_s.arg(host) } },
+                QHttpServerResponder::StatusCode::Forbidden
+            );
         return std::nullopt;
     });
 

--- a/gpt4all-chat/src/server.h
+++ b/gpt4all-chat/src/server.h
@@ -4,7 +4,6 @@
 #include "chatllm.h"
 #include "database.h"
 
-#include <QHttpServer>
 #include <QHttpServerResponse>
 #include <QJsonObject>
 #include <QList>
@@ -18,6 +17,7 @@
 class Chat;
 class ChatRequest;
 class CompletionRequest;
+namespace gpt4all::ui { class MwHttpServer; }
 
 
 class Server : public ChatLLM
@@ -26,7 +26,7 @@ class Server : public ChatLLM
 
 public:
     explicit Server(Chat *chat);
-    ~Server() override = default;
+    ~Server() override;
 
 public Q_SLOTS:
     void start();
@@ -44,7 +44,7 @@ private Q_SLOTS:
 
 private:
     Chat *m_chat;
-    std::unique_ptr<QHttpServer> m_server;
+    std::unique_ptr<gpt4all::ui::MwHttpServer> m_server;
     QList<ResultInfo> m_databaseResults;
     QList<QString> m_collections;
 };


### PR DESCRIPTION
This PR contains the necessary code to prevent a potential DNS rebind attack of the local server, in which a malicious remote host points their domain name to a local IP address to bypass CORS, allowing a client-side script in a web browser to access the local GPT4All instance. This is exacerbated by the fact that the local server currently provides no authentication mechanism.

~~TODO: Test this change.~~ done.