### PR TITLE
Allow removing compatible API models from settings

### DIFF
--- a/gpt4all-chat/qml/ModelSettings.qml
+++ b/gpt4all-chat/qml/ModelSettings.qml
@@ -3,6 +3,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.Basic
 import QtQuick.Layouts
+import download
 import modellist
 import mysettings
 import chatlistmodel
@@ -114,10 +115,13 @@ MySettingsTab {
 
             MySettingsDestructiveButton {
                 id: removeButton
-                enabled: root.currentModelInfo.isClone
+                enabled: root.currentModelInfo.isClone || root.currentModelInfo.isCompatibleApi
                 text: qsTr("Remove")
                 onClicked: {
-                    ModelList.removeClone(root.currentModelInfo);
+                    if (root.currentModelInfo.isClone)
+                        ModelList.removeClone(root.currentModelInfo);
+                    else
+                        Download.removeModel(root.currentModelInfo.filename);
                     comboBox.currentIndex = 0;
                 }
             }


### PR DESCRIPTION
Fixes #3243.

The Remove button in Model Settings is now enabled for user-created OpenAI-compatible models as well as clones. Clones continue through `ModelList.removeClone`; compatible API models use the existing `Download.removeModel` path so their model file, settings, and list entry are removed consistently.

Validation:

- verified `ModelInfo.isCompatibleApi` is exposed to QML
- verified `Download.removeModel` already handles compatible API models through `removeInstalled`
- `git diff --check`

The Qt/QML runtime test suite was not run locally because the Qt toolchain is unavailable in this environment.