### PR TITLE
docs(desktop): Custom OpenAI-compatible base URL example (DaoXE)

### DIFF
--- a/gpt4all-bindings/python/docs/gpt4all_desktop/models.md
+++ b/gpt4all-bindings/python/docs/gpt4all_desktop/models.md
@@ -77,3 +77,48 @@ You can add your API key for remote model providers.
 **Note**: this does not download a model file to your computer to use securely. Instead, this way of interacting with models has your prompts leave your computer to the API provider and returns the response to your computer.
 
 ![Connect APIs](../assets/add_model_gpt4.png)
+
+### Built-in remote providers
+
+In **Models → Add Model**, the remote-provider cards include:
+
+| Provider | Default base URL | Notes |
+|----------|------------------|--------|
+| Groq | `https://api.groq.com/openai/v1/` | Enter API key; pick a listed model |
+| OpenAI | `https://api.openai.com/v1/` | Enter API key; pick a listed model |
+| Mistral | `https://api.mistral.ai/v1/` | Enter API key; pick a listed model |
+| **Custom** | *(you provide)* | Any **OpenAI-compatible** Chat Completions API |
+
+GPT4All talks to remote providers over an **OpenAI-compatible** HTTP API (`/v1/models`, `/v1/chat/completions`). Other protocols a gateway may expose (for example OpenAI Responses or Anthropic Messages) are outside this path.
+
+### Custom OpenAI-compatible base URL
+
+Use the **Custom** card when the provider is not listed above (self-hosted vLLM/LocalAI-style endpoints, multi-model gateways, or third-party OpenAI-compatible APIs).
+
+1. Open **Models** → **+ Add Model**.
+2. Choose the **Custom** remote provider card.
+3. Enter your **API Key**.
+4. Enter the **Base Url** (must include the `/v1` prefix when the provider uses one).
+5. Enter an exact **Model Name** (model ID) that your account/endpoint accepts.
+6. Click **Install**.
+
+Example multi-model gateway (**DaoXE**):
+
+| Field | Value |
+|-------|--------|
+| Base Url | `https://daoxe.com/v1` |
+| API Key | key from your [DaoXE](https://daoxe.com) dashboard |
+| Model Name | an **exact** model ID currently available to **your** account |
+
+```bash
+# Discover account-scoped model IDs (requires your key)
+curl -sS -H "Authorization: Bearer $DAOXE_API_KEY" \
+  https://daoxe.com/v1/models
+```
+
+Notes for Custom / DaoXE-style gateways:
+
+- Prefer model IDs returned by authenticated `GET /v1/models` for **your** account; do not assume a fixed public list.
+- DaoXE is multi-model and multi-protocol; GPT4All uses the **OpenAI-compatible Chat Completions** path only.
+- DaoXE is **not available in mainland China**.
+- Public client examples: [seven7763/DaoXE-AI](https://github.com/seven7763/DaoXE-AI).


### PR DESCRIPTION
## Describe your changes

Expand **Models → Connect Model APIs** documentation for remote providers:

- Table of built-in remote cards (Groq, OpenAI, Mistral) plus **Custom**
- Step-by-step **Custom** flow: API Key, Base Url, exact Model Name, Install
- Example multi-model multi-protocol gateway **DaoXE** at `https://daoxe.com/v1`
  - Account-scoped model IDs via authenticated `GET /v1/models`
  - GPT4All uses the OpenAI-compatible Chat Completions path only
  - Not available in mainland China
- Link to public examples: https://github.com/seven7763/DaoXE-AI

No application code changes—docs only under `gpt4all-bindings/python/docs/`.

## Issue ticket number and link

N/A (documentation improvement for existing Custom remote provider UI)

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [x] I have added thorough documentation for my code.
- [x] I have tagged PR with relevant project labels. I acknowledge that a PR without labels may be dismissed.
- [ ] If this PR addresses a bug, I have provided both a screenshot/video of the original bug and the working solution.

## Demo

Docs-only change to [Models](https://docs.gpt4all.io/gpt4all_desktop/models.html) “Connect Model APIs” section.

### Steps to Reproduce

1. Open Models → + Add Model → Custom remote card in the desktop app.
2. Base Url `https://daoxe.com/v1`, API key, exact model ID from `/v1/models`.
3. Install and chat (remote path; prompts leave the machine).

## Notes

- Disclosure: I am affiliated with DaoXE.
- Labels: `documentation` (please apply if the author cannot).
- GPT4All already ships a **Custom** OpenAI-compatible provider; this PR only documents the fields and one concrete base URL example.