### PR TITLE
removed anchors from item managed by layout to resolve QML warning

### DIFF
--- a/gpt4all-chat/qml/AddHFModelView.qml
+++ b/gpt4all-chat/qml/AddHFModelView.qml
@@ -97,41 +97,50 @@ ColumnLayout {
             function sendDiscovery() {
                 ModelList.huggingFaceDownloadableModels.discoverAndFilter(discoverField.text);
             }
-            RowLayout {
-                spacing: 0
-                anchors.right: discoverField.right
-                anchors.verticalCenter: discoverField.verticalCenter
+
+            Item {
+                id: buttons
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
                 anchors.rightMargin: 15
-                visible: !ModelList.discoverInProgress
-                MyMiniButton {
-                    id: clearDiscoverButton
-                    backgroundColor: theme.textColor
-                    backgroundColorHovered: theme.iconBackgroundDark
-                    visible: discoverField.text !== ""
-                    source: "qrc:/gpt4all/icons/close.svg"
-                    onClicked: {
-                        discoverField.text = ""
-                        discoverField.sendDiscovery() // should clear results
+
+                implicitWidth: buttonsRowLayout.implicitWidth
+                implicitHeight: buttonsRowLayout.implicitHeight
+
+                RowLayout {
+                    id: buttonsRowLayout
+                    spacing: 0
+                    visible: !ModelList.discoverInProgress
+                    MyMiniButton {
+                        id: clearDiscoverButton
+                        backgroundColor: theme.textColor
+                        backgroundColorHovered: theme.iconBackgroundDark
+                        visible: discoverField.text !== ""
+                        source: "qrc:/gpt4all/icons/close.svg"
+                        onClicked: {
+                            discoverField.text = ""
+                            discoverField.sendDiscovery() // should clear results
+                        }
                     }
-                }
-                MyMiniButton {
-                    backgroundColor: theme.textColor
-                    backgroundColorHovered: theme.iconBackgroundDark
-                    source: "qrc:/gpt4all/icons/settings.svg"
-                    onClicked: {
-                        discoveryTools.visible = !discoveryTools.visible
+                    MyMiniButton {
+                        backgroundColor: theme.textColor
+                        backgroundColorHovered: theme.iconBackgroundDark
+                        source: "qrc:/gpt4all/icons/settings.svg"
+                        onClicked: {
+                            discoveryTools.visible = !discoveryTools.visible
+                        }
                     }
-                }
-                MyMiniButton {
-                    id: sendButton
-                    enabled: !ModelList.discoverInProgress
-                    backgroundColor: theme.textColor
-                    backgroundColorHovered: theme.iconBackgroundDark
-                    source: "qrc:/gpt4all/icons/send_message.svg"
-                    Accessible.name: qsTr("Initiate model discovery and filtering")
-                    Accessible.description: qsTr("Triggers discovery and filtering of models")
-                    onClicked: {
-                        discoverField.sendDiscovery()
+                    MyMiniButton {
+                        id: sendButton
+                        enabled: !ModelList.discoverInProgress
+                        backgroundColor: theme.textColor
+                        backgroundColorHovered: theme.iconBackgroundDark
+                        source: "qrc:/gpt4all/icons/send_message.svg"
+                        Accessible.name: qsTr("Initiate model discovery and filtering")
+                        Accessible.description: qsTr("Triggers discovery and filtering of models")
+                        onClicked: {
+                            discoverField.sendDiscovery()
+                        }
                     }
                 }
             }

--- a/gpt4all-chat/qml/AddModelView.qml
+++ b/gpt4all-chat/qml/AddModelView.qml
@@ -143,7 +143,7 @@ Rectangle {
                 // FIXME: This generates a warning and should not be used inside a layout, but without
                 // it the text field inside this qml does not display at full width so it looks like
                 // a bug in stacklayout
-                anchors.fill: parent
+                // anchors.fill: parent
 
                 function show() {
                     stackLayout.currentIndex = 2;


### PR DESCRIPTION
#3600 

Location The warning is reported at AddModelView.qml, line 139 (the AddHFModelView component in the StackLayout).
It appears that anchors.fill: parent is used on a component which is a direct child of a Layout (for example, StackLayout), which is discouraged in Qt Quick and leads to undefined behavior.

Steps to Reproduce
1. Launch the application in Qt Creator.
2. Check application logs. Observe the QML warning:
