### PR TITLE
Cap max_tokens and n to prevent local API DoS

### DIFF
--- a/gpt4all-chat/src/server.cpp
+++ b/gpt4all-chat/src/server.cpp
@@ -147,63 +147,64 @@ public:
 
 protected:
     virtual void parseImpl(QCborMap &request)
-   {
-    using enum Type;
+    {
+        using enum Type;
 
-    static constexpr int32_t MAX_MAX_TOKENS = 4096;
-    static constexpr qint64  MAX_N = 8;
+        static constexpr int32_t MAX_MAX_TOKENS = 4096;
+        static constexpr qint64  MAX_N = 8;
 
-    auto reqValue = [&request](auto &&...args) { return takeValue(request, args...); };
-    QCborValue value;
+        auto reqValue = [&request](auto &&...args) { return takeValue(request, args...); };
+        QCborValue value;
 
-    this->model = reqValue("model", String, /*required*/ true).toString();
+        this->model = reqValue("model", String, /*required*/ true).toString();
 
-    value = reqValue("frequency_penalty", Number, false, /*min*/ -2, /*max*/ 2);
-    if (value.isDouble() || value.toInteger() != 0)
-        throw InvalidRequestError("'frequency_penalty' is not supported");
+        value = reqValue("frequency_penalty", Number, false, /*min*/ -2, /*max*/ 2);
+        if (value.isDouble() || value.toInteger() != 0)
+            throw InvalidRequestError("'frequency_penalty' is not supported");
 
-    value = reqValue("max_tokens", Integer, false, /*min*/ 1, /*max*/ MAX_MAX_TOKENS);
-    if (!value.isNull())
-        this->max_tokens = int32_t(value.toInteger());
+        value = reqValue("max_tokens", Integer, false, /*min*/ 1, /*max*/ MAX_MAX_TOKENS);
+        if (!value.isNull())
+            this->max_tokens = int32_t(value.toInteger());
 
-    value = reqValue("n", Integer, false, /*min*/ 1, /*max*/ MAX_N);
-    if (!value.isNull())
-        this->n = value.toInteger();
+        value = reqValue("n", Integer, false, /*min*/ 1, /*max*/ MAX_N);
+        if (!value.isNull())
+            this->n = value.toInteger();
 
-    value = reqValue("presence_penalty", Number);
-    if (value.isDouble() || value.toInteger() != 0)
-        throw InvalidRequestError("'presence_penalty' is not supported");
+        value = reqValue("presence_penalty", Number);
+        if (value.isDouble() || value.toInteger() != 0)
+            throw InvalidRequestError("'presence_penalty' is not supported");
 
-    value = reqValue("seed", Integer);
-    if (!value.isNull())
-        throw InvalidRequestError("'seed' is not supported");
+        value = reqValue("seed", Integer);
+        if (!value.isNull())
+            throw InvalidRequestError("'seed' is not supported");
 
-    value = reqValue("stop");
-    if (!value.isNull())
-        throw InvalidRequestError("'stop' is not supported");
+        value = reqValue("stop");
+        if (!value.isNull())
+            throw InvalidRequestError("'stop' is not supported");
 
-    value = reqValue("stream", Boolean);
-    if (value.isTrue())
-        throw InvalidRequestError("'stream' is not supported");
+        value = reqValue("stream", Boolean);
+        if (value.isTrue())
+            throw InvalidRequestError("'stream' is not supported");
 
-    value = reqValue("stream_options", Object);
-    if (!value.isNull())
-        throw InvalidRequestError("'stream_options' is not supported");
+        value = reqValue("stream_options", Object);
+        if (!value.isNull())
+            throw InvalidRequestError("'stream_options' is not supported");
 
-    value = reqValue("temperature", Number, false, /*min*/ 0, /*max*/ 2);
-    if (!value.isNull())
-        this->temperature = float(value.toDouble());
+        value = reqValue("temperature", Number, false, /*min*/ 0, /*max*/ 2);
+        if (!value.isNull())
+            this->temperature = float(value.toDouble());
 
-    value = reqValue("top_p", Number, false, /*min*/ 0, /*max*/ 1);
-    if (!value.isNull())
-        this->top_p = float(value.toDouble());
+        value = reqValue("top_p", Number, false, /*min*/ 0, /*max*/ 1);
+        if (!value.isNull())
+            this->top_p = float(value.toDouble());
 
-    value = reqValue("min_p", Number, false, /*min*/ 0, /*max*/ 1);
-    if (!value.isNull())
-        this->min_p = float(value.toDouble());
+        value = reqValue("min_p", Number, false, /*min*/ 0, /*max*/ 1);
+        if (!value.isNull())
+            this->min_p = float(value.toDouble());
 
-    reqValue("user", String); 
-}
+        reqValue("user", String); // validate but don't use
+    }
+
 
     enum class Type : uint8_t {
         Boolean,

--- a/gpt4all-chat/src/server.cpp
+++ b/gpt4all-chat/src/server.cpp
@@ -147,60 +147,63 @@ public:
 
 protected:
     virtual void parseImpl(QCborMap &request)
-    {
-        using enum Type;
+   {
+    using enum Type;
 
-        auto reqValue = [&request](auto &&...args) { return takeValue(request, args...); };
-        QCborValue value;
+    static constexpr int32_t MAX_MAX_TOKENS = 4096;
+    static constexpr qint64  MAX_N = 8;
 
-        this->model = reqValue("model", String, /*required*/ true).toString();
+    auto reqValue = [&request](auto &&...args) { return takeValue(request, args...); };
+    QCborValue value;
 
-        value = reqValue("frequency_penalty", Number, false, /*min*/ -2, /*max*/ 2);
-        if (value.isDouble() || value.toInteger() != 0)
-            throw InvalidRequestError("'frequency_penalty' is not supported");
+    this->model = reqValue("model", String, /*required*/ true).toString();
 
-        value = reqValue("max_tokens", Integer, false, /*min*/ 1);
-        if (!value.isNull())
-            this->max_tokens = int32_t(qMin(value.toInteger(), INT32_MAX));
+    value = reqValue("frequency_penalty", Number, false, /*min*/ -2, /*max*/ 2);
+    if (value.isDouble() || value.toInteger() != 0)
+        throw InvalidRequestError("'frequency_penalty' is not supported");
 
-        value = reqValue("n", Integer, false, /*min*/ 1);
-        if (!value.isNull())
-            this->n = value.toInteger();
+    value = reqValue("max_tokens", Integer, false, /*min*/ 1, /*max*/ MAX_MAX_TOKENS);
+    if (!value.isNull())
+        this->max_tokens = int32_t(value.toInteger());
 
-        value = reqValue("presence_penalty", Number);
-        if (value.isDouble() || value.toInteger() != 0)
-            throw InvalidRequestError("'presence_penalty' is not supported");
+    value = reqValue("n", Integer, false, /*min*/ 1, /*max*/ MAX_N);
+    if (!value.isNull())
+        this->n = value.toInteger();
 
-        value = reqValue("seed", Integer);
-        if (!value.isNull())
-            throw InvalidRequestError("'seed' is not supported");
+    value = reqValue("presence_penalty", Number);
+    if (value.isDouble() || value.toInteger() != 0)
+        throw InvalidRequestError("'presence_penalty' is not supported");
 
-        value = reqValue("stop");
-        if (!value.isNull())
-            throw InvalidRequestError("'stop' is not supported");
+    value = reqValue("seed", Integer);
+    if (!value.isNull())
+        throw InvalidRequestError("'seed' is not supported");
 
-        value = reqValue("stream", Boolean);
-        if (value.isTrue())
-            throw InvalidRequestError("'stream' is not supported");
+    value = reqValue("stop");
+    if (!value.isNull())
+        throw InvalidRequestError("'stop' is not supported");
 
-        value = reqValue("stream_options", Object);
-        if (!value.isNull())
-            throw InvalidRequestError("'stream_options' is not supported");
+    value = reqValue("stream", Boolean);
+    if (value.isTrue())
+        throw InvalidRequestError("'stream' is not supported");
 
-        value = reqValue("temperature", Number, false, /*min*/ 0, /*max*/ 2);
-        if (!value.isNull())
-            this->temperature = float(value.toDouble());
+    value = reqValue("stream_options", Object);
+    if (!value.isNull())
+        throw InvalidRequestError("'stream_options' is not supported");
 
-        value = reqValue("top_p", Number, false, /*min*/ 0, /*max*/ 1);
-        if (!value.isNull())
-            this->top_p = float(value.toDouble());
+    value = reqValue("temperature", Number, false, /*min*/ 0, /*max*/ 2);
+    if (!value.isNull())
+        this->temperature = float(value.toDouble());
 
-        value = reqValue("min_p", Number, false, /*min*/ 0, /*max*/ 1);
-        if (!value.isNull())
-            this->min_p = float(value.toDouble());
+    value = reqValue("top_p", Number, false, /*min*/ 0, /*max*/ 1);
+    if (!value.isNull())
+        this->top_p = float(value.toDouble());
 
-        reqValue("user", String); // validate but don't use
-    }
+    value = reqValue("min_p", Number, false, /*min*/ 0, /*max*/ 1);
+    if (!value.isNull())
+        this->min_p = float(value.toDouble());
+
+    reqValue("user", String); 
+}
 
     enum class Type : uint8_t {
         Boolean,


### PR DESCRIPTION
## My Changes
Added server-side upper bounds for `max_tokens` and `n` in `BaseCompletionRequest::parseImpl`.
Requests exceeding these limits now return 400 via `InvalidRequestError`, preventing memory and CPU exhaustion in
`/v1/completions` and `/v1/chat/completions`.

## Issue ticket number and link
Fixes #3635

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo
N/A (validation change)

### Steps to Reproduce
1. Start GPT4All with API server enabled.
2. Send a request with very large `max_tokens` or `n`.
3. Observe the server now responds with 400 instead of consuming excessive resources.

## Notes
Limits used: `max_tokens <= 4096`, `n <= 8`. Happy to adjust per maintainer preference.
