### PR TITLE
ci: update path-filtering orb to 1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  path-filtering: circleci/path-filtering@1.1.0
+  path-filtering: circleci/path-filtering@1.3.0
 
 workflows:
   version: 2.1


### PR DESCRIPTION
This fixes the CI failure in the path-filtering job of the generate-config workflow:
```
ERROR: This script does not work on Python 3.8. The minimum supported Python version is 3.9. Please use https://bootstrap.pypa.io/pip/3.8/get-pip.py instead.
```

See https://github.com/CircleCI-Public/path-filtering-orb/pull/113