### PR TITLE
fix(chat): verify TLS peers and fetch gpt4all.io over HTTPS

### DIFF
--- a/gpt4all-chat/src/download.cpp
+++ b/gpt4all-chat/src/download.cpp
@@ -22,8 +22,6 @@
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <QSettings>
-#include <QSslConfiguration>
-#include <QSslSocket>
 #include <QStringList> // IWYU pragma: keep
 #include <QTextStream>
 #include <QUrl>
@@ -158,11 +156,8 @@ bool Download::isFirstStart(bool writeVersion) const
 
 void Download::updateReleaseNotes()
 {
-    QUrl jsonUrl("http://gpt4all.io/meta/release.json");
+    QUrl jsonUrl("https://gpt4all.io/meta/release.json");
     QNetworkRequest request(jsonUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *jsonReply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, jsonReply, &QNetworkReply::abort);
     connect(jsonReply, &QNetworkReply::finished, this, &Download::handleReleaseJsonDownloadFinished);
@@ -170,11 +165,8 @@ void Download::updateReleaseNotes()
 
 void Download::updateLatestNews()
 {
-    QUrl url("http://gpt4all.io/meta/latestnews.md");
+    QUrl url("https://gpt4all.io/meta/latestnews.md");
     QNetworkRequest request(url);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *reply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, reply, &QNetworkReply::abort);
     connect(reply, &QNetworkReply::finished, this, &Download::handleLatestNewsDownloadFinished);
@@ -211,14 +203,11 @@ void Download::downloadModel(const QString &modelFile)
 
     ModelList::globalInstance()->updateDataByFilename(modelFile, {{ ModelList::DownloadingRole, true }});
     ModelInfo info = ModelList::globalInstance()->modelInfoByFilename(modelFile);
-    QString url = !info.url().isEmpty() ? info.url() : "http://gpt4all.io/models/gguf/" + modelFile;
+    QString url = !info.url().isEmpty() ? info.url() : "https://gpt4all.io/models/gguf/" + modelFile;
     Network::globalInstance()->trackEvent("download_started", { {"model", modelFile} });
     QNetworkRequest request(url);
     request.setAttribute(QNetworkRequest::User, modelFile);
     request.setRawHeader("range", u"bytes=%1-"_s.arg(tempFile->pos()).toUtf8());
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *modelReply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, modelReply, &QNetworkReply::abort);
     connect(modelReply, &QNetworkReply::downloadProgress, this, &Download::handleDownloadProgress);

--- a/gpt4all-chat/src/modellist.cpp
+++ b/gpt4all-chat/src/modellist.cpp
@@ -28,8 +28,6 @@
 #include <QObject>
 #include <QRegularExpression>
 #include <QSettings>
-#include <QSslConfiguration>
-#include <QSslSocket>
 #include <QStandardPaths>
 #include <QStringList> // IWYU pragma: keep
 #include <QTextStream>
@@ -1484,13 +1482,10 @@ void ModelList::updateModelsFromJson()
 #if defined(USE_LOCAL_MODELSJSON)
     QUrl jsonUrl(u"file://%1/dev/large_language_models/gpt4all/gpt4all-chat/metadata/%2"_s.arg(QDir::homePath(), modelsJsonFname));
 #else
-    QUrl jsonUrl(u"http://gpt4all.io/models/%1"_s.arg(modelsJsonFname));
+    QUrl jsonUrl(u"https://gpt4all.io/models/%1"_s.arg(modelsJsonFname));
 #endif
 
     QNetworkRequest request(jsonUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *jsonReply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, jsonReply, &QNetworkReply::abort);
     QEventLoop loop;
@@ -1527,13 +1522,10 @@ void ModelList::updateModelsFromJsonAsync()
 #if defined(USE_LOCAL_MODELSJSON)
     QUrl jsonUrl(u"file://%1/dev/large_language_models/gpt4all/gpt4all-chat/metadata/%2"_s.arg(QDir::homePath(), modelsJsonFname));
 #else
-    QUrl jsonUrl(u"http://gpt4all.io/models/%1"_s.arg(modelsJsonFname));
+    QUrl jsonUrl(u"https://gpt4all.io/models/%1"_s.arg(modelsJsonFname));
 #endif
 
     QNetworkRequest request(jsonUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *jsonReply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, jsonReply, &QNetworkReply::abort);
     connect(jsonReply, &QNetworkReply::finished, this, &ModelList::handleModelsJsonDownloadFinished);

--- a/gpt4all-chat/src/network.cpp
+++ b/gpt4all-chat/src/network.cpp
@@ -24,8 +24,6 @@
 #include <QScreen>
 #include <QSettings>
 #include <QSize>
-#include <QSslConfiguration>
-#include <QSslSocket>
 #include <QSysInfo>
 #include <Qt>
 #include <QtLogging>
@@ -221,9 +219,6 @@ bool Network::packageAndSendJson(const QString &ingestId, const QString &json)
 
     QUrl jsonUrl("https://api.gpt4all.io/v1/ingest/chat");
     QNetworkRequest request(jsonUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QByteArray body(newDoc.toJson(QJsonDocument::Compact));
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     QNetworkReply *jsonReply = m_networkManager.post(request, body);
@@ -428,9 +423,6 @@ void Network::sendIpify()
 
     QUrl ipifyUrl("https://api.ipify.org");
     QNetworkRequest request(ipifyUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *reply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, reply, &QNetworkReply::abort);
     connect(reply, &QNetworkReply::finished, this, &Network::handleIpifyFinished);
@@ -440,9 +432,6 @@ void Network::sendMixpanel(const QByteArray &json)
 {
     QUrl trackUrl("https://api.mixpanel.com/track");
     QNetworkRequest request(trackUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     QNetworkReply *trackReply = m_networkManager.post(request, json);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, trackReply, &QNetworkReply::abort);
@@ -513,9 +502,6 @@ void Network::sendHealth()
 {
     QUrl healthUrl("https://api.gpt4all.io/v1/health");
     QNetworkRequest request(healthUrl);
-    QSslConfiguration conf = request.sslConfiguration();
-    conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-    request.setSslConfiguration(conf);
     QNetworkReply *healthReply = m_networkManager.get(request);
     connect(qGuiApp, &QCoreApplication::aboutToQuit, healthReply, &QNetworkReply::abort);
     connect(healthReply, &QNetworkReply::finished, this, &Network::handleHealthFinished);


### PR DESCRIPTION
## Summary
- Model catalog / release / news / default GGUF downloads used cleartext `http://gpt4all.io/...`.
- Those requests (and chat ingest / Mixpanel / health) forced `QSslSocket::VerifyNone`, disabling certificate verification.
- Because catalog entries supply both download URL and hash, a MITM that poisons the catalog can make the post-download hash check accept attacker-controlled weights.
- Switch gpt4all.io URLs to HTTPS and remove VerifyNone overrides so Qt uses default peer verification.

## Test plan
- [ ] Build gpt4all-chat and confirm model list / download still works against gpt4all.io
- [ ] Confirm no remaining `VerifyNone` or `http://gpt4all.io` in `gpt4all-chat/src`


Made with [Cursor](https://cursor.com)