### PR TITLE
Security: Make trust_remote_code configurable with safe default

### DIFF
--- a/gpt4all-training/inference.py
+++ b/gpt4all-training/inference.py
@@ -68,8 +68,14 @@ def inference(config):
     )
 
 
-    model = AutoModelForCausalLM.from_pretrained(config["model_name"], 
-                                                    trust_remote_code=True,
+    # Security: trust_remote_code allows arbitrary code execution from model repos.
+    # Only enable this for models you explicitly trust.
+    trust_remote = config.get("trust_remote_code", False)
+    if trust_remote:
+        rank0_print("WARNING: trust_remote_code=True enables arbitrary code execution from the model repository")
+
+    model = AutoModelForCausalLM.from_pretrained(config["model_name"],
+                                                    trust_remote_code=trust_remote,
                                                     torch_dtype=torch.bfloat16,
                                                     ) 
     model.to(f"cuda:{local_rank}")

--- a/gpt4all-training/train.py
+++ b/gpt4all-training/train.py
@@ -55,9 +55,15 @@ def train(accelerator, config):
 
     checkpoint = config["gradient_checkpointing"]
 
-    model = AutoModelForCausalLM.from_pretrained(config["model_name"], 
+    # Security: trust_remote_code allows arbitrary code execution from model repos.
+    # Only enable this for models you explicitly trust.
+    trust_remote = config.get("trust_remote_code", False)
+    if trust_remote:
+        accelerator.print("WARNING: trust_remote_code=True enables arbitrary code execution from the model repository")
+
+    model = AutoModelForCausalLM.from_pretrained(config["model_name"],
                                                     use_cache=False if checkpoint else True,
-                                                    trust_remote_code=True) 
+                                                    trust_remote_code=trust_remote) 
     if checkpoint:
         model.gradient_checkpointing_enable()
 


### PR DESCRIPTION
## Summary

This PR addresses a security concern in the training scripts where `trust_remote_code=True` is hardcoded when loading models via HuggingFace transformers.

**Changes:**
- Make `trust_remote_code` configurable via the config file (default: `False`)
- Add warning message when `trust_remote_code=True` is enabled
- Applied to both `train.py` and `inference.py`

## Security Context

The `trust_remote_code=True` parameter allows arbitrary Python code execution from model repositories. While this is sometimes necessary for custom model architectures, it poses a security risk if:
- Users load models from untrusted sources
- A trusted model repository is compromised

By making this configurable with a safe default, users must explicitly opt-in to this behavior.

Identified using [aisentry](https://aisentry.co).

## Usage

To enable trust_remote_code when needed, add to your config:
```yaml
trust_remote_code: true
```

## Test plan
- [ ] Verify training works with default config (trust_remote_code=False) for standard models
- [ ] Verify training works with trust_remote_code=True for models that require it
- [ ] Confirm warning message appears when trust_remote_code is enabled