### PR TITLE
Improve code block contrast in light theme

### DIFF
--- a/gpt4all-chat/src/chatviewtextprocessor.cpp
+++ b/gpt4all-chat/src/chatviewtextprocessor.cpp
@@ -846,7 +846,21 @@ CodeColors ChatViewTextProcessor::codeColors() const
 
 void ChatViewTextProcessor::setCodeColors(const CodeColors &colors)
 {
-    m_syntaxHighlighter->setCodeColors(colors);
+    CodeColors resolvedColors = colors;
+    resolvedColors.preprocessorColor = colors.keywordColor;
+    resolvedColors.typeColor = colors.numberColor;
+    resolvedColors.arrowColor = colors.functionColor;
+    resolvedColors.commandColor = colors.functionCallColor;
+    resolvedColors.variableColor = colors.numberColor;
+    resolvedColors.keyColor = colors.functionColor;
+    resolvedColors.valueColor = colors.stringColor;
+    resolvedColors.parameterColor = colors.stringColor;
+    resolvedColors.attributeNameColor = colors.numberColor;
+    resolvedColors.attributeValueColor = colors.stringColor;
+    resolvedColors.specialCharacterColor = colors.functionColor;
+    resolvedColors.doctypeColor = colors.commentColor;
+
+    m_syntaxHighlighter->setCodeColors(resolvedColors);
     emit codeColorsChanged();
 }
 
@@ -910,7 +924,7 @@ void ChatViewTextProcessor::handleCodeBlocks()
 
     QTextCharFormat textFormat;
     textFormat.setFontFamilies(QStringList() << "Monospace");
-    textFormat.setForeground(QColor("white"));
+    textFormat.setForeground(codeColors().defaultColor);
 
     QTextFrameFormat frameFormatBase;
     frameFormatBase.setBackground(codeColors().backgroundColor);


### PR DESCRIPTION
## Describe your changes

Improves code block readability in light theme by removing the hardcoded white base foreground used while building code block frames and by resolving derived syntax token colors from the active theme palette before passing them to the highlighter.

This keeps code block text, language headers, and secondary token types on the same light/dark theme-aware color set instead of leaving some of them on hardcoded or unset colors.

## Issue ticket number and link

Fixes https://github.com/nomic-ai/gpt4all/issues/1626

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] I have added thorough documentation for my code.
- [ ] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo

I could not capture an app screenshot locally because the macOS environment does not have the required Qt6 6.8 development package installed.

### Steps to Reproduce

1. Switch GPT4All to the light theme.
2. Generate or paste a chat response containing a fenced code block with a language header and syntax-highlighted content.
3. Confirm the code block uses theme-aware foreground colors instead of hardcoded white/unset token colors.

## Notes

Validation performed:

- `git diff --check`
- `cmake -S gpt4all-chat -B /tmp/gpt4all-1626-build -G Ninja -DGPT4ALL_TEST=OFF -DGPT4ALL_USE_QTPDF=OFF` failed during configuration because Qt6 6.8 is not installed locally (`Qt6Config.cmake` not found).
