### PR TITLE
fix(download): add a transfer timeout so stalled model downloads resume (#3692)

### DIFF
--- a/gpt4all-chat/src/download.cpp
+++ b/gpt4all-chat/src/download.cpp
@@ -34,6 +34,7 @@
 #include <QtLogging>
 #include <QtMinMax>
 
+#include <chrono>
 #include <compare>
 #include <cstddef>
 #include <utility>
@@ -219,8 +220,16 @@ void Download::downloadModel(const QString &modelFile)
     QSslConfiguration conf = request.sslConfiguration();
     conf.setPeerVerifyMode(QSslSocket::VerifyNone);
     request.setSslConfiguration(conf);
+    // Abort the transfer if the server stalls mid-stream without closing the
+    // connection (observed with some HuggingFace mirrors/CDNs): the request then
+    // fails with OperationCanceledError and handleErrorOccurred() resumes it via a
+    // fresh HTTP Range request instead of hanging forever. See issue #3692.
+    request.setTransferTimeout(std::chrono::seconds(30));
     QNetworkReply *modelReply = m_networkManager.get(request);
-    connect(qGuiApp, &QCoreApplication::aboutToQuit, modelReply, &QNetworkReply::abort);
+    connect(qGuiApp, &QCoreApplication::aboutToQuit, modelReply, [modelReply] {
+        modelReply->setProperty("cancelledByUser", true);
+        modelReply->abort();
+    });
     connect(modelReply, &QNetworkReply::downloadProgress, this, &Download::handleDownloadProgress);
     connect(modelReply, &QNetworkReply::errorOccurred, this, &Download::handleErrorOccurred);
     connect(modelReply, &QNetworkReply::finished, this, &Download::handleModelDownloadFinished);
@@ -239,6 +248,7 @@ void Download::cancelDownload(const QString &modelFile)
             disconnect(modelReply, &QNetworkReply::downloadProgress, this, &Download::handleDownloadProgress);
             disconnect(modelReply, &QNetworkReply::finished, this, &Download::handleModelDownloadFinished);
 
+            modelReply->setProperty("cancelledByUser", true);
             modelReply->abort(); // Abort the download
             modelReply->deleteLater(); // Schedule the reply for deletion
 
@@ -461,8 +471,11 @@ void Download::handleErrorOccurred(QNetworkReply::NetworkError code)
     if (!modelReply)
         return;
 
-    // This occurs when the user explicitly cancels the download
-    if (code == QNetworkReply::OperationCanceledError)
+    // OperationCanceledError also fires when the transfer timeout set in downloadModel()
+    // expires. Only a genuine user cancel or app shutdown marks the reply with this
+    // property; a timeout does not, so let it fall through to the retry logic below and
+    // resume the download via a fresh Range request.
+    if (code == QNetworkReply::OperationCanceledError && modelReply->property("cancelledByUser").toBool())
         return;
 
     QString modelFilename = modelReply->request().attribute(QNetworkRequest::User).toString();


### PR DESCRIPTION
## Summary

Fixes #3692. The built-in model downloader had no transfer timeout. When a mirror/CDN (e.g. `hf-mirror.com`) stops sending data mid-stream without closing the TCP connection, the download hangs forever with no progress — the only workaround was to hit **Cancel** then **Resume**, which sends a fresh HTTP `Range` request and unblocks it.

## Changes (`gpt4all-chat/src/download.cpp`)

- Set a **30s transfer timeout** on the model download request via `QNetworkRequest::setTransferTimeout()`. Qt aborts the transfer only when *no bytes are received within the interval*, so healthy downloads (which keep receiving data) are never affected — it fires exactly on the mid-stream stall described in the issue.
- A transfer timeout surfaces as `QNetworkReply::OperationCanceledError`, the same code as a user cancel. `handleErrorOccurred()` previously short-circuited *all* `OperationCanceledError`s and skipped the retry path. It now only short-circuits aborts that are explicitly tagged with a `cancelledByUser` property (set by `cancelDownload()` and the app-shutdown handler); a timeout is left untagged, so it falls through to the existing retry logic and **resumes from the current offset via `Range`** — automating the manual Cancel/Resume workaround (up to the existing 10-retry cap).

## Notes

- No new dependency; `setTransferTimeout()` is available in the required Qt 6.8.
- The retry mechanism (offset-aware `Range` resume in `downloadModel()`) is unchanged; this only routes timeouts into it and prevents genuine user/shutdown cancels from being retried.

Built against `main`; edits are confined to the download path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
