### PR TITLE
add datetime disaply for chat messages

### DIFF
--- a/gpt4all-chat/qml/ApplicationSettings.qml
+++ b/gpt4all-chat/qml/ApplicationSettings.qml
@@ -364,15 +364,36 @@ MySettingsTab {
             }
         }
         MySettingsLabel {
+            id: showTimestampsLabel
+            text: qsTr("Show Message Timestamps")
+            helpText: qsTr("Display the date and time when each message was sent.")
+            Layout.row: 8
+            Layout.column: 0
+        }
+        MyCheckBox {
+            id: showTimestampsBox
+            Layout.row: 8
+            Layout.column: 2
+            Layout.alignment: Qt.AlignRight
+            Component.onCompleted: { showTimestampsBox.checked = MySettings.showMessageTimestamps; }
+            Connections {
+                target: MySettings
+                function onShowMessageTimestampsChanged() { showTimestampsBox.checked = MySettings.showMessageTimestamps; }
+            }
+            onClicked: {
+                MySettings.showMessageTimestamps = showTimestampsBox.checked;
+            }
+        }
+        MySettingsLabel {
             id: modelPathLabel
             text: qsTr("Download Path")
             helpText: qsTr("Where to store local models and the LocalDocs database.")
-            Layout.row: 8
+            Layout.row: 9
             Layout.column: 0
         }
 
         RowLayout {
-            Layout.row: 8
+            Layout.row: 9
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             Layout.minimumWidth: 400
@@ -412,12 +433,12 @@ MySettingsTab {
             id: dataLakeLabel
             text: qsTr("Enable Datalake")
             helpText: qsTr("Send chats and feedback to the GPT4All Open-Source Datalake.")
-            Layout.row: 9
+            Layout.row: 10
             Layout.column: 0
         }
         MyCheckBox {
             id: dataLakeBox
-            Layout.row: 9
+            Layout.row: 10
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             Component.onCompleted: { dataLakeBox.checked = MySettings.networkIsActive; }
@@ -435,7 +456,7 @@ MySettingsTab {
         }
 
         ColumnLayout {
-            Layout.row: 10
+            Layout.row: 11
             Layout.column: 0
             Layout.columnSpan: 3
             Layout.fillWidth: true
@@ -458,7 +479,7 @@ MySettingsTab {
             id: nThreadsLabel
             text: qsTr("CPU Threads")
             helpText: qsTr("The number of CPU threads used for inference and embedding.")
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 0
         }
         MyTextField {
@@ -466,7 +487,7 @@ MySettingsTab {
             color: theme.textColor
             font.pixelSize: theme.fontSizeLarge
             Layout.alignment: Qt.AlignRight
-            Layout.row: 11
+            Layout.row: 12
             Layout.column: 2
             Layout.minimumWidth: 200
             Layout.maximumWidth: 200
@@ -490,12 +511,12 @@ MySettingsTab {
             id: trayLabel
             text: qsTr("Enable System Tray")
             helpText: qsTr("The application will minimize to the system tray when the window is closed.")
-            Layout.row: 13
+            Layout.row: 14
             Layout.column: 0
         }
         MyCheckBox {
             id: trayBox
-            Layout.row: 13
+            Layout.row: 14
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             checked: MySettings.systemTray
@@ -507,12 +528,12 @@ MySettingsTab {
             id: serverChatLabel
             text: qsTr("Enable Local API Server")
             helpText: qsTr("Expose an OpenAI-Compatible server to localhost. WARNING: Results in increased resource usage.")
-            Layout.row: 14
+            Layout.row: 15
             Layout.column: 0
         }
         MyCheckBox {
             id: serverChatBox
-            Layout.row: 14
+            Layout.row: 15
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             checked: MySettings.serverChat
@@ -524,7 +545,7 @@ MySettingsTab {
             id: serverPortLabel
             text: qsTr("API Server Port")
             helpText: qsTr("The port to use for the local server. Requires restart.")
-            Layout.row: 15
+            Layout.row: 16
             Layout.column: 0
         }
         MyTextField {
@@ -532,7 +553,7 @@ MySettingsTab {
             text: MySettings.networkPort
             color: theme.textColor
             font.pixelSize: theme.fontSizeLarge
-            Layout.row: 15
+            Layout.row: 16
             Layout.column: 2
             Layout.minimumWidth: 200
             Layout.maximumWidth: 200
@@ -577,12 +598,12 @@ MySettingsTab {
             id: updatesLabel
             text: qsTr("Check For Updates")
             helpText: qsTr("Manually check for an update to GPT4All.");
-            Layout.row: 16
+            Layout.row: 17
             Layout.column: 0
         }
 
         MySettingsButton {
-            Layout.row: 16
+            Layout.row: 17
             Layout.column: 2
             Layout.alignment: Qt.AlignRight
             text: qsTr("Updates");

--- a/gpt4all-chat/qml/ChatItemView.qml
+++ b/gpt4all-chat/qml/ChatItemView.qml
@@ -97,6 +97,19 @@ GridLayout {
                 text: currentModelName()
                 color: theme.mutedTextColor
             }
+            Text {
+                visible: MySettings.showMessageTimestamps && timestamp > 0
+                font.pixelSize: theme.fontSizeSmall
+                text: {
+                    if (timestamp > 0) {
+                        var date = new Date(timestamp);
+                        return Qt.formatDateTime(date, "yyyy-MM-dd hh:mm:ss");
+                    }
+                    return "";
+                }
+                color: theme.mutedTextColor
+                opacity: 0.6
+            }
             RowLayout {
                 visible: isCurrentResponse && (content === "" && currentChat.responseInProgress)
                 Text {

--- a/gpt4all-chat/src/chatlistmodel.cpp
+++ b/gpt4all-chat/src/chatlistmodel.cpp
@@ -21,7 +21,7 @@
 
 
 static constexpr quint32 CHAT_FORMAT_MAGIC   = 0xF5D553CC;
-static constexpr qint32  CHAT_FORMAT_VERSION = 12;
+static constexpr qint32  CHAT_FORMAT_VERSION = 13;
 
 class MyChatListModel: public ChatListModel { };
 Q_GLOBAL_STATIC(MyChatListModel, chatListModelInstance)

--- a/gpt4all-chat/src/chatmodel.cpp
+++ b/gpt4all-chat/src/chatmodel.cpp
@@ -145,6 +145,10 @@ void ChatItem::serialize(QDataStream &stream, int version)
         for (ChatItem *item :subItems)
             item->serializeSubItems(stream, version);
     }
+
+    if (version >= 13) {
+        stream << timestamp;
+    }
 }
 
 bool ChatItem::deserializeToolCall(QDataStream &stream, int version)
@@ -364,5 +368,10 @@ bool ChatItem::deserialize(QDataStream &stream, int version)
             subItems.push_back(c);
         }
     }
+
+    if (version >= 13) {
+        stream >> timestamp;
+    }
+
     return true;
 }

--- a/gpt4all-chat/src/chatmodel.h
+++ b/gpt4all-chat/src/chatmodel.h
@@ -14,6 +14,7 @@
 #include <QByteArray>
 #include <QClipboard>
 #include <QDataStream>
+#include <QDateTime>
 #include <QFileInfo>
 #include <QGuiApplication>
 #include <QIODevice>
@@ -189,6 +190,9 @@ class ChatItem : public QObject
     // thinking
     Q_PROPERTY(int     thinkingTime    MEMBER thinkingTime NOTIFY thinkingTimeChanged)
 
+    // timestamp
+    Q_PROPERTY(qint64  timestamp       MEMBER timestamp)
+
 public:
     enum class Type { System, Prompt, Response, Text, ToolCall, ToolResponse, Think };
 
@@ -225,12 +229,12 @@ public:
 
     ChatItem(QObject *parent, prompt_tag_t, const QString &value, const QList<PromptAttachment> &attachments = {})
         : ChatItem(parent)
-    { this->name = u"Prompt: "_s; this->value = value; this->promptAttachments = attachments; }
+    { this->name = u"Prompt: "_s; this->value = value; this->promptAttachments = attachments; this->timestamp = QDateTime::currentMSecsSinceEpoch(); }
 
 private:
     ChatItem(QObject *parent, response_tag_t, bool isCurrentResponse, const QString &value = {})
         : ChatItem(parent)
-    { this->name = u"Response: "_s; this->value = value; this->isCurrentResponse = isCurrentResponse; }
+    { this->name = u"Response: "_s; this->value = value; this->isCurrentResponse = isCurrentResponse; this->timestamp = QDateTime::currentMSecsSinceEpoch(); }
 
 public:
     // A new response, to be filled in
@@ -494,6 +498,9 @@ public:
 
     // thinking time in ms
     int     thinkingTime  = 0;
+
+    // timestamp in milliseconds since epoch
+    qint64  timestamp = 0;
 };
 
 class ChatModel : public QAbstractListModel

--- a/gpt4all-chat/src/mysettings.cpp
+++ b/gpt4all-chat/src/mysettings.cpp
@@ -65,6 +65,7 @@ static const QVariantMap basicDefaults {
     { "serverChat",               false },
     { "userDefaultModel",         "Application default" },
     { "suggestionMode",           QVariant::fromValue(SuggestionMode::LocalDocsOnly) },
+    { "showMessageTimestamps",    false },
     { "localdocs/chunkSize",      512 },
     { "localdocs/retrievalSize",  3 },
     { "localdocs/showReferences", true },
@@ -755,6 +756,16 @@ void MySettings::setNetworkUsageStatsActive(bool value)
         m_settings.setValue("network/usageStatsActive", value);
         emit networkUsageStatsActiveChanged();
     }
+}
+
+bool MySettings::showMessageTimestamps() const
+{
+    return getBasicSetting("showMessageTimestamps").toBool();
+}
+
+void MySettings::setShowMessageTimestamps(bool value)
+{
+    setBasicSetting("showMessageTimestamps", value);
 }
 
 QString MySettings::languageAndLocale() const

--- a/gpt4all-chat/src/mysettings.h
+++ b/gpt4all-chat/src/mysettings.h
@@ -79,6 +79,7 @@ class MySettings : public QObject
     Q_PROPERTY(QStringList embeddingsDeviceList MEMBER m_embeddingsDeviceList CONSTANT)
     Q_PROPERTY(int networkPort READ networkPort WRITE setNetworkPort NOTIFY networkPortChanged)
     Q_PROPERTY(SuggestionMode suggestionMode READ suggestionMode WRITE setSuggestionMode NOTIFY suggestionModeChanged)
+    Q_PROPERTY(bool showMessageTimestamps READ showMessageTimestamps WRITE setShowMessageTimestamps NOTIFY showMessageTimestampsChanged)
     Q_PROPERTY(QStringList uiLanguages MEMBER m_uiLanguages CONSTANT)
 
 private:
@@ -218,6 +219,9 @@ public:
     int networkPort() const;
     void setNetworkPort(int value);
 
+    bool showMessageTimestamps() const;
+    void setShowMessageTimestamps(bool value);
+
 Q_SIGNALS:
     void nameChanged(const ModelInfo &info);
     void filenameChanged(const ModelInfo &info);
@@ -259,6 +263,7 @@ Q_SIGNALS:
     void attemptModelLoadChanged();
     void deviceChanged();
     void suggestionModeChanged();
+    void showMessageTimestampsChanged();
     void languageAndLocaleChanged();
 
 private:


### PR DESCRIPTION
## Describe your changes

### Overview
This PR adds a timestamp display feature for chat messages, similar to the functionality found in Alpaca. When enabled, the timestamp shows when each message (both prompts and responses) was sent, which is particularly useful for tracking long-running operations like translations that can take several hours.

## Issue ticket number and link

Closes https://github.com/nomic-ai/gpt4all/issues/3623

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [x] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo

### Steps to Reproduce

## Notes

Contribution by Gittensor, learn more at https://gittensor.io/